### PR TITLE
fix: Docker Swarm DNS resolution and backup status display (v2.2.3)

### DIFF
--- a/backend/src/services/backupService.js
+++ b/backend/src/services/backupService.js
@@ -993,12 +993,16 @@ async function getBackupStatus(limit = 10) {
       }
     }
 
+    const lastRunWithManifest = lastRun ? { ...lastRun, manifestValid } : null;
+
     return {
       isRunning,
       isHealthy: Boolean(lastRun && lastRun.status === 'completed'),
-      lastRun: lastRun ? { ...lastRun, manifestValid } : null,
+      lastRun: lastRunWithManifest,
+      lastBackup: lastRunWithManifest, // Alias for frontend compatibility
       recentRuns: runs,
       recentBackups: runs, // Alias for frontend compatibility
+      totalBackups: runs.filter(r => r.status === 'completed').length,
       nextScheduledRun: getNextScheduledRun()
     };
   } catch (error) {


### PR DESCRIPTION
  ## Summary
  - **nginx**: Add Docker DNS resolver for Swarm/dynamic service discovery
  - **backup**: Fix backup status not displaying in dashboard

  ## Changes

  ### nginx DNS Fix
  - Add `resolver 127.0.0.11 valid=10s ipv6=off` directive for Docker DNS
  - Use variable-based `proxy_pass` to force per-request DNS resolution
  - Fixes 502 Bad Gateway on root path in Docker Swarm deployments

  ### Backup Status Fix
  - Add `lastBackup` alias for frontend compatibility (was returning `lastRun`)
  - Add `totalBackups` count of completed backups
  - Fixes "No backup available" showing when backups exist in history

  ## Test Plan
  - [x] Local Docker environment tested
  - [x] Root path `/` works correctly
  - [x] Backup status API returns correct `lastBackup` and `totalBackups`
  - [ ] Production Docker Swarm deployment