### PR TITLE
fix: mobile upload button visibility in gallery (#113)

### DIFF
--- a/frontend/src/components/gallery/GalleryLayout.tsx
+++ b/frontend/src/components/gallery/GalleryLayout.tsx
@@ -240,11 +240,7 @@ export const GalleryLayout: React.FC<GalleryLayoutProps> = ({
               {/* Right side - Action buttons */}
               <div className="flex items-center gap-2 sm:gap-3 flex-shrink-0">
                 {/* Extra header items (upload button, etc.) */}
-                {headerExtra && (
-                  <div className="hidden sm:block">
-                    {headerExtra}
-                  </div>
-                )}
+                {headerExtra}
                 
                 {/* Download all button - hidden on mobile when sidebar is shown */}
                 {showDownloadAll && onDownloadAll && (

--- a/frontend/src/components/gallery/GallerySidebar.tsx
+++ b/frontend/src/components/gallery/GallerySidebar.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from 'react';
-import { X, Download, Filter, SortAsc, Search, Calendar, Type, HardDrive, Check, Star } from 'lucide-react';
+import { X, Download, Filter, SortAsc, Search, Calendar, Type, HardDrive, Check, Star, Upload } from 'lucide-react';
 import { Button } from '../common';
 import { PhotoCategory } from '../../types';
 import { useTranslation } from 'react-i18next';
@@ -139,6 +139,24 @@ export const GallerySidebar: React.FC<GallerySidebarProps> = ({
 
         {/* Content */}
         <div className="gallery-sidebar-content flex-1 overflow-y-auto">
+          {/* Upload Section - Show prominently at top for mobile users */}
+          {allowUploads && onUploadClick && (
+            <div className="gallery-sidebar-section gallery-sidebar-upload p-4 border-b border-neutral-200">
+              <Button
+                variant="outline"
+                size="sm"
+                leftIcon={<Upload className="w-4 h-4" />}
+                onClick={() => {
+                  onUploadClick();
+                  if (isMobile) onClose();
+                }}
+                className="gallery-btn w-full"
+              >
+                {t('upload.uploadPhotos')}
+              </Button>
+            </div>
+          )}
+
           {/* Search Section - Hidden for carousel layout */}
           {galleryLayout !== 'carousel' && (
             <div className="gallery-sidebar-section gallery-sidebar-search p-4 border-b border-neutral-200">


### PR DESCRIPTION
  ## Summary
  - Fixes mobile upload button not visible/disappearing on smartphones #113 
  - Upload button now consistently appears in both the header and sidebar on all devices and layouts

  ## Changes
  - **GalleryLayout.tsx**: Removed `hidden sm:block` wrapper that was hiding the upload button on mobile for Grid layout
  - **GallerySidebar.tsx**: Added upload button rendering using the existing `allowUploads` and `onUploadClick` props (which were passed but never used)

  ## Test plan
  - [x] Verify upload button visible on desktop (Hero layout)
  - [x] Verify upload button visible on mobile (Hero layout)
  - [x] Verify upload button persists after page refresh
  - [x] Verify upload button visible in sidebar when opened
  - [ ] Verify upload button visible on Grid layout (desktop + mobile)
  - [ ] Verify upload button visible on Carousel layout (desktop + mobile)