### PR TITLE
fix: correct storage path resolution in multiple files (#96)

### DIFF
--- a/backend/src/routes/gallery.js
+++ b/backend/src/routes/gallery.js
@@ -16,7 +16,7 @@ const { NotFoundError } = require('../utils/errors');
 const { ensureThumbnail } = require('../services/imageProcessor');
 
 // Get storage path from environment or default
-const getStoragePath = () => process.env.STORAGE_PATH || path.join(__dirname, '../../storage');
+const getStoragePath = () => process.env.STORAGE_PATH || path.join(__dirname, '../../../storage');
 
 // Check for slug redirect (for renamed events)
 async function checkSlugRedirect(slug) {

--- a/backend/src/services/eventService.js
+++ b/backend/src/services/eventService.js
@@ -15,7 +15,7 @@ const { validatePasswordInContext, getBcryptRounds } = require('../utils/passwor
 const { buildShareLinkVariants } = require('./shareLinkService');
 const { parseBooleanInput, parseStringInput } = require('../utils/parsers');
 
-const getStoragePath = () => process.env.STORAGE_PATH || path.join(__dirname, '../../storage');
+const getStoragePath = () => process.env.STORAGE_PATH || path.join(__dirname, '../../../storage');
 
 // Cache for schema detection
 let customerColumnCache = null;

--- a/backend/src/services/photoService.js
+++ b/backend/src/services/photoService.js
@@ -10,7 +10,7 @@ const fs = require('fs').promises;
 const { db } = require('../database/db');
 const { formatBoolean } = require('../utils/dbCompat');
 
-const getStoragePath = () => process.env.STORAGE_PATH || path.join(__dirname, '../../storage');
+const getStoragePath = () => process.env.STORAGE_PATH || path.join(__dirname, '../../../storage');
 
 /**
  * Get photos for an event with optional filtering


### PR DESCRIPTION
## Summary
  - Fixed 500 "Failed to serve thumbnail" errors due to incorrect storage path resolution (#96)

  ## Changes

  ### Frontend
  - **GalleryLayout.tsx**: Removed `hidden sm:block` wrapper that was hiding the upload button on mobile

  ### Backend
  - **gallery.js, photoService.js, eventService.js**: Fixed incorrect storage path fallback (`../../storage` → `../../../storage`)

  ## Root Causes

  ### Issue #96 - Thumbnail 500 Errors
  1. When `STORAGE_PATH` env var is not set, `gallery.js` resolved to `backend/storage/` while `imageProcessor.js` resolved to `storage/`
  2. Thumbnails were generated in correct location but served from wrong path
  3. `fs.statSync()` threw ENOENT → 500 error

  ## Test plan
  - [ ] Verify thumbnails load correctly when `STORAGE_PATH` is not explicitly set
  - [ ] Verify thumbnails load correctly when `STORAGE_PATH` is explicitly set