### PR TITLE
feat: add original filename preservation and Lightroom export support

### DIFF
--- a/backend/migrations/core/062_add_original_filename.js
+++ b/backend/migrations/core/062_add_original_filename.js
@@ -1,0 +1,23 @@
+/**
+ * Migration 062: Add original_filename to photos table
+ * - photos.original_filename: preserves the original filename from upload
+ *   This enables Lightroom integration by exporting filtered filenames
+ */
+
+const { addColumnIfNotExists } = require('../helpers');
+
+exports.up = async function(knex) {
+  console.log('Running migration: 062_add_original_filename');
+
+  // photos.original_filename (nullable - original filename before renaming)
+  await addColumnIfNotExists(knex, 'photos', 'original_filename', (table) => {
+    table.string('original_filename', 512);
+  });
+
+  console.log('Migration 062_add_original_filename completed');
+};
+
+exports.down = async function(knex) {
+  console.log('Rollback: 062_add_original_filename');
+  // Keep column (safe rollback not removing data). Intentionally no-op.
+};

--- a/backend/src/routes/adminPhotoExport.js
+++ b/backend/src/routes/adminPhotoExport.js
@@ -71,12 +71,12 @@ router.get('/:eventId/filtered', adminAuth, requirePermission('photos.view'), [
     // Build filtered query
     const filterBuilder = new PhotoFilterBuilder(
       db('photos')
-        .leftJoin('categories', 'photos.category_id', 'categories.id')
+        .leftJoin('photo_categories', 'photos.category_id', 'photo_categories.id')
         .select(
           'photos.id',
           'photos.filename',
           'photos.original_filename',
-          'photos.file_path',
+          'photos.path',
           'photos.average_rating',
           'photos.feedback_count',
           'photos.like_count',
@@ -84,8 +84,8 @@ router.get('/:eventId/filtered', adminAuth, requirePermission('photos.view'), [
           'photos.comment_count',
           'photos.width',
           'photos.height',
-          'photos.created_at',
-          'categories.name as category_name'
+          'photos.uploaded_at',
+          'photo_categories.name as category_name'
         ),
       eventId
     );

--- a/backend/src/routes/adminPhotos.js
+++ b/backend/src/routes/adminPhotos.js
@@ -257,6 +257,7 @@ router.post('/:eventId/upload', adminAuth, requirePermission('photos.upload'), u
             const photoData = {
               event_id: parseInt(eventId),
               filename: newFilename,
+              original_filename: file.originalname, // Preserve original filename for Lightroom export
               path: relativePath,
               thumbnail_path: null, // Will generate after successful commit
               type: photoType,

--- a/backend/src/services/photoProcessor.js
+++ b/backend/src/services/photoProcessor.js
@@ -186,6 +186,7 @@ async function processUploadedPhotos(files, eventId, uploadedBy = 'admin', categ
       const photoData = {
         event_id: eventId,
         filename: newFilename,
+        original_filename: file.originalname,
         path: relativePath,
         thumbnail_path: relativeThumbPath,
         type: photoType,

--- a/backend/src/services/xmpGenerator.js
+++ b/backend/src/services/xmpGenerator.js
@@ -76,7 +76,7 @@ class XmpGenerator {
    * @returns {string} Description XML
    */
   generateDescription(photo) {
-    const rating = photo.average_rating ? photo.average_rating.toFixed(1) : '0';
+    const rating = photo.average_rating ? parseFloat(photo.average_rating).toFixed(1) : '0';
     const likes = photo.like_count || 0;
     const favorites = photo.favorite_count || 0;
 


### PR DESCRIPTION
## Summary
  - Add `original_filename` column to photos table to preserve camera filenames during upload
  - Fix export service to correctly query photo data and generate exports
  - Enable photographers to filter client feedback and export filename lists for Lightroom

  Closes #132

  ## Changes
  - **Migration**: Add `original_filename` column to photos table
  - **Upload handling**: Store original filename when photos are uploaded via admin panel
  - **Export service fixes**:
    - Fix table name (`categories` → `photo_categories`)
    - Fix column names (`file_path` → `path`, `file_size` → `size_bytes`, `created_at` → `uploaded_at`)
    - Fix `toFixed()` calls to handle string ratings from database
    - Add fallback to system filename when original is unavailable

  ## Export Formats Available
  | Format | Use Case |
  |--------|----------|
  | TXT (comma-separated) | Paste into Lightroom's filename filter |
  | CSV | Spreadsheet with ratings, likes, favorites metadata |
  | XMP sidecar files | Import ratings directly into Lightroom/Bridge/Capture One |
  | JSON | Automation and integration scripts |

  ## Test Plan
  - [x] Migration adds column successfully
  - [x] New uploads save original filename to database
  - [x] TXT export shows original filenames
  - [x] CSV export includes original_filename column
  - [x] XMP export generates valid sidecar files
  - [x] JSON export includes all metadata
  - [x] E2E test with Playwright confirms UI workflow