### PR TITLE
fix: docker compose v2 syntax and add missing ADMIN_PASSWORD to .env.example (#189)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,7 @@ REDIS_PASSWORD=your_secure_redis_password_here
 # Admin Account (initial setup)
 ADMIN_USERNAME=admin
 ADMIN_EMAIL=admin@yourdomain.com
+ADMIN_PASSWORD=your_secure_admin_password_here
 
 # Email Configuration
 # For Gmail: use app-specific password

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ cp .env.example .env
 nano .env
 
 # Start with Docker Compose
-docker-compose up -d
+docker compose up -d
 
 # Access at http://localhost:3005
 ```
@@ -128,8 +128,8 @@ PICPEAK_CHANNEL=v2.3.0
 Then update your containers:
 
 ```bash
-docker-compose -f docker-compose.production.yml pull
-docker-compose -f docker-compose.production.yml up -d
+docker compose -f docker-compose.production.yml pull
+docker compose -f docker-compose.production.yml up -d
 ```
 
 ### Update Notifications


### PR DESCRIPTION
## Summary
  - Replace deprecated `docker-compose` (v1) with `docker compose` (v2) in README
  - Add missing `ADMIN_PASSWORD` to `.env.example` so new users don't get a blank-string warning and can actually log in after first setup