### PR TITLE
fix: resolve code scanning security alerts (multer, tar, Node 22)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS builder
+FROM node:22-alpine AS builder
 
 # Add build arguments
 ARG CACHEBUST=1
@@ -23,7 +23,7 @@ RUN npm ci --omit=dev
 COPY . .
 
 # Production stage
-FROM node:20-alpine
+FROM node:22-alpine
 
 WORKDIR /app
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "picpeak-backend",
-  "version": "2.5.0",
+  "version": "3.18.0-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "picpeak-backend",
-      "version": "2.5.0",
+      "version": "3.18.0-beta.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.850.0",
         "@aws-sdk/lib-storage": "^3.850.0",
@@ -5986,9 +5986,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
+      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -6662,6 +6662,19 @@
       "license": "MIT",
       "dependencies": {
         "cross-fetch": "4.0.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ieee754": {
@@ -8558,9 +8571,9 @@
       "license": "MIT"
     },
     "node_modules/multer": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.0.tgz",
-      "integrity": "sha512-TBm6j41rxNohqawsxlsWsNNh/VdV4QFXcBvRcPhXaA05EZ79z0qJ2bQFpync6JBoHTeNY5Q1JpG7AlTjdlfAEA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
+      "integrity": "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==",
       "license": "MIT",
       "dependencies": {
         "append-field": "^1.0.0",
@@ -10760,9 +10773,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.9.tgz",
-      "integrity": "sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==",
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.11.tgz",
+      "integrity": "sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -69,7 +69,7 @@
     "js-yaml": "^4.1.1",
     "fast-xml-parser": ">=5.3.8",
     "qs": ">=6.14.2",
-    "tar": ">=7.5.8",
+    "tar": ">=7.5.11",
     "brace-expansion": ">=5.0.0",
     "minimatch": ">=9.0.7"
   }


### PR DESCRIPTION
## Summary
- Upgrade `multer` to 2.1.1 — fixes CVE-2026-3520 (DoS via malformed requests)
- Update `tar` override to >=7.5.11 — fixes CVE-2026-31802 (symlink traversal) and CVE-2026-29786 (hardlink traversal)
- Upgrade Docker base image from `node:20-alpine` to `node:22-alpine` — fixes `tar` and `minimatch` CVEs in npm's bundled dependencies (alerts #111, #112, #127, #131)

## Remaining
- `@tootallnate/once` (low severity, CVE-2026-3449) — transitive dep deep in `sqlite3 → node-gyp`. Fix requires breaking `sqlite3` major upgrade. Low risk since it's only used at build time.

## Test plan
- [x] `npm audit fix` applied successfully
- [x] Backend Docker image builds with `node:22-alpine`
- [x] Backend starts, migrations run, health check passes