### PR TITLE
fix(security): token invalidation on password change, session timeout enforcement

### DIFF
--- a/backend/src/middleware/sessionTimeout.js
+++ b/backend/src/middleware/sessionTimeout.js
@@ -85,18 +85,28 @@ async function sessionTimeoutMiddleware(req, res, next) {
     const now = Date.now();
     const lastActivity = sessions.get(token);
     const timeout = await getSessionTimeout();
-    
-    // If session exists, check if it's expired
+
     if (lastActivity) {
+      // Existing session — check if idle too long
       if (now - lastActivity > timeout) {
         sessions.delete(token);
-        return res.status(401).json({ 
-          error: 'Session expired', 
-          code: 'SESSION_TIMEOUT' 
+        return res.status(401).json({
+          error: 'Session expired',
+          code: 'SESSION_TIMEOUT'
+        });
+      }
+    } else {
+      // First request with this token — check if token was issued longer ago than the timeout
+      // This prevents old/stolen tokens from bypassing session timeout after server restart
+      const tokenIssuedAt = (decoded.iat || 0) * 1000; // iat is in seconds
+      if (now - tokenIssuedAt > timeout) {
+        return res.status(401).json({
+          error: 'Session expired',
+          code: 'SESSION_TIMEOUT'
         });
       }
     }
-    
+
     // Update last activity
     sessions.set(token, now);
     

--- a/backend/src/routes/adminAuth.js
+++ b/backend/src/routes/adminAuth.js
@@ -122,13 +122,15 @@ router.post('/change-password', [
   // Hash new password with more rounds
   const newPasswordHash = await bcrypt.hash(newPassword, 12);
 
-  // Update password and clear must_change_password flag
+  // Update password, set password_changed_at to invalidate existing tokens, and clear must_change_password flag
+  const now = new Date();
   await db('admin_users')
     .where('id', userId)
     .update({
       password_hash: newPasswordHash,
+      password_changed_at: now,
       must_change_password: false,
-      updated_at: new Date()
+      updated_at: now
     });
 
   // Log activity

--- a/frontend/src/services/userManagement.service.ts
+++ b/frontend/src/services/userManagement.service.ts
@@ -149,7 +149,11 @@ export const userManagementService = {
    * Update an admin user
    */
   async updateUser(id: number, data: UpdateUserData): Promise<AdminUser> {
-    const response = await api.put<UpdateUserResponse>(`/admin/users/${id}`, data);
+    // Convert camelCase to snake_case for backend API
+    const payload: Record<string, unknown> = {};
+    if (data.roleId !== undefined) payload.role_id = data.roleId;
+    if (data.isActive !== undefined) payload.is_active = data.isActive;
+    const response = await api.put<UpdateUserResponse>(`/admin/users/${id}`, payload);
     return transformUser(response.data.user);
   },
 


### PR DESCRIPTION
## Summary
Cherry-pick of security fixes from beta (PR #243) to main. Resolves GHSA-rqg3-47p5-vgwg.

- **Token invalidation on password change**: Set `password_changed_at` in adminAuth change-password endpoint so existing JWT tokens are rejected
- **Session timeout enforcement**: Check token `iat` against configured timeout for first-time/unknown tokens (prevents bypass after server restart)
- **Role update naming mismatch**: Convert `roleId`/`isActive` to `role_id`/`is_active` in frontend service layer

## Test plan
- [x] Verified on beta with E2E curl tests
- [x] Cherry-pick applied cleanly — only touches 3 files with no conflicts