### PR TITLE
fix: beta feedback - gallery fixes, Russian locale, email logo

### DIFF
--- a/backend/src/services/emailProcessor.js
+++ b/backend/src/services/emailProcessor.js
@@ -153,9 +153,11 @@ async function wrapEmailHtml(htmlBody, subject, language = 'en') {
 
   const hoverColor = darkenColor(primaryColor, 0.15);
 
-  // If no custom logo, use default PicPeak logo
-  const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:3000';
-  const logoFullUrl = `${frontendUrl}${logoUrl || '/picpeak-logo-transparent.png'}`;
+  // Build full logo URL - ensure logoUrl is a valid non-empty string
+  const frontendUrl = (process.env.FRONTEND_URL || 'http://localhost:3000').replace(/\/+$/, '');
+  const logoPath = (typeof logoUrl === 'string' && logoUrl.trim()) ? logoUrl : '/picpeak-logo-transparent.png';
+  const logoFullUrl = `${frontendUrl}${logoPath.startsWith('/') ? '' : '/'}${logoPath}`;
+  logger.debug('Email logo URL:', { frontendUrl, logoPath, logoFullUrl });
 
   return `
 <!DOCTYPE html>

--- a/frontend/src/components/gallery/layouts/GalleryPremiumLayout.tsx
+++ b/frontend/src/components/gallery/layouts/GalleryPremiumLayout.tsx
@@ -343,7 +343,7 @@ export const GalleryPremiumLayout: React.FC<GalleryPremiumLayoutProps> = ({
         <div
           className="gallery-premium-hero-bg"
           style={{
-            backgroundImage: heroPhoto ? `url(${heroPhoto.thumbnail_url || heroPhoto.url})` : undefined
+            backgroundImage: heroPhoto ? `url(${heroPhoto.hero_url || heroPhoto.url})` : undefined
           }}
         />
         <div className="gallery-premium-hero-overlay" />

--- a/frontend/src/components/gallery/layouts/GalleryStoryLayout.tsx
+++ b/frontend/src/components/gallery/layouts/GalleryStoryLayout.tsx
@@ -17,6 +17,7 @@ import {
   StoryFeedbackSheet,
   StoryScrollToTop
 } from './story';
+import { PhotoLightbox } from '../PhotoLightbox';
 
 import './GalleryStoryLayout.css';
 
@@ -71,6 +72,7 @@ export const GalleryStoryLayout: React.FC<GalleryStoryLayoutProps> = ({
   const [searchQuery, setSearchQuery] = useState('');
   const [favorites, setFavorites] = useState<Set<number>>(new Set());
   const [selectedPhotoForFeedback, setSelectedPhotoForFeedback] = useState<Photo | null>(null);
+  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
   const [comments, setComments] = useState<Record<number, Array<{ id: string; author: string; text: string; date: string }>>>({});
   const [ratings, setRatings] = useState<Record<number, number>>({});
   const [savedIdentity, setSavedIdentity] = useState<{ name: string; email: string } | null>(null);
@@ -112,7 +114,7 @@ export const GalleryStoryLayout: React.FC<GalleryStoryLayoutProps> = ({
 
     // Group by category
     filteredPhotos.forEach(photo => {
-      const categoryName = photo.category_name || t('gallery.uncategorized', 'Gallery');
+      const categoryName = photo.category_name || '';
       if (!photosByCategory[categoryName]) {
         photosByCategory[categoryName] = [];
       }
@@ -162,6 +164,11 @@ export const GalleryStoryLayout: React.FC<GalleryStoryLayoutProps> = ({
   const handleOpenFeedback = useCallback((photo: Photo) => {
     setSelectedPhotoForFeedback(photo);
   }, []);
+
+  const handleOpenLightbox = useCallback((photo: Photo) => {
+    const index = photos.findIndex(p => p.id === photo.id);
+    setLightboxIndex(index >= 0 ? index : 0);
+  }, [photos]);
 
   const handleCloseFeedback = useCallback(() => {
     setSelectedPhotoForFeedback(null);
@@ -312,7 +319,7 @@ export const GalleryStoryLayout: React.FC<GalleryStoryLayoutProps> = ({
                   photos={scene.photos}
                   favorites={favorites}
                   onToggleFavorite={handleToggleFavorite}
-                  onPhotoClick={handleOpenFeedback}
+                  onPhotoClick={handleOpenLightbox}
                   slug={slug}
                   allowDownloads={allowDownloads}
                   protectionLevel={protectionLevel}
@@ -328,7 +335,7 @@ export const GalleryStoryLayout: React.FC<GalleryStoryLayoutProps> = ({
                       index={index}
                       isFavorite={favorites.has(photo.id)}
                       onToggleFavorite={handleToggleFavorite}
-                      onClick={() => handleOpenFeedback(photo)}
+                      onClick={() => handleOpenLightbox(photo)}
                       slug={slug}
                       galleryId={`gallery-${scene.id}`}
                       allowDownloads={allowDownloads}
@@ -358,6 +365,22 @@ export const GalleryStoryLayout: React.FC<GalleryStoryLayoutProps> = ({
           </button>
         )}
       </footer>
+
+      {/* Lightbox */}
+      {lightboxIndex !== null && (
+        <PhotoLightbox
+          photos={photos}
+          initialIndex={lightboxIndex}
+          onClose={() => setLightboxIndex(null)}
+          slug={slug}
+          feedbackEnabled={feedbackEnabled}
+          allowDownloads={allowDownloads}
+          protectionLevel={protectionLevel}
+          useEnhancedProtection={useEnhancedProtection}
+          useCanvasRendering={useCanvasRendering}
+          onFeedbackChange={onFeedbackChange}
+        />
+      )}
 
       {/* Feedback Sheet */}
       {feedbackEnabled && (

--- a/frontend/src/components/gallery/layouts/story/StoryPhotoCard.tsx
+++ b/frontend/src/components/gallery/layouts/story/StoryPhotoCard.tsx
@@ -60,7 +60,7 @@ export const StoryPhotoCard: React.FC<StoryPhotoCardProps> = ({
         className="block w-full h-full"
       >
         <AuthenticatedImage
-          src={photo.thumbnail_url || photo.url}
+          src={photo.url}
           alt={photo.filename}
           onLoad={() => setIsLoaded(true)}
           className={`w-full h-full object-cover transition-all duration-700 ease-out will-change-transform ${

--- a/frontend/src/components/gallery/layouts/story/StoryScene.tsx
+++ b/frontend/src/components/gallery/layouts/story/StoryScene.tsx
@@ -18,27 +18,29 @@ export const StoryScene: React.FC<StorySceneProps> = ({
 }) => {
   return (
     <section className={`story-scene ${fullWidth ? 'full-width' : ''} ${className}`}>
-      <div className="story-scene-header">
-        <motion.h2
-          initial={{ opacity: 0, x: -20 }}
-          whileInView={{ opacity: 1, x: 0 }}
-          viewport={{ once: true }}
-          className="story-scene-title"
-        >
-          {title}
-        </motion.h2>
-        {subtitle && (
-          <motion.p
+      {title && (
+        <div className="story-scene-header">
+          <motion.h2
             initial={{ opacity: 0, x: -20 }}
             whileInView={{ opacity: 1, x: 0 }}
             viewport={{ once: true }}
-            transition={{ delay: 0.1 }}
-            className="story-scene-subtitle"
+            className="story-scene-title"
           >
-            {subtitle}
-          </motion.p>
-        )}
-      </div>
+            {title}
+          </motion.h2>
+          {subtitle && (
+            <motion.p
+              initial={{ opacity: 0, x: -20 }}
+              whileInView={{ opacity: 1, x: 0 }}
+              viewport={{ once: true }}
+              transition={{ delay: 0.1 }}
+              className="story-scene-subtitle"
+            >
+              {subtitle}
+            </motion.p>
+          )}
+        </div>
+      )}
       {children}
     </section>
   );

--- a/frontend/src/features/settings/tabs/GeneralTab.tsx
+++ b/frontend/src/features/settings/tabs/GeneralTab.tsx
@@ -247,6 +247,7 @@ export const GeneralTab: React.FC<GeneralTabProps> = ({
               <option value="en">English</option>
               <option value="de">Deutsch</option>
               <option value="pt">Português (Brasil)</option>
+              <option value="ru">Русский</option>
             </select>
             <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
               {t('settings.general.defaultLanguageHelp')}

--- a/frontend/src/pages/GalleryPage.tsx
+++ b/frontend/src/pages/GalleryPage.tsx
@@ -106,7 +106,7 @@ export const GalleryPage: React.FC = () => {
   }, [resolvedSlug]);
   
   // Fetch branding settings
-  const { data: settingsData } = useQuery({
+  const { data: settingsData, isLoading: isLoadingSettings } = useQuery({
     queryKey: ['gallery-settings'],
     queryFn: async () => {
       const response = await api.get('/public/settings');
@@ -177,7 +177,7 @@ export const GalleryPage: React.FC = () => {
       return;
     }
 
-    if (galleryInfo && isGalleryPublic(galleryInfo.requires_password) && !isAuthenticated && !autoLoginAttempted) {
+    if (galleryInfo && isGalleryPublic(galleryInfo.requires_password) && !isAuthenticated && !autoLoginAttempted && !isLoadingSettings) {
       setAutoLoginAttempted(true);
       setIsLoggingIn(true);
       login(resolvedSlug, '')
@@ -194,7 +194,7 @@ export const GalleryPage: React.FC = () => {
           setIsLoggingIn(false);
         });
     }
-  }, [galleryInfo, isAuthenticated, autoLoginAttempted, login, resolvedSlug, isResolvingIdentifier]);
+  }, [galleryInfo, isAuthenticated, autoLoginAttempted, login, resolvedSlug, isResolvingIdentifier, isLoadingSettings]);
 
   // Calculate days until expiration (null if no expiration set)
   const daysUntilExpiration = galleryInfo?.expires_at
@@ -526,15 +526,23 @@ export const GalleryPage: React.FC = () => {
                 </>
               ) : (
                 <div className="text-center space-y-3">
-                  <h2 className="text-base sm:text-lg lg:text-xl font-semibold">
-                    {t('gallery.publicGalleryTitle', 'This gallery is publicly accessible')}
-                  </h2>
-                  <p className="text-sm text-neutral-600">
-                    {t('gallery.publicGallerySubtitle', 'Loading the photos now...')}
-                  </p>
-                  <div className="flex justify-center py-4">
-                    <Loading size="sm" text={t('gallery.loading')} />
-                  </div>
+                  {isLoadingSettings ? (
+                    <div className="flex justify-center py-4">
+                      <Loading size="sm" />
+                    </div>
+                  ) : (
+                    <>
+                      <h2 className="text-base sm:text-lg lg:text-xl font-semibold">
+                        {t('gallery.publicGalleryTitle', 'This gallery is publicly accessible')}
+                      </h2>
+                      <p className="text-sm text-neutral-600">
+                        {t('gallery.publicGallerySubtitle', 'Loading the photos now...')}
+                      </p>
+                      <div className="flex justify-center py-4">
+                        <Loading size="sm" text={t('gallery.loading')} />
+                      </div>
+                    </>
+                  )}
                   {loginError && (
                     <p className="text-xs text-red-600">{loginError}</p>
                   )}


### PR DESCRIPTION
## Summary

Addresses beta tester feedback with 6 bug fixes:

- **Russian locale**: Add Русский option to admin settings language dropdown
- **Premium hero image**: Use `hero_url` instead of `thumbnail_url` for hero background (was showing blurry 400x300 thumbnail)
- **Story layout "Uncategorized" label**: Hide section header when photos have no category
- **Story layout lightbox**: Add `PhotoLightbox` so clicking photos opens full-screen view (was only opening feedback sheet)
- **Story layout full-res images**: Use `photo.url` instead of `thumbnail_url` in `StoryPhotoCard`
- **No-password gallery locale**: Defer auto-login text rendering until settings/language are loaded, preventing English text flash
- **Email logo URL**: Add validation, trailing slash handling, and debug logging for logo URL construction

## Test plan

- [x] Docker rebuild + containers healthy
- [x] Russian locale visible and selectable in admin Settings > Language
- [x] Premium layout hero shows full-res image (not thumbnail)
- [x] Story layout renders without "Uncategorized" section headers
- [x] Story layout uses PhotoLightbox for photo clicks
- [x] Public (no-password) gallery auto-logs in without English text flash
- [x] TypeScript compilation passes