### PR TITLE
fix: pin npm to v10 in backend Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -30,8 +30,9 @@ WORKDIR /app
 # Upgrade all packages to fix security vulnerabilities (OpenSSL, libexpat, BusyBox CVEs)
 RUN apk upgrade --no-cache
 
-# Upgrade npm to latest to fix tar, minimatch, brace-expansion CVEs in npm's own deps
-RUN npm install -g npm@latest
+# Upgrade npm to fix tar, minimatch, brace-expansion CVEs in npm's own deps
+# Pin to 10.x to stay compatible with Node 22 Alpine (npm 11.x has dependency issues)
+RUN npm install -g npm@10
 
 # Install dumb-init for proper signal handling and postgresql-client for database checks
 RUN apk add --no-cache dumb-init postgresql-client


### PR DESCRIPTION
## Summary
- Pin `npm install -g npm@latest` to `npm install -g npm@10` in backend Dockerfile
- `npm@latest` now resolves to v11 which has a broken `promise-retry` dependency on Node 22 Alpine, causing CI builds to fail
- This is unrelated to the email template changes — it's an upstream npm/Alpine compatibility issue

## Test plan
- [x] Verified `npm install -g npm@10` works in `node:22-alpine` container (installs 10.9.8)
- [ ] CI build should now pass