### PR TITLE
security: pin axios to 1.14.0 — supply chain attack prevention

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "picpeak-backend",
-  "version": "3.18.0-beta.0",
+  "version": "3.24.0-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "picpeak-backend",
-      "version": "3.18.0-beta.0",
+      "version": "3.24.0-beta.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.850.0",
         "@aws-sdk/lib-storage": "^3.850.0",
@@ -14,7 +14,7 @@
         "@ffmpeg-installer/ffmpeg": "^1.1.0",
         "adm-zip": "^0.5.16",
         "archiver": "^5.3.1",
-        "axios": "^1.12.2",
+        "axios": "1.14.0",
         "bcrypt": "6.0.0",
         "chokidar": "4.0.3",
         "cookie-parser": "^1.4.7",
@@ -4071,14 +4071,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
+      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/babel-jest": {
@@ -9592,10 +9592,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",

--- a/backend/package.json
+++ b/backend/package.json
@@ -19,7 +19,7 @@
     "@ffmpeg-installer/ffmpeg": "^1.1.0",
     "adm-zip": "^0.5.16",
     "archiver": "^5.3.1",
-    "axios": "^1.12.2",
+    "axios": "1.14.0",
     "bcrypt": "6.0.0",
     "chokidar": "4.0.3",
     "cookie-parser": "^1.4.7",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "picpeak-frontend",
-  "version": "2.5.0",
+  "version": "3.24.0-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "picpeak-frontend",
-      "version": "2.5.0",
+      "version": "3.24.0-beta.0",
       "dependencies": {
         "@tanstack/react-query": "^5.0.0",
         "@tiptap/extension-character-count": "^2.26.1",
@@ -20,7 +20,7 @@
         "@types/dompurify": "^3.0.5",
         "@types/lodash": "^4.17.20",
         "@types/react-google-recaptcha": "^2.1.9",
-        "axios": "^1.12.2",
+        "axios": "1.14.0",
         "clsx": "^2.0.0",
         "date-fns": "4.1.0",
         "dompurify": "^3.2.6",
@@ -3020,14 +3020,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
+      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -5751,10 +5751,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,7 @@
     "@types/dompurify": "^3.0.5",
     "@types/lodash": "^4.17.20",
     "@types/react-google-recaptcha": "^2.1.9",
-    "axios": "^1.12.2",
+    "axios": "1.14.0",
     "clsx": "^2.0.0",
     "date-fns": "4.1.0",
     "dompurify": "^3.2.6",


### PR DESCRIPTION
## URGENT: Supply Chain Attack on Axios

On March 31, 2026, the npm account of the lead Axios maintainer was hijacked. Two malicious versions were published:
- **axios@1.14.1** (compromised)
- **axios@0.30.4** (compromised)

These versions inject `plain-crypto-js@4.2.1` which drops a **cross-platform RAT** (Remote Access Trojan) attributed to North Korean threat actor UNC1069/Sapphire Sleet.

## Our exposure
- **Current installed version**: 1.13.6 (safe)
- **package.json range was**: `^1.12.2` — would resolve to 1.14.1 on next `npm install`
- **Malicious version removed from npm** but pinning is critical defense-in-depth

## Fix
- Pin both frontend and backend to exact `"axios": "1.14.0"` (latest safe release)
- Lock files updated to resolve only 1.14.0

## References
- https://github.com/axios/axios/issues/10604
- https://snyk.io/blog/axios-npm-package-compromised-supply-chain-attack-delivers-cross-platform/
- https://www.microsoft.com/en-us/security/blog/2026/04/01/mitigating-the-axios-npm-supply-chain-compromise/