### PR TITLE
docs: rewrite README — shorter, cleaner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,350 +1,142 @@
-# 📸 PicPeak - Open Source Photo Sharing for Events
+# PicPeak
 
 <div align="center">
   <img src="docs/picpeak-logo.png" alt="PicPeak Logo" width="300" />
-  
+
+  **Self-hosted photo sharing for event photographers.**
+
   [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
   [![Docker](https://img.shields.io/badge/docker-%230db7ed.svg?style=flat&logo=docker&logoColor=white)](https://www.docker.com/)
   [![Node.js](https://img.shields.io/badge/node.js-6DA55F?style=flat&logo=node.js&logoColor=white)](https://nodejs.org/)
   [![React](https://img.shields.io/badge/react-%2320232a.svg?style=flat&logo=react&logoColor=%2361DAFB)](https://reactjs.org/)
 
-  [Homepage](https://www.picpeak.app) · [Live Demo](https://demo.picpeak.app) · [Documentation](DEPLOYMENT_GUIDE.md)
+  [Live Demo](https://demo.picpeak.app) · [Deployment Guide](DEPLOYMENT_GUIDE.md) · [Homepage](https://www.picpeak.app)
 </div>
 
-**PicPeak** is a powerful, self-hosted open-source alternative to commercial photo-sharing platforms like PicDrop.com and Scrapbook.de. Designed specifically for photographers and event organizers, PicPeak makes it simple to share beautiful, time-limited photo galleries with clients while maintaining full control over your data and branding.
+---
+
+PicPeak lets you create password-protected, time-limited photo galleries for your clients — hosted on your own server. No subscriptions, no storage limits, no third-party access to your photos.
 
 ![PicPeak Gallery Preview](docs/screenshot-gallery.png)
 
-## 🎮 Live Demo
+## Demo
 
-Try PicPeak without installing anything:
+Try it out at [demo.picpeak.app](https://demo.picpeak.app).
 
-| | |
-|---|---|
-| **Demo URL** | [demo.picpeak.app](https://demo.picpeak.app) |
-| **Admin Panel** | [demo.picpeak.app/admin](https://demo.picpeak.app/admin) |
-| **Email** | `demo@picpeak.app` |
-| **Password** | `Demo2026!` |
+Admin panel: [demo.picpeak.app/admin](https://demo.picpeak.app/admin) — login with `demo@picpeak.app` / `Demo2026!`
 
-> The demo resets periodically. Uploaded content may be removed without notice.
+> The demo resets periodically.
 
-## 🌟 Why Choose PicPeak?
+## Features
 
-Unlike expensive SaaS solutions, PicPeak gives you:
+**Gallery Management** — Create galleries, upload photos via drag & drop, set passwords and expiration dates. Galleries auto-archive when they expire. Events start as drafts so you can upload and prepare before notifying the client.
 
-- **💰 No Monthly Fees** - One-time setup, unlimited galleries
-- **🔒 Complete Data Control** - Your photos stay on your server
-- **🎨 White-Label Ready** - Full branding customization
-- **📱 Mobile-First Design** - Beautiful on all devices
-- **🚀 Lightning Fast** - Optimized performance and caching
-- **🌍 Multi-Language** - Built-in i18n support (EN, DE)
+**Client Experience** — Responsive galleries that look great on any device. Guests can browse, download individual photos or everything at once. Optional guest uploads and feedback (likes, comments, ratings).
 
-## ✨ Key Features
+**Themes & Branding** — 11 built-in theme presets, custom CSS templates, configurable colors/fonts/layouts. White-label your admin panel and login page with your own logo and company name.
 
-### For Photographers
-- 📁 **Drag & Drop Upload** - Simply drop photos into folders
-- 🔗 **External Media (Reference Mode)** - Browse and import from a read‑only external folder library without copying originals
-- ⏰ **Auto-Expiring Galleries** - Set expiration dates (default: 30 days)
-- 🔐 **Password Protection** - Secure client galleries
-- 📧 **Automated Emails** - Creation confirmations and expiration warnings
-- 📊 **Analytics Dashboard** - Track views, downloads, and engagement
-- 🎨 **Custom Themes** - Match your brand perfectly
-- 🌐 **Public Landing Page** - Publish a curated marketing page when guests visit your root URL
+**Email Notifications** — Automated gallery creation, expiration warning, and archive emails. Multilingual templates (EN, DE, NL, PT, RU) editable from the admin UI.
 
-### For Clients
-- 🖼️ **Beautiful Galleries** - Clean, modern interface
-- 📱 **Mobile Optimized** - Swipe through photos on any device
-- ⬇️ **Bulk Downloads** - Download all photos with one click
-- 🔍 **Smart Search** - Find photos quickly
-- 📤 **Guest Uploads** - Optional client photo uploads
-- 🛡️ **Download Protection** - Advanced image protection with watermarking and right-click prevention
+**Photo Protection** — Watermarking, right-click prevention, canvas rendering, DevTools detection. Configurable per gallery.
 
-### Technical Excellence
-- 🐳 **Docker Ready** - Deploy in minutes
-- 🔄 **Auto-Processing** - Automatic thumbnail generation
-- 🗂️ **Reference Library Support** - Point PicPeak at `EXTERNAL_MEDIA_ROOT` to reference existing originals, index quickly, and generate thumbnails on demand
-- 💾 **Smart Storage** - Automatic archiving of expired galleries
-- 🛡️ **Security First** - JWT auth, rate limiting, CORS protection
-- 📈 **Scalable** - From small studios to large agencies
+**External Media** — Reference photos from a mounted folder instead of uploading. PicPeak reads originals in place and generates thumbnails on demand.
 
-## 🚀 Quick Start
+**Multi-Language** — Full UI translations for English, German, Dutch, Portuguese, and Russian. Email templates support all languages independently.
 
-Get PicPeak running in under 5 minutes:
+**Analytics** — Built-in view/download tracking plus optional Umami integration for privacy-focused analytics.
+
+**Video Support** — Upload and stream MP4, WebM, MOV alongside photos. FFmpeg bundled via npm.
+
+**Multiple Admins** — Role-based access control with super admin, admin, and editor roles.
+
+## Quick Start
 
 ```bash
-# Clone the repository
 git clone https://github.com/the-luap/picpeak.git
 cd picpeak
-
-# Copy environment template
 cp .env.example .env
-
-# Edit configuration (required: JWT_SECRET)
-nano .env
-
-# Start with Docker Compose
+# Edit .env — set at least JWT_SECRET and passwords
 docker compose up -d
-
-# Access at http://localhost:3000
 ```
 
-Note on Docker file permissions (PUID/PGID)
-- When using bind mounts (e.g., `./storage`, `./data`, `./logs`, `./events`), ensure the container user can write to these host folders. The backend runs as a non‑root user by default.
-- Set `PUID` and `PGID` in your `.env` to match your host user’s UID/GID (run `id -u` and `id -g` on the host). Compose maps the container user to these values.
-- Example in `.env`:
-  - `PUID=1000`
-  - `PGID=1000`
-- Without this, creating events, uploads, thumbnails, or logs can fail with "Permission denied".
+Open `http://localhost:3000` and log in with the credentials from your `.env`.
 
-## 🔄 Release Channels
+> **Permissions:** Set `PUID` and `PGID` in `.env` to match your host user (`id -u` / `id -g`) so Docker volumes are writable.
 
-PicPeak offers two release channels for different needs:
+See the [Deployment Guide](DEPLOYMENT_GUIDE.md) for reverse proxy setup, SSL, external media, and production configuration.
 
-### Stable Channel (Recommended)
-- Production-ready releases
-- Thoroughly tested before release
-- Docker tags: `stable`, `latest`, or specific version like `v2.3.0`
+## Screenshots
 
-### Beta Channel
-- Early access to new features
-- May contain bugs or incomplete functionality
-- Docker tags: `beta` or specific version like `v2.3.0-beta.1`
+<details>
+<summary>Admin Dashboard</summary>
 
-### Switching Channels
+<img src="docs/screenshot-dashboard.png" alt="Admin Dashboard" width="800" />
+</details>
 
-Set the `PICPEAK_CHANNEL` environment variable in your `.env` file:
+<details>
+<summary>Event Management</summary>
+
+<img src="docs/screenshots-events.png" alt="Event Management" width="800" />
+</details>
+
+<details>
+<summary>Analytics</summary>
+
+<img src="docs/screenshot-analytics.png" alt="Analytics" width="800" />
+</details>
+
+## Comparison
+
+| | PicPeak | PicDrop | Scrapbook.de |
+|---|---|---|---|
+| Self-hosted | Yes | No | No |
+| Monthly cost | $0 | $29-199 | 19-99 EUR |
+| Storage | Unlimited | 50-500 GB | 100-1000 GB |
+| Custom branding | Full | Limited | Limited |
+| Open source | Yes | No | No |
+| API | Yes | Paid | No |
+
+## Tech Stack
+
+- **Backend:** Node.js, Express, PostgreSQL (or SQLite)
+- **Frontend:** React, TypeScript, Tailwind CSS
+- **Infrastructure:** Docker, Nginx, Redis
+- **Processing:** Sharp (images), FFmpeg (video)
+
+## Release Channels
+
+**Stable** (`stable` / `latest`) — Production-ready. Use this for real deployments.
+
+**Beta** (`beta`) — Early access to new features. May have rough edges.
 
 ```bash
-# For stable releases (default)
-PICPEAK_CHANNEL=stable
+# Set in .env
+PICPEAK_CHANNEL=stable  # or beta
 
-# For beta releases
-PICPEAK_CHANNEL=beta
-
-# For a specific version
-PICPEAK_CHANNEL=v2.3.0
-```
-
-Then update your containers:
-
-```bash
+# Update
 docker compose -f docker-compose.production.yml pull
 docker compose -f docker-compose.production.yml up -d
 ```
 
-### Update Notifications
+The admin dashboard notifies you when updates are available.
 
-The admin dashboard automatically notifies you when updates are available for your channel. To disable update checks, set:
+## Contributing
 
-```bash
-UPDATE_CHECK_ENABLED=false
-```
+We welcome contributions — bug fixes, features, translations, documentation. See [CONTRIBUTING.md](CONTRIBUTING.md) for setup instructions.
 
-## 📖 Documentation
+## Documentation
 
-- 📘 [**Deployment Guide**](DEPLOYMENT_GUIDE.md) - Detailed installation instructions
-  - Includes the new [External Media Library](DEPLOYMENT_GUIDE.md#external-media-library) reference mode
-- 📚 [**Admin API (OpenAPI)**](docs/picpeak-admin-api.openapi.yaml) - Machine-readable documentation for event automation endpoints
-- 🛠️ [**Admin API Quickstart**](docs/admin-api-quickstart.md) - Step-by-step authentication and testing guide for the documented endpoints
-- 🤝 [**Contributing**](CONTRIBUTING.md) - How to contribute
-- 📜 [**License**](LICENSE) - MIT License
-- 🔒 [**Security**](SECURITY.md) - Security policies
-- 📋 [**Code of Conduct**](CODE_OF_CONDUCT.md) - Community guidelines
+- [Deployment Guide](DEPLOYMENT_GUIDE.md) — Installation, configuration, reverse proxy, external media
+- [Admin API (OpenAPI)](docs/picpeak-admin-api.openapi.yaml) — Machine-readable API spec
+- [Admin API Quickstart](docs/admin-api-quickstart.md) — Authentication and testing guide
+- [Security Policy](SECURITY.md)
 
-## 🌐 Public Landing Page
+## License
 
-Spotlight your studio with a customizable marketing page at `/`:
-
-- Head to **Admin → CMS Pages** to enable the public landing page toggle.
-- Edit the provided HTML template (rich sections, hero, testimonials) and optional CSS overrides.
-- The preview renders in a sandboxed iframe so you can iterate safely before publishing.
-- PicPeak sanitizes stored HTML and CSS server-side—scripts, iframes, and unsafe attributes are stripped automatically.
-- Use **Reset to default** anytime to restore the bundled template.
-- The backend caches the rendered landing page for 60 seconds by default; override with `PUBLIC_SITE_CACHE_TTL_MS` if you need a different TTL.
-- When the landing page is disabled PicPeak continues to serve the admin SPA/login exactly as before.
-
-## 🎯 Use Cases
-
-Perfect for:
-- 💒 **Wedding Photographers** - Share ceremony photos securely
-- 🎂 **Event Photography** - Birthday parties, corporate events
-- 📸 **Portrait Studios** - Client galleries with download limits
-- 🏢 **Corporate Events** - Internal photo sharing with branding
-- 🎓 **School Photography** - Secure parent access with expiration
-
-## 🏗️ Tech Stack
-
-- **Backend**: Node.js, Express, SQLite/PostgreSQL
-- **Frontend**: React, Tailwind CSS, Framer Motion
-- **Storage**: File-based with automatic archiving
-- **Email**: SMTP with customizable templates
-- **Analytics**: Privacy-focused with Umami integration
-
-## 💻 System Requirements
-
-### Minimum Requirements
-- **CPU**: 2 CPU cores
-- **RAM**: 2GB minimum
-- **Storage**: 20GB minimum (plus photo storage needs)
-- **OS**: Linux (Ubuntu 20.04+), macOS, or Windows with WSL2
-- **Node.js**: v18.0.0 or higher
-- **Database**: SQLite (included) or PostgreSQL 12+
-
-### Docker Requirements (Recommended)
-- **Docker**: v20.10.0+
-- **Docker Compose**: v2.0.0+
-
-### Video Support Requirements
-When enabling video uploads, consider these additional resources:
-
-| Resource | Recommendation | Notes |
-|----------|----------------|-------|
-| **RAM** | 4GB+ recommended | FFmpeg processing requires more memory |
-| **Storage** | Plan for 10-100x more | Videos are significantly larger than images |
-| **CPU** | Additional cores help | Video thumbnail extraction is CPU-intensive |
-| **Bandwidth** | Higher throughput | Video streaming requires more bandwidth |
-
-**Technical Notes:**
-- FFmpeg is bundled via npm (`@ffmpeg-installer/ffmpeg`) - no system installation required
-- Maximum upload size: **10GB per video file**
-- Chunked upload support for files >100MB (resumable uploads)
-- Supported formats: MP4, WebM, MOV, AVI
-- Video thumbnails are automatically generated from the first few seconds
-
-**For Nginx/Reverse Proxy:**
-If using Nginx, increase the client max body size:
-```nginx
-client_max_body_size 10G;
-proxy_read_timeout 3600;
-proxy_send_timeout 3600;
-```
-
-## 🤝 Contributing
-
-We love contributions! PicPeak is built by photographers, for photographers. Whether you're fixing bugs, adding features, or improving documentation, your help is welcome.
-
-See our [Contributing Guide](CONTRIBUTING.md) for details.
-
-## 📊 Comparison with Alternatives
-
-| Feature | PicPeak | PicDrop | Scrapbook.de |
-|---------|---------|---------|--------------|
-| Self-Hosted | ✅ | ❌ | ❌ |
-| Custom Branding | ✅ Full | Limited | Limited |
-| Monthly Cost | $0 | $29-199 | €19-99 |
-| Storage Limit | Unlimited* | 50-500GB | 100-1000GB |
-| Client Uploads | ✅ | ✅ | ✅ |
-| API Access | ✅ | Paid | ❌ |
-| Open Source | ✅ | ❌ | ❌ |
-
-*Limited only by your server storage
-
-## 🛡️ Security
-
-PicPeak takes security seriously:
-- 🔐 Password hashing with bcrypt
-- 🎫 JWT-based authentication
-- 🚦 Rate limiting on all endpoints
-- 🛡️ CORS protection
-- 📝 Activity logging
-- 🔒 Secure file access
-
-Found a security issue? Please open a [security issue](https://github.com/the-luap/picpeak/issues/new?labels=security) on GitHub
-
-## 📸 Screenshots
-
-### 🎛️ **Admin Dashboard**
-Get a complete overview of your photo galleries, analytics, and system status.
-
-<img src="docs/screenshot-dashboard.png" alt="PicPeak Admin Dashboard" width="800" />
-
-### 📊 **Analytics & Insights**
-Track gallery performance, view statistics, and monitor user engagement.
-
-<img src="docs/screenshot-analytics.png" alt="PicPeak Analytics Dashboard" width="800" />
-
-### 📁 **Event Management**
-Organize and manage your photo galleries with intuitive event management tools.
-
-<img src="docs/screenshots-events.png" alt="PicPeak Events Management" width="800" />
-
-### ✨ **Key Interface Highlights**
-
-<details>
-<summary>👆 Click to see more interface details</summary>
-
-#### What makes PicPeak's interface special:
-
-- **🎨 Clean Design**: Modern, photographer-friendly interface
-- **📱 Responsive**: Perfect on desktop, tablet, and mobile
-- **⚡ Fast Loading**: Optimized for quick photo browsing
-- **🔒 Secure Access**: Password-protected galleries with expiration
-- **📤 Easy Uploads**: Drag & drop functionality for effortless photo management
-- **🎯 Client-Focused**: Intuitive gallery experience for your clients
-
-</details>
-
-## 🗺️ Roadmap
-
-We're constantly improving PicPeak and welcome contributions from our community! If you have ideas for new features or want to help implement existing ones, please open an issue or submit a pull request. Your contributions help make PicPeak better for everyone.
-
-### 🚧 Beta Features (Use at your own risk)
-
-These features are currently in beta testing and may have limited functionality or stability:
-
-| Feature | Description | Status |
-|---------|-------------|--------|
-| **Simple Deployment Script** | One-click deployment script for quick server setup with automated configuration and dependency installation | 🧪 Beta |
-
-### 📋 Future Enhancements
-
-| Feature | Description | Priority | Status |
-|---------|-------------|----------|---------|
-| **Backup & Restore** | Comprehensive backup system with S3/MinIO support, automated scheduling, and safe restore functionality | High | ✅ Implemented |
-| **External Media Library (Reference Mode)** | Use an external folder library as a read‑only source with import and on‑demand thumbnail generation | High | ✅ Implemented |
-| **Download Protection** | Advanced image protection system with canvas rendering, invisible watermarking, right-click prevention, and DevTools detection to protect photos from unauthorized downloads | High | ✅ Implemented |
-| **Gallery Templates** | Multiple gallery layouts (grid, masonry, carousel, timeline, hero, mosaic) with custom CSS styling support. Includes starter templates like Apple Liquid Glass for complete visual customization | Medium | ✅ Implemented |
-| **Face Recognition** | AI-powered face detection to help guests find their photos and create automatic person-based albums | Low | 🔄 Open |
-| **Gallery Feedback** | Allow guests to like, rate, and comment on photos with admin notifications and moderation | Medium | ✅ Implemented |
-| **Video Support** | Upload and display videos alongside photos in galleries with streaming support | Low | ✅ Implemented |
-| **Multiple Administrators** | Support for multiple admin accounts with role-based permissions and activity tracking | Low | ✅ Implemented |
-| **Filtering & Export Options** | Filter photos by likes, ratings, comments, or favorites. Search by filename. Sort by date, name, size, or rating. Export filtered selections as ZIP or generate Capture One/Lightroom-compatible file lists for professional workflows | Medium | ✅ Implemented |
-
-**Status Legend:** ✅ Implemented | 🚧 In Progress | 🔄 Open | 📋 Planned
-
-## 🙏 Acknowledgments
-
-PicPeak is inspired by the best features of commercial platforms while remaining completely open source. Special thanks to all contributors who make this project possible.
-
-### 🤖 AI-Assisted Development
-
-This project was generated with the assistance of AI technology, but has been:
-- ✅ **Fully tested end-to-end** by human developers
-- 🔒 **Security audited** with comprehensive security checks
-- 👨‍💻 **Human-reviewed** for code quality and best practices
-- 🧪 **Production-tested** in real-world scenarios
-
-We believe in transparent development practices and the responsible use of AI as a tool to accelerate development while maintaining high standards of quality and security.
-
-## 📄 License
-
-PicPeak is released under the [MIT License](LICENSE). Use it freely for personal or commercial projects.
-
-## 🚀 Ready to Get Started?
-
-1. ⭐ **Star this repository** to show your support
-2. 📖 Read the [Deployment Guide](DEPLOYMENT_GUIDE.md)
-3. 🐛 Report issues or request features
-4. 🤝 Join our community and contribute!
+MIT — use it for personal or commercial projects.
 
 ---
 
 <p align="center">
-  Made with ❤️ by photographers, for photographers
-  <br>
-  <a href="https://www.picpeak.app">Homepage</a> •
-  <a href="https://demo.picpeak.app">Live Demo</a> •
-  <a href="https://github.com/the-luap/picpeak">GitHub</a> •
-  <a href="DEPLOYMENT_GUIDE.md">Documentation</a> •
-  <a href="https://github.com/the-luap/picpeak/issues">Support</a>
+  <a href="https://www.picpeak.app">Homepage</a> · <a href="https://demo.picpeak.app">Live Demo</a> · <a href="DEPLOYMENT_GUIDE.md">Docs</a> · <a href="https://github.com/the-luap/picpeak/issues">Issues</a>
 </p>


### PR DESCRIPTION
Cuts README from 350 to ~130 lines. Removes emoji headings, marketing fluff, roadmap table, AI disclosure, system requirements. Keeps: demo, features, quick start, comparison, tech stack, docs links. Screenshots collapsed.