### PR TITLE
fix: resolve password change redirect loop (#263) and file watcher crash (#269)

### DIFF
--- a/backend/src/services/fileWatcher.js
+++ b/backend/src/services/fileWatcher.js
@@ -5,7 +5,7 @@ const { db } = require('../database/db');
 const { formatBoolean } = require('../utils/dbCompat');
 const { generateThumbnail, generateVideoPlaceholder } = require('./imageProcessor');
 const logger = require('../utils/logger');
-const { isVideoMimeType } = require('../utils/fileSecurityUtils');
+const { isVideoMimeType } = require('./videoProcessor');
 const mime = require('mime-types');
 
 const getStoragePath = () => process.env.STORAGE_PATH || path.join(__dirname, '../../../storage');

--- a/frontend/src/components/admin/MandatoryPasswordChangeModal.tsx
+++ b/frontend/src/components/admin/MandatoryPasswordChangeModal.tsx
@@ -27,14 +27,12 @@ export const MandatoryPasswordChangeModal: React.FC = () => {
     mutationFn: adminService.changePassword,
     onSuccess: () => {
       toast.success(t('mandatoryPasswordChange.success'));
-      updatePasswordChanged();
-      // Reset form
-      setFormData({
-        currentPassword: '',
-        newPassword: '',
-        confirmPassword: ''
-      });
-      setErrors({});
+      // Force a full page reload so the browser picks up the new JWT cookie
+      // set by the backend. A React state update alone causes a race condition
+      // where the auth context checks the session before the cookie is stored.
+      setTimeout(() => {
+        window.location.href = '/admin/dashboard';
+      }, 500);
     },
     onError: (error: any) => {
       if (error.response?.data?.error) {


### PR DESCRIPTION
## Fixes

### #263 — Redirect loop after mandatory password change
The modal updated React state (`updatePasswordChanged()`) immediately after the backend responded, but the browser hadn't stored the new JWT cookie yet. The auth context then checked the session with the old invalidated token → 401 → redirect to login → login sees `isAuthenticated: true` → redirect to dashboard → loop.

**Fix:** Replace the React state update with a full page redirect (`window.location.href = '/admin/dashboard'`) after a 500ms delay. This ensures the browser processes the `Set-Cookie` header before any session check runs.

### #269 — File watcher crash: `isVideoMimeType is not a function`
`fileWatcher.js` imported `isVideoMimeType` from `fileSecurityUtils.js` where it doesn't exist. The function is in `videoProcessor.js`.

**Fix:** Correct the import path.

Closes #269