### PR TITLE
fix: resolve JWT iat timing issue in password change (#263)

### DIFF
--- a/backend/src/routes/adminAuth.js
+++ b/backend/src/routes/adminAuth.js
@@ -135,12 +135,17 @@ router.post('/change-password', [
       updated_at: now
     });
 
-  // Issue a new token so the session remains valid after password_changed_at invalidated the old one
+  // Issue a new token so the session remains valid after password_changed_at invalidated the old one.
+  // Set iat to 1 second after password_changed_at to guarantee the token passes the
+  // "iat < password_changed_at" check in auth middleware (password_changed_at has ms precision
+  // but JWT iat is floored to seconds, which can cause the new token to be rejected).
+  const iatAfterPasswordChange = Math.floor(now.getTime() / 1000) + 1;
   const newToken = jwt.sign({
     id: user.id,
     username: user.username,
     type: 'admin',
     role: user.role_name,
+    iat: iatAfterPasswordChange,
     loginTime: Date.now()
   }, process.env.JWT_SECRET, {
     expiresIn: '24h',


### PR DESCRIPTION
Follow-up to PR #284. The previous fix (full page redirect + new JWT cookie) wasn't enough because the new token's `iat` (floored to integer seconds) was always <= `password_changed_at` (millisecond precision), causing the auth middleware to immediately reject the fresh token.

**Root cause:** `decoded.iat (1775742582) < passwordChangedTime (1775742582.291)` → true → 401

**Fix:** Set JWT `iat` explicitly to 1 second after `password_changed_at` so the token always passes the auth middleware check.

**E2E tested:**
- [x] Login with must_change_password=true
- [x] Mandatory password change modal appears
- [x] Submit new password
- [x] Redirects to /admin/dashboard — no loop
- [x] Dashboard fully loads with all data — no 401 errors
- [x] Session persists across navigation