### PR TITLE
fix: apply password change fix to regular modal + longer toast delay (#263)

### DIFF
--- a/frontend/src/components/admin/MandatoryPasswordChangeModal.tsx
+++ b/frontend/src/components/admin/MandatoryPasswordChangeModal.tsx
@@ -32,7 +32,7 @@ export const MandatoryPasswordChangeModal: React.FC = () => {
       // where the auth context checks the session before the cookie is stored.
       setTimeout(() => {
         window.location.href = '/admin/dashboard';
-      }, 500);
+      }, 2000);
     },
     onError: (error: any) => {
       if (error.response?.data?.error) {

--- a/frontend/src/components/admin/PasswordChangeModal.tsx
+++ b/frontend/src/components/admin/PasswordChangeModal.tsx
@@ -30,14 +30,12 @@ export const PasswordChangeModal: React.FC<PasswordChangeModalProps> = ({ isOpen
     mutationFn: adminService.changePassword,
     onSuccess: () => {
       toast.success(t('passwordChange.success'));
-      onClose();
-      // Reset form
-      setFormData({
-        currentPassword: '',
-        newPassword: '',
-        confirmPassword: ''
-      });
-      setErrors({});
+      // Full page reload so the browser picks up the new JWT cookie.
+      // Same fix as MandatoryPasswordChangeModal — without this, the old
+      // token gets rejected and causes a redirect loop.
+      setTimeout(() => {
+        window.location.href = '/admin/dashboard';
+      }, 2000);
     },
     onError: (error: any) => {
       if (error.response?.data?.error) {


### PR DESCRIPTION
Follow-up to reporter's comment on #263:
1. Regular password change (profile settings) had the same redirect loop — same root cause, just a different modal component
2. Success toast disappeared too fast (500ms redirect) — increased to 2000ms so users see the confirmation

Changes:
- `PasswordChangeModal.tsx`: replace onClose/state reset with full page redirect (same pattern as MandatoryPasswordChangeModal)
- `MandatoryPasswordChangeModal.tsx`: increase redirect delay from 500ms to 2000ms