### PR TITLE
fix: admin photo feedback filters have no effect (#293)

### DIFF
--- a/backend/src/routes/adminPhotos.js
+++ b/backend/src/routes/adminPhotos.js
@@ -819,14 +819,15 @@ router.get('/:eventId/photos/:photoId/download', adminAuth, requirePermission('p
 router.get('/:eventId/photos', adminAuth, requirePermission('photos.view'), requireEventOwnership, async (req, res) => {
   try {
     const { eventId } = req.params;
-    const { category_id, type, search, sort = 'date' } = req.query;
+    const { category_id, type, search, sort = 'date', has_likes, has_favorites, has_comments, min_rating } = req.query;
     const order = ['asc', 'desc'].includes(req.query.order) ? req.query.order : 'desc';
-    
+    const logic = req.query.logic === 'OR' ? 'OR' : 'AND';
+
     let query = db('photos')
       .where({ 'photos.event_id': eventId })
       .leftJoin('photo_categories', 'photos.category_id', 'photo_categories.id')
       .select('photos.*', 'photo_categories.name as pc_name', 'photo_categories.slug as pc_slug');
-    
+
     // Filter by category_id
     if (category_id !== undefined && category_id !== '' && category_id !== '0') {
       if (category_id === 'individual' || category_id === 'collage') {
@@ -843,18 +844,53 @@ router.get('/:eventId/photos', adminAuth, requirePermission('photos.view'), requ
         }
       }
     }
-    
+
     // Keep type filter for backwards compatibility
     if (type) {
       query = query.where({ 'photos.type': type });
     }
-    
+
     // Search by filename
     if (search) {
       const escapedSearch = escapeLikePattern(search);
       query = query.where('photos.filename', 'like', `%${escapedSearch}%`);
     }
-    
+
+    // Feedback filters (has likes / favorites / comments / min rating) with AND/OR logic
+    const feedbackConditions = [];
+    if (has_likes === 'true' || has_likes === true) {
+      feedbackConditions.push(qb => qb.where('photos.like_count', '>', 0));
+    }
+    if (has_favorites === 'true' || has_favorites === true) {
+      feedbackConditions.push(qb => qb.where('photos.favorite_count', '>', 0));
+    }
+    if (has_comments === 'true' || has_comments === true) {
+      feedbackConditions.push(qb => qb.where('photos.comment_count', '>', 0));
+    }
+    if (min_rating !== undefined && min_rating !== null && min_rating !== '') {
+      const minRatingNum = parseFloat(min_rating);
+      if (!isNaN(minRatingNum)) {
+        feedbackConditions.push(qb => qb.where('photos.average_rating', '>=', minRatingNum));
+      }
+    }
+    if (feedbackConditions.length > 0) {
+      if (logic === 'OR') {
+        query = query.where(builder => {
+          feedbackConditions.forEach((cond, idx) => {
+            if (idx === 0) {
+              cond(builder);
+            } else {
+              builder.orWhere(sub => cond(sub));
+            }
+          });
+        });
+      } else {
+        feedbackConditions.forEach(cond => {
+          query = query.where(builder => cond(builder));
+        });
+      }
+    }
+
     // Sorting
     let orderByColumn = 'photos.uploaded_at';
     if (sort === 'name') {

--- a/frontend/src/pages/admin/EventDetailsPage.tsx
+++ b/frontend/src/pages/admin/EventDetailsPage.tsx
@@ -294,10 +294,21 @@ export const EventDetailsPage: React.FC = () => {
 
   // Statistics are now fetched with the event details from the admin API
 
+  // Merge feedback filters into photo query params so the grid reflects
+  // the Has Likes / Has Favorites / Has Comments / min rating checkboxes.
+  const combinedPhotoFilters: PhotoFilterParams = useMemo(() => ({
+    ...photoFilters,
+    hasLikes: feedbackFilters.hasLikes || undefined,
+    hasFavorites: feedbackFilters.hasFavorites || undefined,
+    hasComments: feedbackFilters.hasComments || undefined,
+    minRating: feedbackFilters.minRating ?? undefined,
+    logic: feedbackFilters.logic,
+  }), [photoFilters, feedbackFilters]);
+
   // Fetch photos (needed for both photos tab and hero photo selector)
   const { data: photos = [], isLoading: photosLoading, refetch: refetchPhotos } = useQuery({
-    queryKey: ['admin-event-photos', id, photoFilters],
-    queryFn: () => photosService.getEventPhotos(parseInt(id!), photoFilters),
+    queryKey: ['admin-event-photos', id, combinedPhotoFilters],
+    queryFn: () => photosService.getEventPhotos(parseInt(id!), combinedPhotoFilters),
     enabled: !!id && (activeTab === 'photos' || isEditing),
   });
 

--- a/frontend/src/services/photos.service.ts
+++ b/frontend/src/services/photos.service.ts
@@ -32,6 +32,11 @@ export interface PhotoFilters {
   search?: string;
   sort?: 'date' | 'name' | 'size' | 'rating';
   order?: 'asc' | 'desc';
+  hasLikes?: boolean;
+  hasFavorites?: boolean;
+  hasComments?: boolean;
+  minRating?: number | null;
+  logic?: 'AND' | 'OR';
 }
 
 class PhotosService {
@@ -47,6 +52,13 @@ class PhotosService {
       if (filters.search) params.append('search', filters.search);
       if (filters.sort) params.append('sort', filters.sort);
       if (filters.order) params.append('order', filters.order);
+      if (filters.hasLikes) params.append('has_likes', 'true');
+      if (filters.hasFavorites) params.append('has_favorites', 'true');
+      if (filters.hasComments) params.append('has_comments', 'true');
+      if (filters.minRating !== undefined && filters.minRating !== null) {
+        params.append('min_rating', filters.minRating.toString());
+      }
+      if (filters.logic) params.append('logic', filters.logic);
     }
     
     const queryString = params.toString();


### PR DESCRIPTION
## Summary
Fixes #293 — the Has Likes / Has Favorites / Has Comments checkboxes in the admin **Event → Photos** tab updated local state but never affected the visible photo grid.

**Root cause:** the feedback-filter state (`feedbackFilters`) was only wired to the export menu, not the photo grid query. The backend `GET /admin/photos/:eventId/photos` also had no support for these params. The reporter's diagnosis from the minified bundle was partially wrong — the modal/onChange code itself worked; the problem was further upstream.

## Changes
- **Backend** (`src/routes/adminPhotos.js`): extended `GET /:eventId/photos` to accept `has_likes`, `has_favorites`, `has_comments`, `min_rating`, and `logic` (AND/OR) query params. Uses the existing denormalized `like_count` / `favorite_count` / `comment_count` / `average_rating` columns with grouped where-clauses.
- **Frontend service** (`services/photos.service.ts`): added the new fields to the `PhotoFilters` interface and append them in `getEventPhotos`.
- **Admin page** (`pages/admin/EventDetailsPage.tsx`): merges `feedbackFilters` into a new `combinedPhotoFilters` memo and keys the `admin-event-photos` query on it so toggling any checkbox refetches the grid.

## Test plan
Verified end-to-end against local Docker with seeded feedback data (event 168):
- [x] Has Likes → 4 photos (expected 4) ✅
- [x] Has Favorites → 3 photos (expected 3) ✅
- [x] Likes **AND** Favorites → 1 photo (expected 1) ✅
- [x] Likes **OR** Favorites → 6 photos (expected 6) ✅
- [x] Has Comments → 2 photos (expected 2) ✅
- [x] Network trace confirms the new query params (`has_likes=true&has_favorites=true&logic=OR`) are sent
- [x] Frontend TypeScript check passes
- [x] Existing category/search/sort filters still work unchanged