### PR TITLE
fix: guest feedback flow bugs in Masonry grid and PhotoLightbox (#292)

### DIFF
--- a/frontend/src/components/gallery/GuestNamePromptModal.tsx
+++ b/frontend/src/components/gallery/GuestNamePromptModal.tsx
@@ -72,7 +72,7 @@ export const GuestNamePromptModal: React.FC<GuestNamePromptModalProps> = ({
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+    <div className="fixed inset-0 z-[60] flex items-center justify-center p-4">
       <div className="fixed inset-0 bg-black bg-opacity-50" onClick={allowCancel ? handleClose : undefined} />
       <div className="relative bg-surface rounded-lg shadow-xl max-w-md w-full p-6">
         {allowCancel && (

--- a/frontend/src/components/gallery/GuestRecoveryModal.tsx
+++ b/frontend/src/components/gallery/GuestRecoveryModal.tsx
@@ -86,7 +86,7 @@ export const GuestRecoveryModal: React.FC = () => {
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+    <div className="fixed inset-0 z-[60] flex items-center justify-center p-4">
       <div className="fixed inset-0 bg-black bg-opacity-50" onClick={handleClose} />
       <div className="relative bg-surface rounded-lg shadow-xl max-w-md w-full p-6">
         <button

--- a/frontend/src/components/gallery/PhotoLightbox.tsx
+++ b/frontend/src/components/gallery/PhotoLightbox.tsx
@@ -8,6 +8,7 @@ import { PhotoFeedback } from './PhotoFeedback';
 import { feedbackService } from '../../services/feedback.service';
 import { FeedbackIdentityModal } from './FeedbackIdentityModal';
 import { VideoPlayer } from './VideoPlayer';
+import { useGuestIdentityOptional } from '../../contexts/GuestIdentityContext';
 
 interface PhotoLightboxProps {
   photos: Photo[];
@@ -63,6 +64,8 @@ export const PhotoLightbox: React.FC<PhotoLightboxProps> = ({
   const [showIdentityModal, setShowIdentityModal] = useState(false);
   const [pendingAction, setPendingAction] = useState<null | { type: 'like' | 'rating'; rating?: number }>(null);
   const [imageLoaded, setImageLoaded] = useState(false);
+  const guestIdentity = useGuestIdentityOptional();
+  const isGuestMode = guestIdentity?.identityMode === 'guest';
 
   useEffect(() => {
     const onResize = () => setIsSmallScreen(window.innerWidth < 640);
@@ -203,6 +206,33 @@ export const PhotoLightbox: React.FC<PhotoLightboxProps> = ({
   }, [slug, currentPhoto.id, feedbackSettings?.feedback_enabled]);
 
   const submitLike = async () => {
+    // Guest identity mode: ensure we have a per-person guest token. The
+    // server reads name/email from the token — body values are ignored.
+    if (isGuestMode && guestIdentity) {
+      try {
+        await guestIdentity.ensureIdentity();
+      } catch {
+        // User cancelled the prompt — abort silently.
+        return;
+      }
+      try {
+        await feedbackService.submitFeedback(slug, String(currentPhoto.id), {
+          feedback_type: 'like',
+        });
+        setMyLiked(prev => {
+          const next = !prev;
+          setLikeCount(c => Math.max(0, c + (next ? 1 : -1)));
+          return next;
+        });
+        if (onFeedbackChange) onFeedbackChange();
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.warn('Like submit failed', err);
+      }
+      return;
+    }
+
+    // Simple mode: legacy inline identity modal flow.
     const needIdentity = feedbackSettings?.require_name_email && !savedIdentity;
     if (needIdentity) {
       setPendingAction({ type: 'like' });
@@ -222,6 +252,33 @@ export const PhotoLightbox: React.FC<PhotoLightboxProps> = ({
   };
 
   const submitRating = async (value: number) => {
+    // Guest identity mode.
+    if (isGuestMode && guestIdentity) {
+      try {
+        await guestIdentity.ensureIdentity();
+      } catch {
+        return;
+      }
+      try {
+        await feedbackService.submitFeedback(slug, String(currentPhoto.id), {
+          feedback_type: 'rating',
+          rating: value,
+        });
+        setMyRating(value);
+        try {
+          const fresh = await feedbackService.getPhotoFeedback(slug, String(currentPhoto.id));
+          setAvgRating(Number(fresh.summary?.average_rating) || 0);
+          setTotalRatings(Number(fresh.summary?.total_ratings) || 0);
+        } catch {}
+        if (onFeedbackChange) onFeedbackChange();
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.warn('Rating submit failed', err);
+      }
+      return;
+    }
+
+    // Simple mode: legacy inline identity modal flow.
     const needIdentity = feedbackSettings?.require_name_email && !savedIdentity;
     if (needIdentity) {
       setPendingAction({ type: 'rating', rating: value });

--- a/frontend/src/components/gallery/layouts/MasonryGalleryLayout.tsx
+++ b/frontend/src/components/gallery/layouts/MasonryGalleryLayout.tsx
@@ -34,6 +34,9 @@ interface MasonryPhotoProps {
   onQuickComment?: () => void;
   // Column width for calculating proper aspect-ratio-based height
   columnWidth?: number;
+  // Optimistic "I liked this" state + callback (lifted to parent)
+  liked?: boolean;
+  onLikeSuccess?: () => void;
 }
 
 const MasonryPhoto: React.FC<MasonryPhotoProps> = ({
@@ -49,7 +52,9 @@ const MasonryPhoto: React.FC<MasonryPhotoProps> = ({
   slug,
   feedbackOptions,
   onQuickComment,
-  columnWidth = 300
+  columnWidth = 300,
+  liked = false,
+  onLikeSuccess,
 }) => {
   const [showIdentityModal, setShowIdentityModal] = useState(false);
   const [pendingAction, setPendingAction] = useState<null | { type: 'like'; photoId: number }>(null);
@@ -150,7 +155,11 @@ const MasonryPhoto: React.FC<MasonryPhotoProps> = ({
             )}
             {feedbackEnabled && feedbackOptions?.allowLikes && (
               <button
-                className="p-2 bg-white/90 rounded-full hover:bg-white transition-colors"
+                className={`p-2 rounded-full transition-colors ${
+                  liked
+                    ? 'bg-red-500/90 hover:bg-red-500'
+                    : 'bg-white/90 hover:bg-white'
+                }`}
                 onClick={async (e) => {
                   e.stopPropagation();
                   if (guestIdentity?.identityMode === 'guest') {
@@ -159,9 +168,16 @@ const MasonryPhoto: React.FC<MasonryPhotoProps> = ({
                     } catch {
                       return;
                     }
-                    await feedbackService.submitFeedback(slug!, String(photo.id), {
-                      feedback_type: 'like',
-                    });
+                    // Optimistic UI: mark as liked immediately
+                    if (onLikeSuccess) onLikeSuccess();
+                    try {
+                      await feedbackService.submitFeedback(slug!, String(photo.id), {
+                        feedback_type: 'like',
+                      });
+                    } catch (err) {
+                      // eslint-disable-next-line no-console
+                      console.warn('Like submit failed, keeping optimistic UI', err);
+                    }
                     return;
                   }
                   if (feedbackOptions?.requireNameEmail && !savedIdentity) {
@@ -169,16 +185,26 @@ const MasonryPhoto: React.FC<MasonryPhotoProps> = ({
                     setShowIdentityModal(true);
                     return;
                   }
-                  await feedbackService.submitFeedback(slug!, String(photo.id), {
-                    feedback_type: 'like',
-                    guest_name: savedIdentity?.name,
-                    guest_email: savedIdentity?.email,
-                  });
+                  // Optimistic UI: mark as liked immediately
+                  if (onLikeSuccess) onLikeSuccess();
+                  try {
+                    await feedbackService.submitFeedback(slug!, String(photo.id), {
+                      feedback_type: 'like',
+                      guest_name: savedIdentity?.name,
+                      guest_email: savedIdentity?.email,
+                    });
+                  } catch (err) {
+                    // eslint-disable-next-line no-console
+                    console.warn('Like submit failed, keeping optimistic UI', err);
+                  }
                 }}
-                aria-label="Like photo"
-                title="Like"
+                aria-label={liked ? 'Unlike photo' : 'Like photo'}
+                aria-pressed={liked}
+                title={liked ? 'Unlike' : 'Like'}
               >
-                <Heart className="w-5 h-5 text-neutral-800" />
+                <Heart
+                  className={`w-5 h-5 ${liked ? 'text-white fill-white' : 'text-neutral-800'}`}
+                />
               </button>
             )}
           </>
@@ -193,6 +219,9 @@ const MasonryPhoto: React.FC<MasonryPhotoProps> = ({
           setSavedIdentity({ name, email });
           setShowIdentityModal(false);
           if (pendingAction) {
+            if (pendingAction.type === 'like' && onLikeSuccess) {
+              onLikeSuccess();
+            }
             await feedbackService.submitFeedback(slug!, String(pendingAction.photoId), {
               feedback_type: pendingAction.type,
               guest_name: name,
@@ -249,6 +278,9 @@ export const MasonryGalleryLayout: React.FC<BaseGalleryLayoutProps> = ({
   const containerRef = useRef<HTMLDivElement>(null);
   const [columns, setColumns] = useState(3);
   const [containerWidth, setContainerWidth] = useState(0);
+  // Optimistic "I liked this" state — lifted here so it survives re-renders
+  // of individual MasonryPhoto components during layout reflow/resize.
+  const [likedPhotoIds, setLikedPhotoIds] = useState<Set<number>>(new Set());
   const gallerySettings = theme.gallerySettings || {};
   const gutter = gallerySettings.masonryGutter || 16;
   const mode = gallerySettings.masonryMode || 'columns';
@@ -798,6 +830,14 @@ export const MasonryGalleryLayout: React.FC<BaseGalleryLayoutProps> = ({
                 feedbackOptions={feedbackOptions}
                 onQuickComment={() => onOpenPhotoWithFeedback && onOpenPhotoWithFeedback(originalIndex)}
                 columnWidth={columnWidth}
+                liked={likedPhotoIds.has(photo.id)}
+                onLikeSuccess={() => {
+                  setLikedPhotoIds((prev) => {
+                    const next = new Set(prev);
+                    next.add(photo.id);
+                    return next;
+                  });
+                }}
               />
             );
           })}


### PR DESCRIPTION
## Summary
Fixes the two bugs reported on #292 after 3.27.0-beta.0 shipped ([comment](https://github.com/the-luap/picpeak/issues/292#issuecomment-)).

### Bug 1 — Masonry grid: no visual feedback after liking
`MasonryGalleryLayout` had no \`liked\` state plumbing — the Heart icon was a static \`<Heart>\` regardless of whether the user had liked the photo. Invisible in simple mode (no personal state) but obvious in guest mode where each visitor expects to see confirmation of their own action.

**Fix:** added the same \`likedPhotoIds: Set<number>\` parent-state pattern that \`GridGalleryLayout\` already uses. The Like button now:
- Shows a red background + white-filled Heart when liked
- Toggles aria-label between \`Like photo\` / \`Unlike photo\`
- Mirrors \`aria-pressed\`
- Fires \`onLikeSuccess()\` optimistically in both guest-mode and simple-mode branches plus the FeedbackIdentityModal onSubmit path

### Bug 2 — PhotoLightbox: identity prompt missing on first like
\`submitLike()\` and \`submitRating()\` in PhotoLightbox were written before the guest identity context existed. They only checked the legacy \`require_name_email\` flag, so in guest identity mode they silently fired the API request → 401 from the server → nothing happened visually.

**Fix:** \`PhotoLightbox\` now consumes \`useGuestIdentityOptional()\`. \`submitLike\` and \`submitRating\` get a guest-mode branch that calls \`ensureIdentity()\` first (which opens the prompt if no identity exists) and submits without body \`guest_name\`/\`guest_email\` (server reads from the verified token).

### Also fixed: z-index conflict
While testing, discovered the \`GuestNamePromptModal\` (\`z-50\`) was sitting at the same level as \`PhotoLightbox\` (\`z-50\`). When the prompt opened over the lightbox, the fullscreen image intercepted pointer events and the Continue button was unclickable. Bumped both guest modals to \`z-[60]\`.

## Test plan
End-to-end verified against local Docker with Playwright MCP on event 168 (Masonry Columns Test layout):

**Masonry visual feedback**
- [x] Fresh session, click Like in grid → name prompt opens
- [x] Register \"Alice\" → feedback persists with \`guest_id\`
- [x] Heart button turns red, \`aria-pressed=true\`, label \"Unlike photo\"
- [x] Like another photo → that one also shows red state independently
- [x] Visual confirmation via screenshot (red Heart buttons on hover)
- [x] DB confirms \`photo_feedback\` rows with correct \`guest_id\`

**PhotoLightbox**
- [x] Fresh session, open photo in lightbox BEFORE registering
- [x] Click Like in lightbox → name prompt opens **on top of** lightbox (z-index fix)
- [x] Register \"Bob\" → feedback submits, lightbox shows \"Unlike photo\" + count \"1\"
- [x] Grid shows \"1 likes\" badge after closing lightbox
- [x] Rate 4 stars → works, lightbox shows \"4.0 (1)\", grid shows \"Rating: 4.0\" badge
- [x] DB: Bob id=4, 1 like on photo 227

**Regression**
- [x] TypeScript check passes (0 errors)
- [x] Simple mode unchanged (no prompt, legacy flow)
- [x] Other layouts (Grid, Justified, Premium) unchanged
- [x] Backend unchanged

## Files changed (4)
- \`frontend/src/components/gallery/layouts/MasonryGalleryLayout.tsx\` — optimistic liked UI
- \`frontend/src/components/gallery/PhotoLightbox.tsx\` — guest identity enforcement
- \`frontend/src/components/gallery/GuestNamePromptModal.tsx\` — z-index bump
- \`frontend/src/components/gallery/GuestRecoveryModal.tsx\` — z-index bump

+112 / -15

## Out of scope
The audit found partial optimistic-UI issues in Mosaic/Carousel/Timeline layouts that pre-date guest mode and behave the same in simple mode. Not reported by the user, not a regression from guest mode — leaving alone per scope discipline. Can be addressed in a follow-up if desired.