### PR TITLE
fix: display welcome message in gallery and fix guest thumbnail URLs (#306, #307)

### DIFF
--- a/backend/src/routes/adminGuests.js
+++ b/backend/src/routes/adminGuests.js
@@ -138,8 +138,8 @@ router.get(
             id: p.id,
             filename: p.filename,
             original_filename: p.original_filename,
-            url: `/admin/photos/${eventId}/photo/${p.id}`,
-            thumbnail_url: `/admin/photos/${eventId}/thumbnail/${p.id}`,
+            url: `/api/admin/photos/${eventId}/photo/${p.id}`,
+            thumbnail_url: `/api/admin/photos/${eventId}/thumbnail/${p.id}`,
             picker_count: parseInt(p.picker_count, 10),
           })),
       });
@@ -418,8 +418,8 @@ router.get(
         filename: row.filename,
         original_filename: row.original_filename,
         type: row.type,
-        url: `/admin/photos/${eventId}/photo/${row.photo_id}`,
-        thumbnail_url: `/admin/photos/${eventId}/thumbnail/${row.photo_id}`,
+        url: `/api/admin/photos/${eventId}/photo/${row.photo_id}`,
+        thumbnail_url: `/api/admin/photos/${eventId}/thumbnail/${row.photo_id}`,
       });
 
       const selections = {

--- a/backend/src/routes/adminPhotos.js
+++ b/backend/src/routes/adminPhotos.js
@@ -922,9 +922,9 @@ router.get('/:eventId/photos', adminAuth, requirePermission('photos.view'), requ
         filename: photo.filename,
         original_filename: photo.original_filename || null,
         // Use the correct admin photos router base for serving images
-        url: `/admin/photos/${eventId}/photo/${photo.id}`,
+        url: `/api/admin/photos/${eventId}/photo/${photo.id}`,
         // Always expose a thumbnail URL; backend will generate on demand if missing
-        thumbnail_url: `/admin/photos/${eventId}/thumbnail/${photo.id}`,
+        thumbnail_url: `/api/admin/photos/${eventId}/thumbnail/${photo.id}`,
         type: photo.type,
         category_id: photo.category_id || photo.type,
         category_name: photo.pc_name || (photo.type === 'individual' ? 'Individual Photos' : 'Collages'),

--- a/frontend/src/components/gallery/PhotoGridWithLayouts.tsx
+++ b/frontend/src/components/gallery/PhotoGridWithLayouts.tsx
@@ -295,6 +295,13 @@ export const PhotoGridWithLayouts: React.FC<PhotoGridWithLayoutsProps> = ({
         />
       )}
 
+      {/* Welcome Message - shown for non-fullpage layouts when set */}
+      {!isFullPageLayout && welcomeMessage && (
+        <div className="mb-6 px-4 py-3 rounded-lg bg-card-theme/50 border border-border-theme text-center">
+          <p className="text-sm text-muted-theme whitespace-pre-line">{welcomeMessage}</p>
+        </div>
+      )}
+
       {/* Selection Mode Controls - Not shown for carousel, full-page layouts, or when controls are hidden */}
       {showSelectionControls && photos.length > 1 && galleryLayout !== 'carousel' && !isFullPageLayout && (
         <div className="mb-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">


### PR DESCRIPTION
## Summary
- **#306**: Welcome message is now rendered in the gallery view for all non-fullpage layouts (grid, masonry, carousel, timeline, mosaic) as a centered banner between the hero header and photo grid. The `gallery-story` layout already had its own rendering.
- **#307**: Added missing `/api` prefix to photo/thumbnail URLs in `adminGuests.js` (2 locations) and `adminPhotos.js` (1 location). Without the prefix, Nginx proxy serves the SPA fallback HTML instead of image data.

Closes #306
Closes #307

## Test plan
- [x] Welcome message displays in gallery view (masonry layout verified)
- [x] Welcome message does not render when not set
- [x] Admin photo URLs include `/api` prefix (`/api/admin/photos/{id}/photo/{id}`)
- [x] Admin thumbnail URLs include `/api` prefix (`/api/admin/photos/{id}/thumbnail/{id}`)