### PR TITLE
fix: revert /api prefix in adminPhotos.js to avoid double-prefix (#307)

### DIFF
--- a/backend/src/routes/adminPhotos.js
+++ b/backend/src/routes/adminPhotos.js
@@ -922,9 +922,9 @@ router.get('/:eventId/photos', adminAuth, requirePermission('photos.view'), requ
         filename: photo.filename,
         original_filename: photo.original_filename || null,
         // Use the correct admin photos router base for serving images
-        url: `/api/admin/photos/${eventId}/photo/${photo.id}`,
+        url: `/admin/photos/${eventId}/photo/${photo.id}`,
         // Always expose a thumbnail URL; backend will generate on demand if missing
-        thumbnail_url: `/api/admin/photos/${eventId}/thumbnail/${photo.id}`,
+        thumbnail_url: `/admin/photos/${eventId}/thumbnail/${photo.id}`,
         type: photo.type,
         category_id: photo.category_id || photo.type,
         category_name: photo.pc_name || (photo.type === 'individual' ? 'Individual Photos' : 'Collages'),


### PR DESCRIPTION
## Summary
The previous fix (#308) added `/api` prefix to URLs in `adminPhotos.js`, but `AdminPhotoGrid` uses `AdminAuthenticatedImage` which fetches via Axios (`baseURL: /api`). This caused double-prefixed requests like `/api/api/admin/photos/...` → 404.

Reverts the `adminPhotos.js` change only. The `adminGuests.js` `/api` prefix is correct — its consumer (`AuthenticatedImage`) uses `fetch()` with `buildResourceUrl()` which doesn't auto-prefix.

Closes #307

## Test plan
- [x] Admin photo grid loads thumbnails correctly (no double `/api/api/` prefix)
- [x] Guest detail thumbnails still work with `/api` prefix