### PR TITLE
Fix Admin Events search and counters for large datasets

### DIFF
--- a/frontend/src/pages/admin/EventsListPage.tsx
+++ b/frontend/src/pages/admin/EventsListPage.tsx
@@ -100,8 +100,8 @@ export const EventsListPage: React.FC = () => {
 
   // Fetch events
   const { data, isLoading, error } = useQuery({
-    queryKey: ['admin-events', apiStatus || 'all', debouncedSearchTerm],
-    queryFn: () => eventsService.getEvents(1, 100, apiStatus, debouncedSearchTerm || undefined),
+    queryKey: ['admin-events', apiStatus || 'all'],
+    queryFn: () => eventsService.getEvents(1, 100, apiStatus),
   });
 
   const { data: allEventsData } = useQuery({

--- a/frontend/src/pages/admin/EventsListPage.tsx
+++ b/frontend/src/pages/admin/EventsListPage.tsx
@@ -22,6 +22,7 @@ import { Button, Input, Card, SkeletonTable, ErrorBoundary } from '../../compone
 import { BulkArchiveModal } from '../../components/admin';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { eventsService } from '../../services/events.service';
+import { adminService } from '../../services/admin.service';
 import { isGalleryPublic } from '../../utils/accessControl';
 import type { Event } from '../../types';
 import { useTranslation } from 'react-i18next';
@@ -41,6 +42,7 @@ export const EventsListPage: React.FC = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   
   const [searchTerm, setSearchTerm] = useState('');
+  const [debouncedSearchTerm, setDebouncedSearchTerm] = useState('');
   const [selectedEvents, setSelectedEvents] = useState<number[]>([]);
   // const [showFilters, setShowFilters] = useState(false);
   const [activeDropdown, setActiveDropdown] = useState<number | null>(null);
@@ -50,6 +52,17 @@ export const EventsListPage: React.FC = () => {
   // Get filter from URL
   const statusFilter = searchParams.get('filter') as 'active' | 'archived' | null;
   const isExpiringFilter = searchParams.get('filter') === 'expiring';
+  const apiStatus = isExpiringFilter
+    ? 'expiring'
+    : ((statusFilter === 'archived' || statusFilter === 'active') ? statusFilter : undefined);
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      setDebouncedSearchTerm(searchTerm.trim());
+    }, 300);
+
+    return () => window.clearTimeout(timeout);
+  }, [searchTerm]);
 
   // Close dropdown when clicking outside
   useEffect(() => {
@@ -87,8 +100,18 @@ export const EventsListPage: React.FC = () => {
 
   // Fetch events
   const { data, isLoading, error } = useQuery({
-    queryKey: ['admin-events', statusFilter],
-    queryFn: () => eventsService.getEvents(1, 100, (statusFilter === 'archived' || statusFilter === 'active') ? statusFilter : undefined),
+    queryKey: ['admin-events', apiStatus || 'all', debouncedSearchTerm],
+    queryFn: () => eventsService.getEvents(1, 100, apiStatus, debouncedSearchTerm || undefined),
+  });
+
+  const { data: allEventsData } = useQuery({
+    queryKey: ['admin-events-total-count'],
+    queryFn: () => eventsService.getEvents(1, 1),
+  });
+
+  const { data: dashboardStats } = useQuery({
+    queryKey: ['admin-dashboard-stats'],
+    queryFn: () => adminService.getDashboardStats(),
   });
 
   // Archive mutation
@@ -137,31 +160,8 @@ export const EventsListPage: React.FC = () => {
   // Filter and search events
   const filteredEvents = useMemo(() => {
     if (!data?.events) return [];
-    
-    let events = [...data.events];
-    
-    // Apply status filter
-    if (statusFilter === 'active') {
-      events = events.filter(e => e.is_active && !e.is_archived);
-    } else if (isExpiringFilter) {
-      events = events.filter(e => {
-        if (!e.is_active || e.is_archived) return false;
-        const days = e.expires_at ? differenceInDays(parseISO(e.expires_at), new Date()) : 0;
-        return days <= 7 && days > 0;
-      });
-    } else if (statusFilter === 'archived') {
-      events = events.filter(e => e.is_archived);
-    }
-    
-    // Apply search
-    if (searchTerm) {
-      const term = searchTerm.toLowerCase();
-      events = events.filter(e => 
-        e.event_name.toLowerCase().includes(term) ||
-        e.event_type.toLowerCase().includes(term) ||
-        (e.customer_email || '').toLowerCase().includes(term)
-      );
-    }
+
+    const events = [...data.events];
     
     // Sort by creation date (newest first)
     events.sort((a, b) => {
@@ -171,7 +171,9 @@ export const EventsListPage: React.FC = () => {
     });
     
     return events;
-  }, [data?.events, statusFilter, searchTerm]);
+  }, [data?.events]);
+
+  const totalEventsCount = allEventsData?.pagination?.total ?? allEventsData?.total ?? 0;
 
   const handleSelectAll = () => {
     if (selectedEvents.length === filteredEvents.length) {
@@ -251,7 +253,7 @@ export const EventsListPage: React.FC = () => {
           <div className="flex items-center justify-between">
             <div>
               <p className="text-sm text-neutral-600 dark:text-neutral-400">{t('events.stats.totalEvents')}</p>
-              <p className="text-2xl font-bold text-neutral-900 dark:text-neutral-100">{data?.events.length || 0}</p>
+              <p className="text-2xl font-bold text-neutral-900 dark:text-neutral-100">{totalEventsCount}</p>
             </div>
             <Calendar className="w-8 h-8 text-primary-600" />
           </div>
@@ -262,7 +264,7 @@ export const EventsListPage: React.FC = () => {
             <div>
               <p className="text-sm text-neutral-600 dark:text-neutral-400">{t('events.stats.activeEvents')}</p>
               <p className="text-2xl font-bold text-neutral-900 dark:text-neutral-100">
-                {data?.events.filter(e => e.is_active && !e.is_archived).length || 0}
+                {dashboardStats?.activeEvents || 0}
               </p>
             </div>
             <Activity className="w-8 h-8 text-green-600" />
@@ -274,7 +276,7 @@ export const EventsListPage: React.FC = () => {
             <div>
               <p className="text-sm text-neutral-600 dark:text-neutral-400">{t('events.stats.totalPhotos')}</p>
               <p className="text-2xl font-bold text-neutral-900 dark:text-neutral-100">
-                {data?.events.reduce((sum, e) => sum + (e.photo_count || 0), 0) || 0}
+                {dashboardStats?.totalPhotos || 0}
               </p>
             </div>
             <Image className="w-8 h-8 text-blue-600" />
@@ -286,11 +288,7 @@ export const EventsListPage: React.FC = () => {
             <div>
               <p className="text-sm text-neutral-600 dark:text-neutral-400">{t('events.stats.expiringEvents')}</p>
               <p className="text-2xl font-bold text-neutral-900 dark:text-neutral-100">
-                {data?.events.filter(e => {
-                  if (!e.is_active || e.is_archived) return false;
-                  const days = e.expires_at ? differenceInDays(parseISO(e.expires_at), new Date()) : 0;
-                  return days <= 7 && days > 0;
-                }).length || 0}
+                {dashboardStats?.expiringEvents || 0}
               </p>
             </div>
             <AlertTriangle className="w-8 h-8 text-orange-600" />
@@ -322,7 +320,7 @@ export const EventsListPage: React.FC = () => {
                 setSearchParams(searchParams);
               }}
             >
-              {t('events.all')} ({data?.events.length || 0})
+              {t('events.all')} ({totalEventsCount})
             </Button>
             <Button
               variant={statusFilter === 'active' ? 'primary' : 'outline'}

--- a/frontend/src/pages/admin/EventsListPage.tsx
+++ b/frontend/src/pages/admin/EventsListPage.tsx
@@ -20,7 +20,7 @@ import { useLocalizedDate } from '../../hooks/useLocalizedDate';
 
 import { Button, Input, Card, SkeletonTable, ErrorBoundary } from '../../components/common';
 import { BulkArchiveModal } from '../../components/admin';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/react-query';
 import { eventsService } from '../../services/events.service';
 import { adminService } from '../../services/admin.service';
 import { isGalleryPublic } from '../../utils/accessControl';
@@ -98,10 +98,12 @@ export const EventsListPage: React.FC = () => {
     };
   }, [activeDropdown]);
 
-  // Fetch events
+  // Fetch events (server-side filter + search; backend supports `search` and `status`)
   const { data, isLoading, error } = useQuery({
-    queryKey: ['admin-events', apiStatus || 'all'],
-    queryFn: () => eventsService.getEvents(1, 100, apiStatus),
+    queryKey: ['admin-events', apiStatus || 'all', debouncedSearchTerm],
+    queryFn: () =>
+      eventsService.getEvents(1, 100, apiStatus, debouncedSearchTerm || undefined),
+    placeholderData: keepPreviousData,
   });
 
   const { data: allEventsData } = useQuery({

--- a/frontend/src/pages/admin/EventsListPage.tsx
+++ b/frontend/src/pages/admin/EventsListPage.tsx
@@ -1,8 +1,8 @@
 import React, { useState, useMemo, useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { 
-  Plus, 
-  Search, 
+import {
+  Plus,
+  Search,
   Archive,
   AlertTriangle,
   MoreVertical,
@@ -40,7 +40,7 @@ export const EventsListPage: React.FC = () => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [searchParams, setSearchParams] = useSearchParams();
-  
+
   const [searchTerm, setSearchTerm] = useState('');
   const [debouncedSearchTerm, setDebouncedSearchTerm] = useState('');
   const [selectedEvents, setSelectedEvents] = useState<number[]>([]);
@@ -91,7 +91,7 @@ export const EventsListPage: React.FC = () => {
 
     window.addEventListener('scroll', handleScrollOrResize, true);
     window.addEventListener('resize', handleScrollOrResize);
-    
+
     return () => {
       window.removeEventListener('scroll', handleScrollOrResize, true);
       window.removeEventListener('resize', handleScrollOrResize);
@@ -147,7 +147,7 @@ export const EventsListPage: React.FC = () => {
       queryClient.invalidateQueries({ queryKey: ['admin-events'] });
       setSelectedEvents([]);
       setShowBulkArchiveModal(false);
-      
+
       if (data.results.failed.length === 0) {
         toast.success(t('events.bulkArchiveSuccess', { count: data.results.successful.length }));
       } else {
@@ -164,14 +164,14 @@ export const EventsListPage: React.FC = () => {
     if (!data?.events) return [];
 
     const events = [...data.events];
-    
+
     // Sort by creation date (newest first)
     events.sort((a, b) => {
       const dateA = a.created_at ? new Date(a.created_at).getTime() : 0;
       const dateB = b.created_at ? new Date(b.created_at).getTime() : 0;
       return dateB - dateA;
     });
-    
+
     return events;
   }, [data?.events]);
 
@@ -186,8 +186,8 @@ export const EventsListPage: React.FC = () => {
   };
 
   const handleSelectEvent = (id: number) => {
-    setSelectedEvents(prev => 
-      prev.includes(id) 
+    setSelectedEvents(prev =>
+      prev.includes(id)
         ? prev.filter(i => i !== id)
         : [...prev, id]
     );
@@ -249,360 +249,359 @@ export const EventsListPage: React.FC = () => {
           </Button>
         </div>
 
-      {/* Statistics Cards */}
-      <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
-        <Card padding="sm">
-          <div className="flex items-center justify-between">
-            <div>
-              <p className="text-sm text-neutral-600 dark:text-neutral-400">{t('events.stats.totalEvents')}</p>
-              <p className="text-2xl font-bold text-neutral-900 dark:text-neutral-100">{totalEventsCount}</p>
+        {/* Statistics Cards */}
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
+          <Card padding="sm">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm text-neutral-600 dark:text-neutral-400">{t('events.stats.totalEvents')}</p>
+                <p className="text-2xl font-bold text-neutral-900 dark:text-neutral-100">{totalEventsCount}</p>
+              </div>
+              <Calendar className="w-8 h-8 text-primary-600" />
             </div>
-            <Calendar className="w-8 h-8 text-primary-600" />
-          </div>
-        </Card>
-        
-        <Card padding="sm">
-          <div className="flex items-center justify-between">
-            <div>
-              <p className="text-sm text-neutral-600 dark:text-neutral-400">{t('events.stats.activeEvents')}</p>
-              <p className="text-2xl font-bold text-neutral-900 dark:text-neutral-100">
-                {dashboardStats?.activeEvents || 0}
-              </p>
-            </div>
-            <Activity className="w-8 h-8 text-green-600" />
-          </div>
-        </Card>
-        
-        <Card padding="sm">
-          <div className="flex items-center justify-between">
-            <div>
-              <p className="text-sm text-neutral-600 dark:text-neutral-400">{t('events.stats.totalPhotos')}</p>
-              <p className="text-2xl font-bold text-neutral-900 dark:text-neutral-100">
-                {dashboardStats?.totalPhotos || 0}
-              </p>
-            </div>
-            <Image className="w-8 h-8 text-blue-600" />
-          </div>
-        </Card>
-        
-        <Card padding="sm">
-          <div className="flex items-center justify-between">
-            <div>
-              <p className="text-sm text-neutral-600 dark:text-neutral-400">{t('events.stats.expiringEvents')}</p>
-              <p className="text-2xl font-bold text-neutral-900 dark:text-neutral-100">
-                {dashboardStats?.expiringEvents || 0}
-              </p>
-            </div>
-            <AlertTriangle className="w-8 h-8 text-orange-600" />
-          </div>
-        </Card>
-      </div>
+          </Card>
 
-      {/* Filters and Search */}
-      <Card padding="sm" className="mb-6">
-        <div className="flex flex-col lg:flex-row gap-4">
-          {/* Search */}
-          <div className="flex-1">
-            <Input
-              type="text"
-              placeholder={t('events.searchEventsPlaceholder')}
-              leftIcon={<Search className="w-5 h-5 text-neutral-400" />}
-              value={searchTerm}
-              onChange={(e) => setSearchTerm(e.target.value)}
-            />
-          </div>
+          <Card padding="sm">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm text-neutral-600 dark:text-neutral-400">{t('events.stats.activeEvents')}</p>
+                <p className="text-2xl font-bold text-neutral-900 dark:text-neutral-100">
+                  {dashboardStats?.activeEvents || 0}
+                </p>
+              </div>
+              <Activity className="w-8 h-8 text-green-600" />
+            </div>
+          </Card>
 
-          {/* Filter Buttons */}
-          <div className="flex gap-2">
-            <Button
-              variant={!statusFilter ? 'primary' : 'outline'}
-              size="md"
-              onClick={() => {
-                searchParams.delete('filter');
-                setSearchParams(searchParams);
-              }}
-            >
-              {t('events.all')} ({totalEventsCount})
-            </Button>
-            <Button
-              variant={statusFilter === 'active' ? 'primary' : 'outline'}
-              size="md"
-              onClick={() => setSearchParams({ filter: 'active' })}
-            >
-              {t('events.active')}
-            </Button>
-            <Button
-              variant={isExpiringFilter ? 'primary' : 'outline'}
-              size="md"
-              onClick={() => setSearchParams({ filter: 'expiring' })}
-              leftIcon={<AlertTriangle className="w-4 h-4" />}
-            >
-              {t('events.expiring')}
-            </Button>
-            <Button
-              variant={statusFilter === 'archived' ? 'primary' : 'outline'}
-              size="md"
-              onClick={() => setSearchParams({ filter: 'archived' })}
-              leftIcon={<Archive className="w-4 h-4" />}
-            >
-              {t('events.archived')}
-            </Button>
-          </div>
+          <Card padding="sm">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm text-neutral-600 dark:text-neutral-400">{t('events.stats.totalPhotos')}</p>
+                <p className="text-2xl font-bold text-neutral-900 dark:text-neutral-100">
+                  {dashboardStats?.totalPhotos || 0}
+                </p>
+              </div>
+              <Image className="w-8 h-8 text-blue-600" />
+            </div>
+          </Card>
+
+          <Card padding="sm">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm text-neutral-600 dark:text-neutral-400">{t('events.stats.expiringEvents')}</p>
+                <p className="text-2xl font-bold text-neutral-900 dark:text-neutral-100">
+                  {dashboardStats?.expiringEvents || 0}
+                </p>
+              </div>
+              <AlertTriangle className="w-8 h-8 text-orange-600" />
+            </div>
+          </Card>
         </div>
 
-        {/* Bulk Actions */}
-        {selectedEvents.length > 0 && (
-          <div className="mt-4 p-3 bg-primary-50 dark:bg-primary-900/30 rounded-lg flex items-center justify-between">
-            <span className="text-sm text-primary-900 dark:text-primary-100">
-              {t('events.eventsSelected', { count: selectedEvents.length })}
-            </span>
+        {/* Filters and Search */}
+        <Card padding="sm" className="mb-6">
+          <div className="flex flex-col lg:flex-row gap-4">
+            {/* Search */}
+            <div className="flex-1">
+              <Input
+                type="text"
+                placeholder={t('events.searchEventsPlaceholder')}
+                leftIcon={<Search className="w-5 h-5 text-neutral-400" />}
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+              />
+            </div>
+
+            {/* Filter Buttons */}
             <div className="flex gap-2">
-              <Button variant="outline" size="sm" onClick={() => setSelectedEvents([])}>
-                {t('events.clear')}
-              </Button>
-              <Button 
-                variant="outline" 
-                size="sm"
-                onClick={() => setShowBulkArchiveModal(true)}
+              <Button
+                variant={!statusFilter ? 'primary' : 'outline'}
+                size="md"
+                onClick={() => {
+                  searchParams.delete('filter');
+                  setSearchParams(searchParams);
+                }}
               >
-                {t('events.archiveSelected')}
+                {t('events.all')} ({totalEventsCount})
+              </Button>
+              <Button
+                variant={statusFilter === 'active' ? 'primary' : 'outline'}
+                size="md"
+                onClick={() => setSearchParams({ filter: 'active' })}
+              >
+                {t('events.active')}
+              </Button>
+              <Button
+                variant={isExpiringFilter ? 'primary' : 'outline'}
+                size="md"
+                onClick={() => setSearchParams({ filter: 'expiring' })}
+                leftIcon={<AlertTriangle className="w-4 h-4" />}
+              >
+                {t('events.expiring')}
+              </Button>
+              <Button
+                variant={statusFilter === 'archived' ? 'primary' : 'outline'}
+                size="md"
+                onClick={() => setSearchParams({ filter: 'archived' })}
+                leftIcon={<Archive className="w-4 h-4" />}
+              >
+                {t('events.archived')}
               </Button>
             </div>
           </div>
-        )}
-      </Card>
 
-      {/* Events Table */}
-      <Card className="overflow-visible">
-        <div className="overflow-x-auto overflow-y-visible">
-          <table className="w-full">
-            <thead className="bg-neutral-50 dark:bg-neutral-800 border-b border-neutral-200 dark:border-neutral-700">
-              <tr>
-                <th className="px-6 py-3 text-left">
-                  <input
-                    type="checkbox"
-                    checked={selectedEvents.length === filteredEvents.length && filteredEvents.length > 0}
-                    onChange={handleSelectAll}
-                    className="w-4 h-4 text-primary-600 border-neutral-300 dark:border-neutral-600 rounded focus:ring-primary-500 dark:bg-neutral-700"
-                  />
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
-                  {t('events.event')}
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
-                  {t('events.type')}
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
-                  {t('events.date')}
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
-                  {t('events.status')}
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
-                  {t('events.expires')}
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
-                  {t('events.actions')}
-                </th>
-              </tr>
-            </thead>
-            <tbody className="bg-white dark:bg-neutral-800 divide-y divide-neutral-200 dark:divide-neutral-700">
-              {filteredEvents.length === 0 ? (
+          {/* Bulk Actions */}
+          {selectedEvents.length > 0 && (
+            <div className="mt-4 p-3 bg-primary-50 dark:bg-primary-900/30 rounded-lg flex items-center justify-between">
+              <span className="text-sm text-primary-900 dark:text-primary-100">
+                {t('events.eventsSelected', { count: selectedEvents.length })}
+              </span>
+              <div className="flex gap-2">
+                <Button variant="outline" size="sm" onClick={() => setSelectedEvents([])}>
+                  {t('events.clear')}
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setShowBulkArchiveModal(true)}
+                >
+                  {t('events.archiveSelected')}
+                </Button>
+              </div>
+            </div>
+          )}
+        </Card>
+
+        {/* Events Table */}
+        <Card className="overflow-visible">
+          <div className="overflow-x-auto overflow-y-visible">
+            <table className="w-full">
+              <thead className="bg-neutral-50 dark:bg-neutral-800 border-b border-neutral-200 dark:border-neutral-700">
                 <tr>
-                  <td colSpan={7} className="px-6 py-12 text-center text-neutral-500 dark:text-neutral-400">
-                    {t('events.noEventsFound')}
-                  </td>
+                  <th className="px-6 py-3 text-left">
+                    <input
+                      type="checkbox"
+                      checked={selectedEvents.length === filteredEvents.length && filteredEvents.length > 0}
+                      onChange={handleSelectAll}
+                      className="w-4 h-4 text-primary-600 border-neutral-300 dark:border-neutral-600 rounded focus:ring-primary-500 dark:bg-neutral-700"
+                    />
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
+                    {t('events.event')}
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
+                    {t('events.type')}
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
+                    {t('events.date')}
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
+                    {t('events.status')}
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
+                    {t('events.expires')}
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
+                    {t('events.actions')}
+                  </th>
                 </tr>
-              ) : (
-                filteredEvents.map((event) => {
-                  const status = getEventStatus(event);
+              </thead>
+              <tbody className="bg-white dark:bg-neutral-800 divide-y divide-neutral-200 dark:divide-neutral-700">
+                {filteredEvents.length === 0 ? (
+                  <tr>
+                    <td colSpan={7} className="px-6 py-12 text-center text-neutral-500 dark:text-neutral-400">
+                      {t('events.noEventsFound')}
+                    </td>
+                  </tr>
+                ) : (
+                  filteredEvents.map((event) => {
+                    const status = getEventStatus(event);
 
-                  return (
-                    <tr
-                      key={event.id}
-                      className="hover:bg-neutral-50 dark:hover:bg-neutral-700/50 cursor-pointer"
-                      onClick={() => navigate(`/admin/events/${event.id}`)}
-                    >
-                      <td className="px-6 py-4" onClick={(e) => e.stopPropagation()}>
-                        <input
-                          type="checkbox"
-                          checked={selectedEvents.includes(event.id)}
-                          onChange={() => handleSelectEvent(event.id)}
-                          className="w-4 h-4 text-primary-600 border-neutral-300 dark:border-neutral-600 rounded focus:ring-primary-500 dark:bg-neutral-700"
-                        />
-                      </td>
-                      <td className="px-6 py-4">
-                        <div>
-                          <p className="text-sm font-medium text-neutral-900 dark:text-neutral-100">{event.event_name}</p>
-                          <p className="text-xs text-neutral-500 dark:text-neutral-400">{event.customer_email}</p>
-                          <div className="mt-1">
-                            <span
-                              className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium ${
-                                isGalleryPublic(event.require_password)
-                                  ? 'bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-300'
-                                  : 'bg-neutral-100 dark:bg-neutral-700 text-neutral-700 dark:text-neutral-300'
-                              }`}
-                            >
-                              {isGalleryPublic(event.require_password) ? t('events.publicAccess', 'Public access') : t('events.passwordProtected', 'Password protected')}
-                            </span>
+                    return (
+                      <tr
+                        key={event.id}
+                        className="hover:bg-neutral-50 dark:hover:bg-neutral-700/50 cursor-pointer"
+                        onClick={() => navigate(`/admin/events/${event.id}`)}
+                      >
+                        <td className="px-6 py-4" onClick={(e) => e.stopPropagation()}>
+                          <input
+                            type="checkbox"
+                            checked={selectedEvents.includes(event.id)}
+                            onChange={() => handleSelectEvent(event.id)}
+                            className="w-4 h-4 text-primary-600 border-neutral-300 dark:border-neutral-600 rounded focus:ring-primary-500 dark:bg-neutral-700"
+                          />
+                        </td>
+                        <td className="px-6 py-4">
+                          <div>
+                            <p className="text-sm font-medium text-neutral-900 dark:text-neutral-100">{event.event_name}</p>
+                            <p className="text-xs text-neutral-500 dark:text-neutral-400">{event.customer_email}</p>
+                            <div className="mt-1">
+                              <span
+                                className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium ${isGalleryPublic(event.require_password)
+                                    ? 'bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-300'
+                                    : 'bg-neutral-100 dark:bg-neutral-700 text-neutral-700 dark:text-neutral-300'
+                                  }`}
+                              >
+                                {isGalleryPublic(event.require_password) ? t('events.publicAccess', 'Public access') : t('events.passwordProtected', 'Password protected')}
+                              </span>
+                            </div>
                           </div>
-                        </div>
-                      </td>
-                      <td className="px-6 py-4 text-sm text-neutral-700 dark:text-neutral-300">
-                        {event.event_type}
-                      </td>
-                      <td className="px-6 py-4 text-sm text-neutral-700 dark:text-neutral-300">
-                        {event.event_date ? format(parseISO(event.event_date), 'MMM d, yyyy') : 'N/A'}
-                      </td>
-                      <td className="px-6 py-4">
-                        <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${status.color}`}>
-                          {status.label}
-                        </span>
-                      </td>
-                      <td className="px-6 py-4 text-sm text-neutral-700 dark:text-neutral-300">
-                        {event.expires_at ? format(parseISO(event.expires_at), 'MMM d, yyyy') : 'N/A'}
-                      </td>
-                      <td className="px-6 py-4" onClick={(e) => e.stopPropagation()}>
-                        <div className="flex items-center gap-1">
-                          {/* Inline action buttons - hidden on mobile */}
-                          <div className="hidden md:flex items-center gap-1">
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              onClick={() => navigate(`/admin/events/${event.id}`)}
-                              title={t('events.viewDetails')}
-                            >
-                              <Edit className="w-4 h-4" />
-                            </Button>
-                            {event.share_link && (
+                        </td>
+                        <td className="px-6 py-4 text-sm text-neutral-700 dark:text-neutral-300">
+                          {event.event_type}
+                        </td>
+                        <td className="px-6 py-4 text-sm text-neutral-700 dark:text-neutral-300">
+                          {event.event_date ? format(parseISO(event.event_date), 'MMM d, yyyy') : 'N/A'}
+                        </td>
+                        <td className="px-6 py-4">
+                          <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${status.color}`}>
+                            {status.label}
+                          </span>
+                        </td>
+                        <td className="px-6 py-4 text-sm text-neutral-700 dark:text-neutral-300">
+                          {event.expires_at ? format(parseISO(event.expires_at), 'MMM d, yyyy') : 'N/A'}
+                        </td>
+                        <td className="px-6 py-4" onClick={(e) => e.stopPropagation()}>
+                          <div className="flex items-center gap-1">
+                            {/* Inline action buttons - hidden on mobile */}
+                            <div className="hidden md:flex items-center gap-1">
                               <Button
                                 variant="ghost"
                                 size="sm"
-                                onClick={() => window.open(resolveShareLink(event.share_link), '_blank')}
-                                title={t('events.viewGallery')}
+                                onClick={() => navigate(`/admin/events/${event.id}`)}
+                                title={t('events.viewDetails')}
                               >
-                                <ExternalLink className="w-4 h-4" />
+                                <Edit className="w-4 h-4" />
                               </Button>
-                            )}
-                          </div>
+                              {event.share_link && (
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  onClick={() => window.open(resolveShareLink(event.share_link), '_blank')}
+                                  title={t('events.viewGallery')}
+                                >
+                                  <ExternalLink className="w-4 h-4" />
+                                </Button>
+                              )}
+                            </div>
 
-                          {/* Context menu for additional actions */}
-                          <div className="relative inline-block text-left dropdown-container">
-                            <button
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                if (activeDropdown === event.id) {
-                                  setActiveDropdown(null);
-                                  setDropdownPosition(null);
-                                } else {
-                                  const rect = e.currentTarget.getBoundingClientRect();
-                                  setActiveDropdown(event.id);
-                                  setDropdownPosition({
-                                    top: rect.bottom + window.scrollY,
-                                    left: rect.right - 224 + window.scrollX // 224px = 14rem (w-56)
-                                  });
-                                }
-                              }}
-                              className="text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-200 p-1"
-                            >
-                              <MoreVertical className="w-5 h-5" />
-                            </button>
-
-                            {activeDropdown === event.id && dropdownPosition && (
-                              <div
-                                className="fixed z-50 w-56 rounded-md shadow-lg bg-white dark:bg-neutral-800 ring-1 ring-black ring-opacity-5 dark:ring-neutral-700"
-                                style={{ top: `${dropdownPosition.top}px`, left: `${dropdownPosition.left}px` }}
+                            {/* Context menu for additional actions */}
+                            <div className="relative inline-block text-left dropdown-container">
+                              <button
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  if (activeDropdown === event.id) {
+                                    setActiveDropdown(null);
+                                    setDropdownPosition(null);
+                                  } else {
+                                    const rect = e.currentTarget.getBoundingClientRect();
+                                    setActiveDropdown(event.id);
+                                    setDropdownPosition({
+                                      top: rect.bottom + window.scrollY,
+                                      left: rect.right - 224 + window.scrollX // 224px = 14rem (w-56)
+                                    });
+                                  }
+                                }}
+                                className="text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-200 p-1"
                               >
-                                <div className="py-1">
-                                  {/* Show Edit/View on mobile only (already visible inline on desktop) */}
-                                  <button
-                                    onClick={() => {
-                                      navigate(`/admin/events/${event.id}`);
-                                      setActiveDropdown(null);
-                                      setDropdownPosition(null);
-                                    }}
-                                    className="md:hidden w-full text-left px-4 py-2 text-sm text-neutral-700 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-700 flex items-center gap-2"
-                                  >
-                                    <Edit className="w-4 h-4" />
-                                    {t('events.viewDetails')}
-                                  </button>
-                                  {event.share_link ? (
-                                    <a
-                                      href={resolveShareLink(event.share_link)}
-                                      target="_blank"
-                                      rel="noopener noreferrer"
+                                <MoreVertical className="w-5 h-5" />
+                              </button>
+
+                              {activeDropdown === event.id && dropdownPosition && (
+                                <div
+                                  className="fixed z-50 w-56 rounded-md shadow-lg bg-white dark:bg-neutral-800 ring-1 ring-black ring-opacity-5 dark:ring-neutral-700"
+                                  style={{ top: `${dropdownPosition.top}px`, left: `${dropdownPosition.left}px` }}
+                                >
+                                  <div className="py-1">
+                                    {/* Show Edit/View on mobile only (already visible inline on desktop) */}
+                                    <button
+                                      onClick={() => {
+                                        navigate(`/admin/events/${event.id}`);
+                                        setActiveDropdown(null);
+                                        setDropdownPosition(null);
+                                      }}
                                       className="md:hidden w-full text-left px-4 py-2 text-sm text-neutral-700 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-700 flex items-center gap-2"
-                                      onClick={() => {
-                                        setActiveDropdown(null);
-                                        setDropdownPosition(null);
-                                      }}
                                     >
-                                      <ExternalLink className="w-4 h-4" />
-                                      {t('events.viewGallery')}
-                                    </a>
-                                  ) : null}
-                                  {!event.is_archived ? (
+                                      <Edit className="w-4 h-4" />
+                                      {t('events.viewDetails')}
+                                    </button>
+                                    {event.share_link ? (
+                                      <a
+                                        href={resolveShareLink(event.share_link)}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="md:hidden w-full text-left px-4 py-2 text-sm text-neutral-700 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-700 flex items-center gap-2"
+                                        onClick={() => {
+                                          setActiveDropdown(null);
+                                          setDropdownPosition(null);
+                                        }}
+                                      >
+                                        <ExternalLink className="w-4 h-4" />
+                                        {t('events.viewGallery')}
+                                      </a>
+                                    ) : null}
+                                    {!event.is_archived ? (
+                                      <button
+                                        onClick={() => {
+                                          archiveMutation.mutate(event.id);
+                                          setActiveDropdown(null);
+                                          setDropdownPosition(null);
+                                        }}
+                                        className="w-full text-left px-4 py-2 text-sm text-neutral-700 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-700 flex items-center gap-2"
+                                      >
+                                        <Archive className="w-4 h-4" />
+                                        {t('events.archiveEventAction')}
+                                      </button>
+                                    ) : null}
+                                    {event.is_archived ? (
+                                      <button
+                                        onClick={() => {
+                                          toast.info(t('events.downloadArchiveSoon'));
+                                          setActiveDropdown(null);
+                                          setDropdownPosition(null);
+                                        }}
+                                        className="w-full text-left px-4 py-2 text-sm text-neutral-700 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-700 flex items-center gap-2"
+                                      >
+                                        <Download className="w-4 h-4" />
+                                        {t('events.downloadArchiveAction')}
+                                      </button>
+                                    ) : null}
                                     <button
                                       onClick={() => {
-                                        archiveMutation.mutate(event.id);
-                                        setActiveDropdown(null);
-                                        setDropdownPosition(null);
+                                        if (confirm(t('events.deleteEventConfirm'))) {
+                                          deleteMutation.mutate(event.id);
+                                          setActiveDropdown(null);
+                                          setDropdownPosition(null);
+                                        }
                                       }}
-                                      className="w-full text-left px-4 py-2 text-sm text-neutral-700 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-700 flex items-center gap-2"
+                                      className="w-full text-left px-4 py-2 text-sm text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/30 flex items-center gap-2"
                                     >
-                                      <Archive className="w-4 h-4" />
-                                      {t('events.archiveEventAction')}
+                                      <Trash2 className="w-4 h-4" />
+                                      {t('events.deleteEvent')}
                                     </button>
-                                  ) : null}
-                                  {event.is_archived ? (
-                                    <button
-                                      onClick={() => {
-                                        toast.info(t('events.downloadArchiveSoon'));
-                                        setActiveDropdown(null);
-                                        setDropdownPosition(null);
-                                      }}
-                                      className="w-full text-left px-4 py-2 text-sm text-neutral-700 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-700 flex items-center gap-2"
-                                    >
-                                      <Download className="w-4 h-4" />
-                                      {t('events.downloadArchiveAction')}
-                                    </button>
-                                  ) : null}
-                                  <button
-                                    onClick={() => {
-                                      if (confirm(t('events.deleteEventConfirm'))) {
-                                        deleteMutation.mutate(event.id);
-                                        setActiveDropdown(null);
-                                        setDropdownPosition(null);
-                                      }
-                                    }}
-                                    className="w-full text-left px-4 py-2 text-sm text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/30 flex items-center gap-2"
-                                  >
-                                    <Trash2 className="w-4 h-4" />
-                                    {t('events.deleteEvent')}
-                                  </button>
+                                  </div>
                                 </div>
-                              </div>
-                            )}
+                              )}
+                            </div>
                           </div>
-                        </div>
-                      </td>
-                    </tr>
-                  );
-                })
-              )}
-            </tbody>
-          </table>
-        </div>
-      </Card>
-      
-      {/* Bulk Archive Modal */}
-      <BulkArchiveModal
-        isOpen={showBulkArchiveModal}
-        onClose={() => setShowBulkArchiveModal(false)}
-        onConfirm={() => bulkArchiveMutation.mutate(selectedEvents)}
-        selectedEvents={filteredEvents.filter(e => selectedEvents.includes(e.id))}
-        isLoading={bulkArchiveMutation.isPending}
-      />
+                        </td>
+                      </tr>
+                    );
+                  })
+                )}
+              </tbody>
+            </table>
+          </div>
+        </Card>
+
+        {/* Bulk Archive Modal */}
+        <BulkArchiveModal
+          isOpen={showBulkArchiveModal}
+          onClose={() => setShowBulkArchiveModal(false)}
+          onConfirm={() => bulkArchiveMutation.mutate(selectedEvents)}
+          selectedEvents={filteredEvents.filter(e => selectedEvents.includes(e.id))}
+          isLoading={bulkArchiveMutation.isPending}
+        />
       </div>
     </ErrorBoundary>
   );

--- a/frontend/src/services/events.service.ts
+++ b/frontend/src/services/events.service.ts
@@ -62,9 +62,15 @@ interface UpdateEventData {
 
 interface EventsListResponse {
   events: Event[];
-  total: number;
-  page: number;
-  limit: number;
+  pagination?: {
+    page: number;
+    limit: number;
+    total: number;
+    totalPages: number;
+  };
+  total?: number;
+  page?: number;
+  limit?: number;
 }
 
 export const eventsService = {
@@ -72,7 +78,8 @@ export const eventsService = {
   async getEvents(
     page: number = 1,
     limit: number = 20,
-    status?: 'active' | 'inactive' | 'archived'
+    status?: 'active' | 'inactive' | 'archived' | 'expiring',
+    search?: string
   ): Promise<EventsListResponse> {
     const params = new URLSearchParams({
       page: page.toString(),
@@ -81,6 +88,10 @@ export const eventsService = {
     
     if (status) {
       params.append('status', status);
+    }
+
+    if (search && search.trim()) {
+      params.append('search', search.trim());
     }
 
     const response = await api.get<EventsListResponse>(`/admin/events?${params}`);


### PR DESCRIPTION
## Summary
Fixes Admin Events search and counters so they no longer rely on only the first 100 loaded records.

## What changed
- Switched Events page search to server-side by passing search to /api/admin/events.
- Switched status filtering (including xpiring) to server-side query params.
- Replaced subset-based counters with global values:
  - Total Events from /admin/events pagination total
  - Active/Expiring/Total Photos from /admin/dashboard/stats
- Updated "All (N)" pill to use real total events count.
- Extended frontend events service to support search and xpiring status.

## Why
On large datasets (e.g. 452 events), the page previously fetched only page=1&limit=100, then filtered/search locally. That made search miss existing events and showed incorrect counts.

## Validation
- Type checks on changed files: no errors
- Full frontend build still has pre-existing unrelated TS issues elsewhere in the repo

Closes #346
