### PR TITLE
docs: make external media library in README and config files more dis…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,6 +86,14 @@ APP_STORAGE=./storage
 APP_DATA=./data
 LOGS=./logs
 
+# External Media Library (optional)
+# Reference photos that already live on your host filesystem instead of
+# uploading them through the admin UI. Set this to the path on YOUR HOST
+# where your photo library is stored — the compose file mounts it
+# read-only into the backend container at /external-media.
+# Full setup guide: DEPLOYMENT_GUIDE.md#-external-media-library
+# EXTERNAL_MEDIA_ROOT=/path/to/your/photos
+
 # Note on FRONTEND_API_URL (documentation only):
 # When using pre-built frontend images, runtime env vars cannot override the built JS.
 # Do NOT rely on FRONTEND_API_URL in Compose. Instead, keep VITE_API_URL=/api and

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Admin panel: [demo.picpeak.app/admin](https://demo.picpeak.app/admin) — login 
 
 **Photo Protection** — Watermarking, right-click prevention, canvas rendering, DevTools detection. Configurable per gallery.
 
-**External Media** — Reference photos from a mounted folder instead of uploading. PicPeak reads originals in place and generates thumbnails on demand.
+**External Media** — Reference photos from a mounted folder instead of uploading. PicPeak reads originals in place and generates thumbnails on demand. [Setup →](DEPLOYMENT_GUIDE.md#-external-media-library)
 
 **Multi-Language** — Full UI translations for English, German, Dutch, Portuguese, and Russian. Email templates support all languages independently.
 

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -49,10 +49,22 @@ services:
       - STORAGE_PATH=/app/storage
       - PHOTOS_DIR=/app/storage/events
       - PICPEAK_RELEASE_CHANNEL=${PICPEAK_CHANNEL:-stable}
+      # External Media Library (optional) — uncomment together with the
+      # matching volume mount below. This overrides the .env value so the
+      # backend reads the in-container path, while the volume line uses
+      # the host path from .env.
+      # - EXTERNAL_MEDIA_ROOT=/external-media
     volumes:
       - ${APP_STORAGE}:/app/storage
       - ${LOGS}:/app/logs
       - ${APP_DATA}:/app/data
+      # External Media Library (optional)
+      # Mount a host photo library read-only so events can reference photos
+      # in place instead of uploading them. Set EXTERNAL_MEDIA_ROOT in .env
+      # to the host path, then uncomment the line below AND the matching
+      # environment override above. Full setup guide:
+      # DEPLOYMENT_GUIDE.md#-external-media-library
+      # - ${EXTERNAL_MEDIA_ROOT}:/external-media:ro
     ports:
       - "${BACKEND_PORT:-3001}:3000"
     networks:


### PR DESCRIPTION
## Summary

The External Media Library is fully documented in `DEPLOYMENT_GUIDE.md`,
but invisible from the entry points users actually read first. The
README feature bullet had no link, `.env.example` didn't mention
`EXTERNAL_MEDIA_ROOT`, and `docker-compose.production.yml` had no
volume-mount example. New users had to already know the feature existed
to find the docs.

This PR makes it discoverable without changing any behavior.

## Changes

- `README.md` — link the External Media bullet to the deployment guide
  section.
- `.env.example` — commented `EXTERNAL_MEDIA_ROOT` block with a one-line
  pointer to the same section.
- `docker-compose.production.yml` — commented backend `environment:`
  override and `volumes:` mount, matching the pattern from the
  deployment guide.

All three additions are commented out. The feature stays opt-in;
nothing is mounted or set unless the user explicitly uncomments.

## Test plan

- [x] `docker compose -f docker-compose.production.yml config` parses
      cleanly with the comments in place.
- [x] Verified the README anchor `#-external-media-library` matches the
      existing heading in `DEPLOYMENT_GUIDE.md`.