### PR TITLE
fix(auth): /auth/session must verify issuer claim like adminAuth (#350)

### DIFF
--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -483,7 +483,14 @@ router.get('/session', async (req, res) => {
     }
 
     try {
-      const decoded = jwt.verify(token, process.env.JWT_SECRET);
+      // Verify with the same `issuer` claim that adminAuth/galleryAuth
+      // require (#350 — without this, /auth/session accepted pre-issuer
+      // tokens and the frontend thought the user was authenticated, but
+      // every protected endpoint rejected them with 401, producing a
+      // /admin/login → /admin/dashboard → /admin/login redirect loop).
+      const decoded = jwt.verify(token, process.env.JWT_SECRET, {
+        issuer: 'picpeak-auth'
+      });
 
       // Check if token has been revoked (e.g. after logout)
       const { isTokenRevoked } = require('../utils/tokenRevocation');


### PR DESCRIPTION
## Summary

Fixes the `/admin/login → /admin/dashboard → /admin/login` redirect loop reported by @Rekoo-PS in #350. Reproduces on `v3.32.1-beta.0` (and earlier 3.x betas) for users carrying admin cookies issued before commit `23cd9cb` added the `iss: 'picpeak-auth'` claim.

## Root cause

Asymmetric JWT verification:

| Caller | `jwt.verify` options | Behaviour on pre-issuer token |
|---|---|---|
| `GET /auth/session` (auth.js:486) | `(token, JWT_SECRET)` — no issuer | **accepts**, returns `valid: true` |
| `adminAuth` middleware (auth.js:20) | `(token, JWT_SECRET, { issuer: 'picpeak-auth' })` | **rejects** with 401 |
| `galleryAuth` middleware (auth.js:142) | same strict | rejects with 401 |

The frontend trusts `/auth/session` as the source of truth for "is the user authenticated?". On a stale admin cookie:

1. `AdminAuthContext` calls `/auth/session` → `valid: true, type: 'admin'`.
2. `AdminLoginPage` sees `isAuthenticated` → `<Navigate to="/admin/dashboard" replace />`.
3. `AdminDashboard` mounts, fires `/admin/dashboard/stats`, `/admin/dashboard/activity`, `/admin/dashboard/health`, `/admin/events?...`.
4. `adminAuth` strict-verifies, rejects each → `401 Token expired/invalid`.
5. Frontend 401 interceptor sees admin URL → `window.location.href = '/admin/login'`.
6. Loop closes at step 1.

The reporter's "open a removed event link → session timeout → back to home" path surfaces the bug because that flow lands you on `/admin/login` while still carrying the stale admin cookie.

I confirmed by extracting frames from their video — it bounces between `/admin/login` (default PicPeak logo, settings still loading) and `/admin/dashboard` ("Loading dashboard…" with their custom Arkan logo).

## The fix

One-line change: pass `{ issuer: 'picpeak-auth' }` to `/auth/session`'s `jwt.verify` so its acceptance matches what every protected endpoint requires.

Pre-issuer tokens now correctly return `valid: false` from the session check → `AdminLoginPage` shows the login form → a fresh login mints a properly-issued cookie → loop broken.

## Why not also fix the other lax verify call sites?

Other `jwt.verify(token, JWT_SECRET)` (no-issuer) calls exist in `logout` flow logging, `photoAuth`, `sessionTimeout`, and rate-limit utilities. They're intentionally lax — their callers don't gate "authenticated?" decisions on the result, they just extract user info for logging/limiting. Out of scope for this fix.

## Why doesn't the existing 401 dedupe (`038e84c`) catch this?

That guard prevents *parallel* `window.location.href = '/admin/login'` calls from a fan-out of admin queries firing 401s in the same tick. It can't help when the redirect loop is *sequential* across full page navigations — each `window.location.href` reloads the JS module and resets `adminLoginRedirectPending` to `false`.

## Test plan

- [ ] **Repro the bug pre-fix**: spin up beta, sign tokens with `JWT_SECRET` and no issuer claim (or rebuild a `v2.6.x` cookie), set the cookie, hit `/admin/login` → confirm loop.
- [ ] **Apply fix**: rebuild backend, hit `/admin/login` → confirm login form renders, no redirect to dashboard, no loop.
- [ ] **Login fresh**: type credentials → `Set-Cookie` overwrites stale cookie → dashboard loads.
- [ ] **Existing tokens (post-issuer)**: confirm normal admin login + admin actions still work — no regression.
- [ ] **Gallery sessions**: confirm gallery login still works (gallery tokens go through `galleryAuth`, already strict).
- [ ] **Reporter test**: ask @Rekoo-PS to update to next beta and confirm loop is gone.

Closes #350