### PR TITLE
fix(events): coerce expires_in_days to Number before addDays

### DIFF
--- a/frontend/src/pages/admin/CreateEventPage.tsx
+++ b/frontend/src/pages/admin/CreateEventPage.tsx
@@ -780,7 +780,12 @@ export const CreateEventPage: React.FC = () => {
                 </div>
                 {formData.event_date && (
                   <p className="mt-2 text-sm text-neutral-500 dark:text-neutral-400">
-                    {t('events.expiresOn')}: {format(addDays(new Date(formData.event_date), formData.expires_in_days))}
+                    {/* Coerce to Number — handleInputChange stores the
+                        <input type="number"> value as a string, and date-fns
+                        addDays does `_date.setDate(_date.getDate() + amount)`
+                        which string-concatenates (25 + "120" = "25120") and
+                        ends up ~68 years in the future. */}
+                    {t('events.expiresOn')}: {format(addDays(new Date(formData.event_date), Number(formData.expires_in_days)))}
                   </p>
                 )}
               </div>


### PR DESCRIPTION
## Summary

The "Expires on" preview under the days-after-event input on Create Event renders dates ~68 years in the future. Reproduced exactly: event date `2026-04-25` + 120 days renders as **`08.01.2095`** instead of `23.08.2026`.

## Root cause

`handleInputChange` (CreateEventPage.tsx:387) stores `e.target.value` verbatim. For `<input type="number">` that's a **string**, so `formData.expires_in_days` is `"120"`, not `120`. The `FormData` interface type-annotates the field as `number` but the runtime value is a string — TypeScript can't catch it because the dynamic `[field]: e.target.value` widens to string-or-whatever.

date-fns `addDays` does (`addDays.js`):
```js
_date.setDate(_date.getDate() + amount);
```

When `amount` is a string, `+` is **string concatenation**:
- `_date.getDate()` → `25` (number, day of month for 2026-04-25)
- `25 + "120"` → `"25120"` (string)
- `setDate("25120")` → coerces to 25120, sets day-of-month to 25120 → carries over by ~68 years → 8 Jan 2095.

Verified locally:
```
$ node -e "const {addDays,format}=require('date-fns'); console.log(format(addDays(new Date('2026-04-25'),'120'),'dd.MM.yyyy'))"
08.01.2095

$ node -e "const {addDays,format}=require('date-fns'); console.log(format(addDays(new Date('2026-04-25'),Number('120')),'dd.MM.yyyy'))"
23.08.2026
```

## The fix

One-line change at the call site:
```diff
- {format(addDays(new Date(formData.event_date), formData.expires_in_days))}
+ {format(addDays(new Date(formData.event_date), Number(formData.expires_in_days)))}
```

The other codepaths that read `expires_in_days` work despite the type mismatch because they coerce numerically through different paths:
- Validation `< 1 || > 365` (line 330) — JS comparison coerces string-to-number.
- API payload (line 361) — JSON serialises the string, backend accepts.

Only `addDays` was actually broken.

## Out of scope (worth a follow-up)

`FormData.expires_in_days: number` is a lie because `handleInputChange` always sets `e.target.value` (string) regardless of the input type. Tightening that handler — `e.target.type === 'number' ? Number(...) : ...` — would prevent this whole class of bug. Doing it requires touching every other field that gets set through the handler, so it's a separate cleanup, not bundled here.

## Test plan

- [ ] Create event, set date to 2026-04-25, set expiration to 120 days → preview shows ~23.08.2026 (locale-formatted).
- [ ] Try edge values: 1 day, 365 days — preview matches expectation.
- [ ] Save the event — `expires_at` in the DB should be the same correct date.
- [ ] Verify other pages still render expiration correctly (EventsListPage, EventDetailsPage, AdminDashboard).