### PR TITLE
fix(events): stop mapping branding_logo_position onto hero_logo_position

### DIFF
--- a/backend/migrations/core/084_fix_hero_logo_position.js
+++ b/backend/migrations/core/084_fix_hero_logo_position.js
@@ -1,0 +1,21 @@
+/**
+ * Heal events whose hero_logo_position contains a branding-style value
+ * (left/right) caused by a prior bug in adminEvents.js getBrandingDefaults
+ * that mapped branding_logo_position (left/center/right) onto
+ * hero_logo_position (top/center/bottom). Any non-canonical value is
+ * reset to 'top' so subsequent PUTs no longer fail validation.
+ */
+
+exports.up = async function up(knex) {
+  const hasColumn = await knex.schema.hasColumn('events', 'hero_logo_position');
+  if (!hasColumn) return;
+
+  await knex('events')
+    .whereNotIn('hero_logo_position', ['top', 'center', 'bottom'])
+    .update({ hero_logo_position: 'top' });
+};
+
+exports.down = async function down() {
+  // Data correction is not reversible — the original (incorrect) values
+  // are not preserved.
+};

--- a/backend/src/routes/adminEvents.js
+++ b/backend/src/routes/adminEvents.js
@@ -138,14 +138,20 @@ const getDownloadProtectionDefaults = async () => {
   return { enable_devtools_protection: await readBooleanSetting('enable_devtools_protection') };
 };
 
-// Helper to get branding defaults for new events (Feature 7: Branding Inheritance)
+// Helper to get branding defaults for new events (Feature 7: Branding Inheritance).
+//
+// Note: `branding_logo_position` (header bar — left/center/right) is a
+// different concept from `hero_logo_position` (hero block — top/center/
+// bottom) and must NOT be mapped here. A previous version copied the
+// branding value over, which wrote 'left'/'right' into per-event
+// hero_logo_position columns and broke any subsequent PUT validation
+// (#357). Migration 084 heals existing rows.
 const getBrandingDefaults = async () => {
   try {
     const settings = await db('app_settings')
       .whereIn('setting_key', [
         'branding_logo_display_hero',
-        'branding_logo_size',
-        'branding_logo_position'
+        'branding_logo_size'
       ])
       .select('setting_key', 'setting_value');
 
@@ -165,9 +171,6 @@ const getBrandingDefaults = async () => {
       }
       if (s.setting_key === 'branding_logo_size' && value) {
         defaults.hero_logo_size = value;
-      }
-      if (s.setting_key === 'branding_logo_position' && value) {
-        defaults.hero_logo_position = value;
       }
     });
 


### PR DESCRIPTION
## Summary

Saving an event fails with `Invalid value (field: hero_logo_position)` when the admin's global branding logo position is set to `'left'` (or `'right'`). Two settings with overlapping names were being conflated.

## Root cause

| Setting | Concept | Allowed values |
|---|---|---|
| `branding_logo_position` (global) | header bar, **horizontal** | `'left' \| 'center' \| 'right'` |
| `hero_logo_position` (per-event) | hero block, **vertical** | `'top' \| 'center' \| 'bottom'` |

`getBrandingDefaults()` in `adminEvents.js` copied the global branding value into the per-event hero value when seeding new events:

```js
if (s.setting_key === 'branding_logo_position' && value) {
  defaults.hero_logo_position = value;  // ← wrong concept, wrong value set
}
```

Result: every admin with branding-logo-position set to `'left'` (the most common choice) created events with `hero_logo_position = 'left'` in the DB. The validator at line 1014 rejects anything outside `['top', 'center', 'bottom']`, so subsequent PUTs to `/admin/events/:id` returned 400 with `Invalid value (field: hero_logo_position)` until the admin manually picked a valid value from the dropdown.

## Fix

1. **`adminEvents.js`** — remove the bogus mapping. `branding_logo_position` is no longer read by `getBrandingDefaults`. The fallback default `'top'` is used unless the request body explicitly provides `hero_logo_position` (which is independently validated). Comment in the file explains the two-concepts-similar-names trap so this doesn't get re-added.

2. **`migrations/core/084_fix_hero_logo_position.js`** — heals existing rows by setting any `hero_logo_position` outside `('top','center','bottom')` back to `'top'`. Without this, affected events would continue to 400 on every save until the admin manually changed the dropdown.

## Repro (pre-fix)

1. Admin Settings → Branding → set logo position to `'left'`.
2. Create a new event (any type).
3. Open the event detail page → click Save without changing anything.
4. → `400 Bad Request`, toast: `Invalid value (field: hero_logo_position)`.

PUT body that surfaced this in the wild (from @the-luap):
```json
{ ..., "hero_logo_position": "left", "hero_image_anchor": "center", ... }
```

## Test plan

- [ ] Set branding logo position to `'left'`.
- [ ] Create a new event → confirm the event row in the DB has `hero_logo_position = 'top'` (not `'left'`).
- [ ] Run the migration on an instance with affected rows → confirm they're normalised to `'top'`.
- [ ] Open an event with hero header style and the dropdown → confirm `'top'/'center'/'bottom'` are the only options and saving works.
- [ ] Set branding logo position to `'left'/'center'/'right'` → confirm header bar still renders correctly (regression check on the global branding side).

Closes the issue raised in conversation; no GitHub issue number to attach.