### PR TITLE
feat(cms): add external URL toggle for imprint and privacy pages

### DIFF
--- a/backend/src/database/db.js
+++ b/backend/src/database/db.js
@@ -464,14 +464,30 @@ async function ensureGlobalCategories() {
       table.text('content_en');
       table.text('content_de');
       table.string('logo_url').nullable();
+      table.boolean('use_external_url').notNullable().defaultTo(false);
+      table.string('external_url').nullable();
       table.timestamp('updated_at').defaultTo(db.fn.now());
     });
-  } else if (!(await db.schema.hasColumn('cms_pages', 'logo_url'))) {
-    // Online migration for existing deployments — see issue #324, per-page
-    // logo override for admin-customisable error pages.
-    await db.schema.alterTable('cms_pages', (table) => {
-      table.string('logo_url').nullable();
-    });
+  } else {
+    if (!(await db.schema.hasColumn('cms_pages', 'logo_url'))) {
+      // Online migration for existing deployments — see issue #324, per-page
+      // logo override for admin-customisable error pages.
+      await db.schema.alterTable('cms_pages', (table) => {
+        table.string('logo_url').nullable();
+      });
+    }
+    if (!(await db.schema.hasColumn('cms_pages', 'use_external_url'))) {
+      // Per-page toggle to redirect visitors to an external imprint /
+      // privacy-policy URL instead of rendering the internal CMS content.
+      await db.schema.alterTable('cms_pages', (table) => {
+        table.boolean('use_external_url').notNullable().defaultTo(false);
+      });
+    }
+    if (!(await db.schema.hasColumn('cms_pages', 'external_url'))) {
+      await db.schema.alterTable('cms_pages', (table) => {
+        table.string('external_url').nullable();
+      });
+    }
   }
 
   const categoryCountRow = await db('photo_categories').count({ count: 'id' }).first();

--- a/backend/src/routes/adminCMS.js
+++ b/backend/src/routes/adminCMS.js
@@ -71,7 +71,9 @@ router.put('/pages/:slug', adminAuth, requirePermission('cms.edit'), [
   body('title_de').optional().isString(),
   body('content_en').optional().isString(),
   body('content_de').optional().isString(),
-  body('logo_url').optional({ nullable: true }).isString()
+  body('logo_url').optional({ nullable: true }).isString(),
+  body('use_external_url').optional().isBoolean(),
+  body('external_url').optional({ nullable: true }).isString()
 ], async (req, res) => {
   try {
     const errors = validationResult(req);
@@ -80,7 +82,26 @@ router.put('/pages/:slug', adminAuth, requirePermission('cms.edit'), [
     }
 
     const { slug } = req.params;
-    const { title_en, title_de, content_en, content_de, logo_url } = req.body;
+    const { title_en, title_de, content_en, content_de, logo_url, use_external_url, external_url } = req.body;
+
+    // When the external-URL toggle is on, the URL must parse and use https://.
+    // express-validator's isURL() is too permissive (allows http:, ftp:, etc.) —
+    // an explicit protocol check is the security-relevant gate.
+    if (use_external_url === true) {
+      const candidate = typeof external_url === 'string' ? external_url.trim() : '';
+      if (!candidate) {
+        return res.status(400).json({ error: 'external_url is required when use_external_url is true' });
+      }
+      let parsed;
+      try {
+        parsed = new URL(candidate);
+      } catch (_err) {
+        return res.status(400).json({ error: 'external_url must be a valid URL' });
+      }
+      if (parsed.protocol !== 'https:') {
+        return res.status(400).json({ error: 'external_url must use https://' });
+      }
+    }
 
     const page = await db('cms_pages').where('slug', slug).first();
     if (!page) {
@@ -98,6 +119,13 @@ router.put('/pages/:slug', adminAuth, requirePermission('cms.edit'), [
     // (e.g. text-only edits) don't accidentally clear the upload.
     if (Object.prototype.hasOwnProperty.call(req.body, 'logo_url')) {
       updateFields.logo_url = logo_url || null;
+    }
+    if (Object.prototype.hasOwnProperty.call(req.body, 'use_external_url')) {
+      updateFields.use_external_url = !!use_external_url;
+    }
+    if (Object.prototype.hasOwnProperty.call(req.body, 'external_url')) {
+      const trimmed = typeof external_url === 'string' ? external_url.trim() : '';
+      updateFields.external_url = trimmed || null;
     }
 
     await db('cms_pages').where('slug', slug).update(updateFields);

--- a/backend/src/routes/publicCMS.js
+++ b/backend/src/routes/publicCMS.js
@@ -25,6 +25,11 @@ router.get('/pages/:slug', async (req, res) => {
       // Per-page logo override (#324). Null means "fall back to global
       // branding logo" — the consumer decides.
       logo_url: page.logo_url || null,
+      // Per-page external-URL override. When use_external_url is true and
+      // external_url is set, consumers should redirect / link out instead
+      // of rendering the internal title/content.
+      use_external_url: !!page.use_external_url,
+      external_url: page.external_url || null,
       updated_at: page.updated_at
     });
   } catch (error) {

--- a/frontend/src/components/gallery/GalleryLayout.tsx
+++ b/frontend/src/components/gallery/GalleryLayout.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
 import { Calendar, Clock, Download, LogOut } from 'lucide-react';
 import { parseISO } from 'date-fns';
 import { useTranslation } from 'react-i18next';
@@ -9,6 +10,7 @@ import { DynamicFavicon } from '../common/DynamicFavicon';
 import { useTheme } from '../../contexts/ThemeContext';
 import { useGuestIdentityOptional } from '../../contexts/GuestIdentityContext';
 import { buildResourceUrl } from '../../utils/url';
+import { cmsService, type PublicCMSPage } from '../../services/cms.service';
 import type { HeaderStyleType } from '../../types/theme.types';
 
 interface GalleryLayoutProps {
@@ -61,6 +63,22 @@ export const GalleryLayout: React.FC<GalleryLayoutProps> = ({
   const { format } = useLocalizedDate();
   const { theme } = useTheme();
   const guestIdentity = useGuestIdentityOptional();
+
+  // Footer legal-link config. Cached aggressively because the toggle state
+  // changes rarely and the gallery footer renders on every page view.
+  // Failures fall back to the internal /impressum and /datenschutz routes.
+  const { data: impressumPage } = useQuery<PublicCMSPage>({
+    queryKey: ['public-cms', 'impressum'],
+    queryFn: () => cmsService.getPublicPage('impressum'),
+    staleTime: 5 * 60 * 1000,
+    retry: false,
+  });
+  const { data: datenschutzPage } = useQuery<PublicCMSPage>({
+    queryKey: ['public-cms', 'datenschutz'],
+    queryFn: () => cmsService.getPublicPage('datenschutz'),
+    staleTime: 5 * 60 * 1000,
+    retry: false,
+  });
 
   // Determine header style - use prop first (from event data), then theme, then fall back to 'standard'
   const headerStyle: HeaderStyleType = headerStyleProp || theme.headerStyle || 'standard';
@@ -592,19 +610,41 @@ export const GalleryLayout: React.FC<GalleryLayoutProps> = ({
           )}
           {/* Legal Links */}
           <div className="mt-4 flex items-center justify-center gap-4 flex-wrap">
-            <Link
-              to="/impressum"
-              className="text-xs text-muted-theme hover:text-theme transition-colors"
-            >
-              {t('legal.impressum')}
-            </Link>
+            {impressumPage?.use_external_url && impressumPage.external_url ? (
+              <a
+                href={impressumPage.external_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-xs text-muted-theme hover:text-theme transition-colors"
+              >
+                {t('legal.impressum')}
+              </a>
+            ) : (
+              <Link
+                to="/impressum"
+                className="text-xs text-muted-theme hover:text-theme transition-colors"
+              >
+                {t('legal.impressum')}
+              </Link>
+            )}
             <span className="text-xs text-muted-theme">|</span>
-            <Link
-              to="/datenschutz"
-              className="text-xs text-muted-theme hover:text-theme transition-colors"
-            >
-              {t('legal.datenschutz')}
-            </Link>
+            {datenschutzPage?.use_external_url && datenschutzPage.external_url ? (
+              <a
+                href={datenschutzPage.external_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-xs text-muted-theme hover:text-theme transition-colors"
+              >
+                {t('legal.datenschutz')}
+              </a>
+            ) : (
+              <Link
+                to="/datenschutz"
+                className="text-xs text-muted-theme hover:text-theme transition-colors"
+              >
+                {t('legal.datenschutz')}
+              </Link>
+            )}
             {guestIdentity?.identity && (
               <>
                 <span className="text-xs text-muted-theme">|</span>

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -2187,7 +2187,13 @@
     "lastUpdated": "Zuletzt aktualisiert:",
     "impressum": "Impressum",
     "datenschutz": "Datenschutzerklärung",
-    "pageUpdated": "Seite erfolgreich aktualisiert"
+    "pageUpdated": "Seite erfolgreich aktualisiert",
+    "useExternalUrl": "Externe URL verwenden",
+    "useExternalUrlHelp": "Besucher werden auf eine externe Seite weitergeleitet, anstatt die internen Inhalte anzuzeigen. Titel und Inhalt bleiben als Fallback gespeichert.",
+    "externalUrl": "Externe URL",
+    "externalUrlPlaceholder": "https://example.com/impressum",
+    "externalUrlInvalid": "Muss eine gültige https://-URL sein",
+    "externalUrlActive": "Externe URL ist aktiv — interne Inhalte bleiben gespeichert, werden Besuchern aber nicht angezeigt."
   },
   "validation": {
     "eventNameRequired": "Veranstaltungsname ist erforderlich",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1736,7 +1736,13 @@
     "lastUpdated": "Last updated:",
     "impressum": "Legal Notice",
     "datenschutz": "Privacy Policy",
-    "pageUpdated": "Page updated successfully"
+    "pageUpdated": "Page updated successfully",
+    "useExternalUrl": "Use external URL",
+    "useExternalUrlHelp": "Redirect visitors to an external page instead of showing the internal content. The internal title and content stay saved as a fallback.",
+    "externalUrl": "External URL",
+    "externalUrlPlaceholder": "https://example.com/impressum",
+    "externalUrlInvalid": "Must be a valid https:// URL",
+    "externalUrlActive": "External URL is active — internal content is preserved but not shown to visitors."
   },
   "eventTypes": {
     "title": "Event Types",

--- a/frontend/src/pages/admin/CMSPage.tsx
+++ b/frontend/src/pages/admin/CMSPage.tsx
@@ -182,6 +182,31 @@ export const CMSPage: React.FC = () => {
     setHasUnsavedChanges(true);
   };
 
+  const handleUseExternalUrlChange = (val: boolean) => {
+    setEditForm(prev => ({ ...prev, use_external_url: val }));
+    setHasUnsavedChanges(true);
+  };
+
+  const handleExternalUrlChange = (val: string) => {
+    setEditForm(prev => ({ ...prev, external_url: val }));
+    setHasUnsavedChanges(true);
+  };
+
+  // Inline URL validation. Empty input while typing is not an error
+  // (avoid flagging mid-edit). Backend re-validates on save regardless.
+  const externalUrlError = useMemo(() => {
+    if (!editForm.use_external_url) return null;
+    const v = (editForm.external_url || '').trim();
+    if (!v) return null;
+    try {
+      const u = new URL(v);
+      if (u.protocol !== 'https:') return t('cms.externalUrlInvalid');
+      return null;
+    } catch {
+      return t('cms.externalUrlInvalid');
+    }
+  }, [editForm.use_external_url, editForm.external_url, t]);
+
   // Per-page logo upload (#324). Only meaningful for the customisable
   // error pages right now, but harmless if exposed for any slug.
   const logoInputRef = useRef<HTMLInputElement>(null);
@@ -607,6 +632,41 @@ export const CMSPage: React.FC = () => {
             </div>
 
             <div className="space-y-4">
+              {/* External URL override */}
+              <div className="rounded-lg border border-neutral-200 dark:border-neutral-700 p-4 bg-neutral-50 dark:bg-neutral-800/40">
+                <label className="flex items-start gap-3 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    className="mt-1 h-4 w-4 rounded border-neutral-300 text-primary-600 focus:ring-primary-500"
+                    checked={!!editForm.use_external_url}
+                    onChange={(e) => handleUseExternalUrlChange(e.target.checked)}
+                  />
+                  <span className="flex-1">
+                    <span className="block text-sm font-medium text-neutral-900 dark:text-neutral-100">
+                      {t('cms.useExternalUrl')}
+                    </span>
+                    <span className="block text-xs text-neutral-500 dark:text-neutral-400 mt-1">
+                      {t('cms.useExternalUrlHelp')}
+                    </span>
+                  </span>
+                </label>
+                {editForm.use_external_url && (
+                  <div className="mt-3">
+                    <Input
+                      type="url"
+                      label={t('cms.externalUrl')}
+                      value={editForm.external_url || ''}
+                      onChange={(e) => handleExternalUrlChange(e.target.value)}
+                      placeholder={t('cms.externalUrlPlaceholder')}
+                      error={externalUrlError || undefined}
+                    />
+                    <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-2">
+                      {t('cms.externalUrlActive')}
+                    </p>
+                  </div>
+                )}
+              </div>
+
               {/* Title */}
               <div>
                 <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">

--- a/frontend/src/pages/public/LegalPage.tsx
+++ b/frontend/src/pages/public/LegalPage.tsx
@@ -44,7 +44,17 @@ export const LegalPage: React.FC = () => {
     }
   }, [page?.title]);
 
-  if (isLoading) {
+  // External-URL override: full-page redirect so the visitor lands on the
+  // operator's own canonical legal page. Use replace() so the back button
+  // returns to the gallery instead of looping back through the redirect.
+  const willRedirect = !!(page?.use_external_url && page?.external_url);
+  useEffect(() => {
+    if (willRedirect && page?.external_url) {
+      window.location.replace(page.external_url);
+    }
+  }, [willRedirect, page?.external_url]);
+
+  if (isLoading || willRedirect) {
     return (
       <div className="min-h-screen bg-neutral-50 flex items-center justify-center">
         <Loading size="lg" text="Loading..." />

--- a/frontend/src/services/cms.service.ts
+++ b/frontend/src/services/cms.service.ts
@@ -8,6 +8,8 @@ export interface CMSPage {
   content_en: string;
   content_de: string;
   logo_url: string | null;
+  use_external_url: boolean;
+  external_url: string | null;
   updated_at: string;
 }
 
@@ -16,6 +18,8 @@ export interface PublicCMSPage {
   content: string;
   slug: string;
   logo_url: string | null;
+  use_external_url: boolean;
+  external_url: string | null;
   updated_at: string;
 }
 


### PR DESCRIPTION
## Description

Adds a per-CMS-page toggle "Use external URL" plus a URL input for the imprint and privacy-policy pages. When enabled, the gallery footer link points at the external URL and direct navigation to `/impressum` or `/datenschutz` redirects there. When disabled, behavior is unchanged.

Internal title/content/logo stay saved in the database when the toggle is on, so flipping it back restores the previous CMS page intact.

**Why:** operators (myself included) often maintain authoritative legal pages on a separate domain (e.g. a personal/agency site that already has a lawyer-reviewed Impressum and Datenschutzerklärung). Forcing PicPeak to host its own copy means duplicating content and risking drift between the two. The toggle lets each gallery deployment point at the canonical source per legal page, while keeping the internal CMS page as a fallback.

**Link behaviour:**
- **External URL configured →** rendered as `<a target="_blank" rel="noopener noreferrer">`, opens in a **new tab** so the gallery stays open behind it. Direct navigation to `/impressum` or `/datenschutz` performs `window.location.replace()` to the external URL (back button returns to the gallery, not the redirect).
- **External URL not configured →** rendered as the existing internal `<Link>`, opens in the **same tab** (current behavior, unchanged).

**Security:**
- Backend strictly validates `external_url` parses as a URL with protocol `https:` when the toggle is on. Rejects `http:`, `javascript:`, `data:`, missing schemes, and malformed input. The explicit protocol check is the security-relevant gate  `express-validator`'s `isURL()` is too permissive.
- The endpoint already requires the `cms.edit` permission, so no new auth surface is introduced.
- External link uses `rel="noopener noreferrer"` to prevent tab-nabbing and referrer leaks.

Fixes # (n/a — feature request, no issue filed)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Manual testing completed
- [x] Tested on Docker deployment

**Manual test steps:**
1. Online migration adds `use_external_url` (boolean, default false) and `external_url` (varchar) to `cms_pages` on backend startup, verified via `\d cms_pages` on a fresh PostgreSQL volume.
2. `PUT /api/admin/cms/pages/impressum` with `use_external_url: true` and a non-https URL → 400. With `https://...` → 200, persisted.
3. Admin UI `/admin/cms`: toggle on, paste URL, auto-save fires after 3s, "Last saved" timestamp updates. Inline error shown for invalid URLs before round-trip.
4. Gallery footer: with toggle on, clicking "Impressum" / "Datenschutz" opens the external URL in a new tab. With toggle off, clicking opens the internal page in the same tab.
5. Direct navigation to `/impressum` with toggle on: full-page redirect to external URL, browser back button returns to gallery.
6. Reversibility: toggle off again — internal title/content/logo render exactly as before.

**Test Configuration:**
* PicPeak Version: beta (commits 66423bb, a4e3d10, c5bba50)
* Node.js Version: container default (Node 18 image)
* Database: PostgreSQL 15
* Browser: Chrome / Safari on macOS

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works *(manual coverage only; no unit tests added —validation logic is small, gated by an admin permission, and exercised by the manual flow above)*
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [ ] I have updated the CHANGELOG.md file *(release-please will generate this from the conventional commits)*

## Files changed

**Backend** (commit `66423bb`):
- `backend/src/database/db.js` — online migration for the two new columns, mirroring the existing `logo_url` pattern.
- `backend/src/routes/adminCMS.js` — extended `PUT /pages/:slug` validators + strict `https://` URL check.
- `backend/src/routes/publicCMS.js` — new fields included in the public response.

**Frontend admin** (commit `a4e3d10`):
- `frontend/src/services/cms.service.ts` — extended `CMSPage` and `PublicCMSPage` interfaces.
- `frontend/src/pages/admin/CMSPage.tsx` — toggle + URL input above the title/content editors with inline `https://` validation.
- `frontend/src/i18n/locales/{en,de}.json` — six new keys under the `cms.*` namespace.

**Frontend public** (commit `c5bba50`):
- `frontend/src/components/gallery/GalleryLayout.tsx` — footer conditionally renders external `<a>` (new tab) or internal `<Link>`
  (same tab).
- `frontend/src/pages/public/LegalPage.tsx` — `window.location.replace` redirect when the toggle is on.

## Additional Notes

- Localisation: only `en` and `de` admin labels were added in this PR (the locales actually edited day-to-day by the project). `nl`, `ru`, `pt` will fall back to English via i18next; happy to add native translations in a follow-up if desired.
- The legal review is on the operator: an external imprint must still identify the responsible party for the gallery service, and an external privacy policy must accurately describe PicPeak's data processing (image storage, guest emails, downloads, etc.), the toggle does not relax DSGVO Art. 13 requirements, just lets the policy live elsewhere.