### PR TITLE
feat(events): prefill admin email + admin picker on event creation

### DIFF
--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1017,6 +1017,8 @@
     "welcomeMessagePlaceholder": "Willkommen zu unserem besonderen Tag! Laden Sie diese Erinnerungen gerne herunter und teilen Sie sie...",
     "hostEmailPlaceholder": "kunde@beispiel.de",
     "adminEmailPlaceholder": "admin@beispiel.de",
+    "adminEmailPickFromAdmins": "Aus Admins wählen:",
+    "adminEmailCustom": "Eigene E-Mail",
     "securityAndAccess": "Sicherheit & Zugriff",
     "accessAndSecurity": "Zugriff & Sicherheit",
     "enterPassword": "Passwort eingeben",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -356,6 +356,8 @@
     "welcomeMessagePlaceholder": "Welcome to our special day! Feel free to download and share these memories...",
     "hostEmailPlaceholder": "customer@example.com",
     "adminEmailPlaceholder": "admin@example.com",
+    "adminEmailPickFromAdmins": "Pick from admins:",
+    "adminEmailCustom": "Custom email",
     "securityAndAccess": "Security & Access",
     "accessAndSecurity": "Access & Security",
     "enterPassword": "Enter password",

--- a/frontend/src/i18n/locales/nl.json
+++ b/frontend/src/i18n/locales/nl.json
@@ -350,6 +350,8 @@
     "welcomeMessagePlaceholder": "Welkom bij onze bijzondere dag! Voel u vrij om deze herinneringen te downloaden en te delen...",
     "hostEmailPlaceholder": "klant@voorbeeld.nl",
     "adminEmailPlaceholder": "admin@voorbeeld.nl",
+    "adminEmailPickFromAdmins": "Kies uit beheerders:",
+    "adminEmailCustom": "Aangepast e-mailadres",
     "securityAndAccess": "Beveiliging & Toegang",
     "accessAndSecurity": "Toegang & Beveiliging",
     "enterPassword": "Voer wachtwoord in",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -350,6 +350,8 @@
     "welcomeMessagePlaceholder": "Bem-vindo(a) ao nosso dia especial! Sinta-se à vontade para baixar e compartilhar essas memórias...",
     "hostEmailPlaceholder": "cliente@exemplo.com",
     "adminEmailPlaceholder": "admin@exemplo.com",
+    "adminEmailPickFromAdmins": "Escolher entre administradores:",
+    "adminEmailCustom": "E-mail personalizado",
     "securityAndAccess": "Segurança e Acesso",
     "accessAndSecurity": "Acesso e Segurança",
     "enterPassword": "Digite a senha",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -350,6 +350,8 @@
     "welcomeMessagePlaceholder": "Добро пожаловать на наш особый день! Скачивайте и делитесь этими воспоминаниями...",
     "hostEmailPlaceholder": "client@example.com",
     "adminEmailPlaceholder": "admin@example.com",
+    "adminEmailPickFromAdmins": "Выбрать из админов:",
+    "adminEmailCustom": "Произвольный e-mail",
     "securityAndAccess": "Безопасность и доступ",
     "accessAndSecurity": "Доступ и безопасность",
     "enterPassword": "Введите пароль",

--- a/frontend/src/pages/admin/CreateEventPage.tsx
+++ b/frontend/src/pages/admin/CreateEventPage.tsx
@@ -25,6 +25,8 @@ import { settingsService } from '../../services/settings.service';
 import { usePublicSettings } from '../../hooks/usePublicSettings';
 import { cssTemplatesService } from '../../services/cssTemplates.service';
 import { eventTypesService } from '../../services/eventTypes.service';
+import { userManagementService } from '../../services/userManagement.service';
+import { useAdminAuth } from '../../contexts/AdminAuthContext';
 import { useTranslation } from 'react-i18next';
 import { ThemeConfig, GALLERY_THEME_PRESETS } from '../../types/theme.types';
 import { Code } from 'lucide-react';
@@ -171,6 +173,41 @@ export const CreateEventPage: React.FC = () => {
   });
 
   const { data: publicSettings } = usePublicSettings();
+
+  // Current logged-in admin (used to prefill the admin email field)
+  const { user: currentAdmin } = useAdminAuth();
+
+  // Optional: list of admin users — used to populate the email picker when
+  // there are multiple admins. Falls back to an empty list silently if the
+  // current user lacks `users.view` permission, so basic admins still get
+  // the auto-prefill from `currentAdmin` without errors surfacing.
+  const { data: adminUsers } = useQuery({
+    queryKey: ['admin-users-list'],
+    queryFn: async () => {
+      try {
+        return await userManagementService.getUsers();
+      } catch {
+        return [];
+      }
+    },
+    staleTime: 5 * 60 * 1000,
+    retry: false
+  });
+
+  const activeAdmins = useMemo(
+    () => (adminUsers || []).filter(u => u.isActive !== false && !!u.email),
+    [adminUsers]
+  );
+
+  // Auto-prefill admin email with the current user's email exactly once,
+  // and only if the field is still empty (don't clobber typed input).
+  const didPrefillAdminEmailRef = useRef(false);
+  useEffect(() => {
+    if (didPrefillAdminEmailRef.current) return;
+    if (!currentAdmin?.email) return;
+    didPrefillAdminEmailRef.current = true;
+    setFormData(prev => (prev.admin_email ? prev : { ...prev, admin_email: currentAdmin.email }));
+  }, [currentAdmin?.email]);
 
   // Get field requirements (default to true if not set)
   const requireCustomerName = publicSettings?.event_require_customer_name !== false;
@@ -673,6 +710,31 @@ export const CreateEventPage: React.FC = () => {
                 error={errors.admin_email}
                 leftIcon={<Mail className="w-5 h-5" />}
               />
+              {activeAdmins.length > 1 && (
+                <div className="flex items-center gap-2 -mt-1">
+                  <label htmlFor="admin-email-picker" className="text-xs text-neutral-600 dark:text-neutral-400 whitespace-nowrap">
+                    {t('events.adminEmailPickFromAdmins', 'Pick from admins:')}
+                  </label>
+                  <select
+                    id="admin-email-picker"
+                    value={activeAdmins.some(a => a.email === formData.admin_email) ? formData.admin_email : ''}
+                    onChange={(e) => {
+                      const email = e.target.value;
+                      if (email) {
+                        setFormData(prev => ({ ...prev, admin_email: email }));
+                      }
+                    }}
+                    className="text-xs px-2 py-1 border border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100 rounded focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+                  >
+                    <option value="">{t('events.adminEmailCustom', 'Custom email')}</option>
+                    {activeAdmins.map(a => (
+                      <option key={a.id} value={a.email}>
+                        {a.username} ({a.email})
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              )}
             </div>
 
             <div className="space-y-3">


### PR DESCRIPTION
## Summary

When creating a new event, the **Admin Email** field now:

- **Auto-prefills** with the currently logged-in admin's email on first load (only if the field is empty, never clobbers typed input or a returned-to draft).
- **Shows a small "Pick from admins" dropdown** under the input when there are 2+ active admins, so you can switch to another admin's email in one click. The field stays a normal email input, typing a non-admin address still works and the dropdown reverts to "Custom email" to reflect that.

## Why

I shouldn't have to type my own email every time I create an event, it's the same value 99% of the time. And when there are multiple admins on the team, picking who should be the contact is one click instead of remembering and typing the address.

## Behavior

- **1 admin (you alone):** field auto-fills with your email. No dropdown.
- **2+ admins:** field auto-fills with your email; dropdown appears below the input listing `username (email)` for each active admin.
- **Low-permission admin** (no `users.view` permission): the admin-list API call is silently caught and returns `[]` — auto-fill from the auth context still works, the dropdown just doesn't render. No errors surface.

## Implementation notes

- Current admin pulled from `useAdminAuth()`.
- Admin list fetched via `userManagementService.getUsers()` with React Query (`['admin-users-list']`, 5 min stale, `retry: false`). Errors caught in the `queryFn` so missing `users.view` permission doesn't bubble up.
- Auto-prefill effect uses a `useRef` guard so it runs at most once, and only when `admin_email` is empty.

## i18n

Two new keys under `events.*`: `adminEmailPickFromAdmins`, `adminEmailCustom`.

- en + de: hand-written.
- **nl, pt, ru: machine-suggested — please flag for native-speaker review.** Falls back to the English default in `t(key, 'fallback')` if anything is off.

## Test plan

Verified on local dev instance:

- [x] Single-admin account: opening the create form shows my email pre-filled, no dropdown.
- [x] Multi-admin account: opening the create form shows my email pre-filled with the picker dropdown below; selecting another admin updates the field.
- [x] Typing a non-admin address keeps the input value and the dropdown shows "Custom email".
- [x] Auto-prefill does not overwrite an already-populated field.