### PR TITLE
chore(events): type FolderTreeNode entries with ExternalEntry

### DIFF
--- a/frontend/src/pages/admin/EventDetailsPage.tsx
+++ b/frontend/src/pages/admin/EventDetailsPage.tsx
@@ -66,7 +66,7 @@ import { api } from '../../config/api';
 import { buildResourceUrl, buildShareLinkUrl } from '../../utils/url';
 import { isGalleryPublic, normalizeRequirePassword } from '../../utils/accessControl';
 import { archiveService } from '../../services/archive.service';
-import { externalMediaService } from '../../services/externalMedia.service';
+import { externalMediaService, type ExternalEntry } from '../../services/externalMedia.service';
 import { photosService, AdminPhoto, type PhotoFilters as PhotoFilterParams, type FeedbackFilters } from '../../services/photos.service';
 import { feedbackService, FeedbackSettings as FeedbackSettingsType } from '../../services/feedback.service';
 import { cssTemplatesService, type EnabledTemplate } from '../../services/cssTemplates.service';
@@ -92,7 +92,7 @@ const FolderTreeNode: React.FC<{
     staleTime: 30_000
   });
 
-  const dirs = (data?.entries || []).filter((e: any) => e.type === 'dir');
+  const dirs: ExternalEntry[] = (data?.entries || []).filter((e: ExternalEntry) => e.type === 'dir');
   const showEmpty = isExpanded && !isLoading && !isError && dirs.length === 0;
   const indentStyle = { paddingLeft: depth * 16 + 4 };
   const childIndentStyle = { paddingLeft: (depth + 1) * 16 + 4 };
@@ -158,7 +158,7 @@ const FolderTreeNode: React.FC<{
               {t('events.externalFolderEmpty', 'No subfolders')}
             </div>
           )}
-          {dirs.map((d: any) => {
+          {dirs.map((d) => {
             const childPath = path ? `${path}/${d.name}` : d.name;
             return (
               <FolderTreeNode


### PR DESCRIPTION
## Summary

Follow-up to PR #378 — drops the `(e: any)` / `(d: any)` casts in the new external-folder-tree picker. `ExternalEntry` is already exported from `externalMedia.service.ts`; the call site just wasn't using it.

## Changes

- Import the type alongside the service.
- Annotate the `dirs` filter callback so `e.type` is the union `'dir' | 'file'` instead of `any`.
- Drop the `(d: any)` annotation from the `map` — TypeScript infers `ExternalEntry` from the typed `dirs` array.

## Out of scope (translation review)

The PR #378 review-comment also flagged "native-speaker review of the nl/pt/ru strings" as a follow-up. After reviewing the four locales (`externalFolderEmpty`, `clearSelection`):

- **nl/pt/ru** translations are standard UI choices and acceptable as-is.
- **de** "Löschen" reads as "delete" in isolation but matches the existing app pattern (`clearAll: "Alle löschen"`); changing one without the other would create inconsistency.

No translation changes shipped here. If the German "Clear" wording is revisited later, it should be done globally rather than per-key.

## Verified

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on the touched file
- [x] No behaviour change, no test impact