### PR TITLE
docs(readme): add Contributors section with @Luca-Timo and @Rekoo-PS

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,15 @@ Other ways to support without spending anything: ⭐ star the repo, share it wit
 
 PicPeak is inspired by the best features of commercial platforms while remaining completely open source. Special thanks to all contributors who make this project possible.
 
+### 👥 Contributors
+
+A huge thank you to the people whose code, reports, and feedback have shaped PicPeak:
+
+- [**@Luca-Timo**](https://github.com/Luca-Timo) — native Apple Silicon multi-arch images, external-URL toggle for legal CMS pages, the lazy-loaded folder tree picker, the admin-email picker on event creation, the data-driven self-hosted webfont system, the gallery header/banner decoupling, and several typed-API refactors. Consistently raises the bar with thoughtful PRs.
+- [**@Rekoo-PS**](https://github.com/Rekoo-PS) — sharp-eyed bug reporter and product feedback. Filed the issues that drove the login-loop fix, the gallery-loading skeleton work, the redirection cleanup, the mobile-lightbox overhaul, the admin-events search-counter fix, the photo-count column, and the bulk-delete workflow. Also a [BuyMeACoffee](https://buymeacoffee.com/theluap) supporter — the kind of feedback loop that keeps the project useful for real deployments.
+
+If you've contributed and aren't listed here, please open a PR — this list is meant to grow.
+
 ### 🤖 AI-Assisted Development
 
 This project was generated with the assistance of AI technology, but has been:


### PR DESCRIPTION
## Summary

The Acknowledgments section had a generic \"thanks to all contributors\" line but no actual recognition by name. Adds a **Contributors** subsection naming the two people who've moved the project forward most concretely.

## Who

- **[@Luca-Timo](https://github.com/Luca-Timo)** — code contributor across multi-arch Docker (#349), external-URL CMS toggle (#372), folder tree picker (#378), admin email picker (#379), self-hosted webfonts (#390), gallery header/banner decoupling (#385), typed-API refactors (#382). Consistent craftsmanship — i18n in all 5 locales every time, dark mode, defensive validation, honest scope discipline.

- **[@Rekoo-PS](https://github.com/Rekoo-PS)** — bug reporter and feedback loop. Filed the issues that drove: login-loop fix (#350), gallery-loading skeleton work (#358, #321), mobile lightbox overhaul (#336), admin-events search-counter fix (#346), and the photo-count + bulk-delete workflow (#384). Also a BuyMeACoffee supporter — the kind of feedback loop that keeps the project genuinely useful for real deployments.

Section ends with an invitation for unlisted contributors to open a PR adding themselves, so it can grow organically without needing a maintainer push every time.

## Verified

- [x] Markdown renders cleanly (visual check)
- [x] Both GitHub handles link correctly
- [x] BuyMeACoffee link unchanged from elsewhere in README