### PR TITLE
feat(gallery): icon-only menu, accent Download CTA (#386)

### DIFF
--- a/frontend/src/components/gallery/GalleryLayout.tsx
+++ b/frontend/src/components/gallery/GalleryLayout.tsx
@@ -40,6 +40,16 @@ interface GalleryLayoutProps {
   showDownloadAll?: boolean;
   onDownloadAll?: () => void;
   isDownloading?: boolean;
+  /**
+   * "Download" CTA shown immediately to the left of the Logout button in the
+   * standard / banner header. Same handler as Download All; the label and
+   * placement are intentionally simpler — single primary action right before
+   * Logout, the natural step at the end of a gallery visit (#386). Always
+   * visible when allowed (independent of sidebar state) so guests aren't
+   * forced to discover the download in the menu.
+   */
+  showHeaderDownload?: boolean;
+  onHeaderDownload?: () => void;
   headerExtra?: React.ReactNode;
   menuButton?: React.ReactNode;
   headerStyle?: HeaderStyleType;
@@ -54,6 +64,8 @@ export const GalleryLayout: React.FC<GalleryLayoutProps> = ({
   showDownloadAll = false,
   onDownloadAll,
   isDownloading = false,
+  showHeaderDownload = false,
+  onHeaderDownload,
   headerExtra,
   menuButton,
   headerStyle: headerStyleProp,
@@ -154,17 +166,22 @@ export const GalleryLayout: React.FC<GalleryLayoutProps> = ({
       <header className={`gallery-header bg-surface border-b border-surface sticky top-0 z-40 ${isHeroHeader || isBannerHeader ? 'shadow-sm' : ''}`}>
         {/* Standard / Banner header - full bar with logo, event info, and actions (all layouts) */}
         {!isHeroHeader && !isMinimalHeader && !isNoHeader && (
-          <div className="container py-3">
+          <div className="container py-3 relative">
+            {/*
+             * Menu icon is absolute-positioned at the very left of the header
+             * row instead of sitting inside the flex flow, so the logo's left
+             * edge can align with the leftmost gallery image (both anchored at
+             * `.container` left padding) — see #386. The icon stays vertically
+             * centred via top-1/2 + -translate-y-1/2.
+             */}
+            {menuButton && (
+              <div className="absolute left-3 sm:left-6 lg:left-8 top-1/2 -translate-y-1/2 z-10">
+                {menuButton}
+              </div>
+            )}
             <div className="flex items-center justify-between gap-2 sm:gap-4">
-              {/* Left side - Menu button, Logo */}
-              <div className="flex items-center gap-2 sm:gap-4 flex-shrink-0">
-                {/* Menu button */}
-                {menuButton && (
-                  <div className="flex-shrink-0">
-                    {menuButton}
-                  </div>
-                )}
-                
+              {/* Left side - Logo (menu lives in the absolute wrapper above) */}
+              <div className={`flex items-center gap-2 sm:gap-4 flex-shrink-0 ${menuButton ? 'pl-12 sm:pl-14' : ''}`}>
                 {/* Logo - Show custom logo or fallback to PicPeak logo */}
                 {shouldShowLogo('header') && (
                   <div className={`gallery-logo-wrapper flex-shrink-0 flex items-center gap-2 ${brandingSettings?.logo_position === 'center' ? 'flex-1' : ''} ${getLogoPositionClass()}`}>
@@ -239,6 +256,27 @@ export const GalleryLayout: React.FC<GalleryLayoutProps> = ({
                   </Button>
                 )}
 
+                {/*
+                 * "Download" CTA — accent-coloured button immediately left of
+                 * Logout, always visible when the gallery allows downloads.
+                 * Uses var(--color-accent) inline so the same colour token
+                 * shared with the 8-token palette (PR #400) resolves to the
+                 * admin's chosen accent regardless of which PR merges first.
+                 */}
+                {showHeaderDownload && onHeaderDownload && (
+                  <button
+                    type="button"
+                    onClick={onHeaderDownload}
+                    disabled={isDownloading}
+                    aria-label={t('gallery.download', 'Download')}
+                    className="gallery-btn gallery-btn-download inline-flex items-center gap-2 px-3 sm:px-4 h-9 rounded-lg text-sm font-medium transition-opacity hover:opacity-90 disabled:opacity-60 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+                    style={{ backgroundColor: 'var(--color-accent)', color: '#ffffff' }}
+                  >
+                    <Download className="w-4 h-4" />
+                    <span className="hidden sm:inline">{t('gallery.download', 'Download')}</span>
+                  </button>
+                )}
+
                 {/* Logout button */}
                 {showLogout && onLogout && (
                   <Button
@@ -300,6 +338,23 @@ export const GalleryLayout: React.FC<GalleryLayoutProps> = ({
                   >
                     <span className="hidden sm:inline">{t('gallery.downloadAll')}</span>
                   </Button>
+                )}
+                {/* Accent Download CTA — also rendered in the minimal header
+                    so the action stays one click away regardless of header
+                    style. Intentionally NOT shown in the no-header variant
+                    where the gallery is fully chromeless by design. */}
+                {showHeaderDownload && onHeaderDownload && (
+                  <button
+                    type="button"
+                    onClick={onHeaderDownload}
+                    disabled={isDownloading}
+                    aria-label={t('gallery.download', 'Download')}
+                    className="gallery-btn gallery-btn-download inline-flex items-center gap-2 px-3 sm:px-4 h-9 rounded-lg text-sm font-medium transition-opacity hover:opacity-90 disabled:opacity-60 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+                    style={{ backgroundColor: 'var(--color-accent)', color: '#ffffff' }}
+                  >
+                    <Download className="w-4 h-4" />
+                    <span className="hidden sm:inline">{t('gallery.download', 'Download')}</span>
+                  </button>
                 )}
                 {showLogout && onLogout && (
                   <Button
@@ -379,6 +434,24 @@ export const GalleryLayout: React.FC<GalleryLayoutProps> = ({
                     <span className="hidden sm:inline">{t('gallery.downloadAll')}</span>
                     <span className="sm:hidden">{t('common.download')}</span>
                   </Button>
+                )}
+
+                {/* Accent Download CTA — also rendered above the hero so the
+                    primary download action is reachable without scrolling.
+                    Intentionally NOT shown in the no-header variant where
+                    the gallery is fully chromeless by design. */}
+                {showHeaderDownload && onHeaderDownload && (
+                  <button
+                    type="button"
+                    onClick={onHeaderDownload}
+                    disabled={isDownloading}
+                    aria-label={t('gallery.download', 'Download')}
+                    className="gallery-btn gallery-btn-download inline-flex items-center gap-2 px-3 sm:px-4 h-9 rounded-lg text-sm font-medium transition-opacity hover:opacity-90 disabled:opacity-60 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+                    style={{ backgroundColor: 'var(--color-accent)', color: '#ffffff' }}
+                  >
+                    <Download className="w-4 h-4" />
+                    <span className="hidden sm:inline">{t('gallery.download', 'Download')}</span>
+                  </button>
                 )}
 
                 {/* Logout button */}

--- a/frontend/src/components/gallery/GalleryView.tsx
+++ b/frontend/src/components/gallery/GalleryView.tsx
@@ -729,21 +729,32 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event }) => {
         headerStyle={data?.event?.header_style || theme.headerStyle}
         showLogout={true}
         onLogout={logout}
-        showDownloadAll={!showSidebar && allowDownloads}
+        // Old Download All header button is replaced by the new
+        // showHeaderDownload below — accent-coloured, always visible when
+        // downloads are allowed, sits right before Logout (#386).
+        showDownloadAll={false}
         onDownloadAll={handleDownloadAll}
         isDownloading={downloadAllMutation.isPending}
-        menuButton={showSidebar ? (
-          <Button
-            variant="ghost"
-            size="sm"
-            className="gallery-btn"
-            leftIcon={<Menu className="w-4 h-4" />}
-            onClick={() => setSidebarOpen(!sidebarOpen)}
-            aria-label={t('gallery.toggleMenu')}
-          >
-            <span className="hidden sm:inline">{t('common.menu')}</span>
-          </Button>
-        ) : undefined}
+        menuButton={
+          // Menu icon is shown when the event theme uses the sidebar
+          // controls style. The button is icon-only — the redundant
+          // "Menu" text label was dropped (#386). The wrapper aligns the
+          // icon to the very left of the header so the logo lines up
+          // with the leftmost gallery image.
+          showSidebar ? (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="gallery-btn p-2"
+              onClick={() => setSidebarOpen(!sidebarOpen)}
+              aria-label={t('gallery.toggleMenu')}
+            >
+              <Menu className="w-5 h-5" />
+            </Button>
+          ) : undefined
+        }
+        showHeaderDownload={allowDownloads}
+        onHeaderDownload={handleDownloadAll}
         headerExtra={(() => {
           const items = [];
           


### PR DESCRIPTION
Addresses [the-luap/picpeak#386](https://github.com/the-luap/picpeak/issues/386) — gallery header layout cleanup.

## Summary

- Menu icon is now icon-only (the redundant "Menu" text label is gone).
- Menu icon is absolute-positioned at the very left of the header.
- New accent-coloured **Download** button placed immediately left of Logout — always visible when downloads are allowed, replacing the previous primary-coloured "Download All" header button.
- Same Download CTA is rendered in standard, banner, hero, and minimal headers. Intentionally **not** rendered in the no-header variant (chromeless by design).

## Why

The previous header pushed the logo to the right of the menu icon (so it never lined up with the gallery image grid below) and tucked the download action behind either the sidebar or a secondary "Download All" button. Single-image downloads happen in the lightbox per-image; the natural batch action sits next to Logout — one click before leaving.

## What changed

### Menu button
- `frontend/src/components/gallery/GalleryView.tsx` — drops `<span>{t('common.menu')}</span>`; the button now renders just `<Menu />` with `p-2` for tight icon padding.
- `frontend/src/components/gallery/GalleryLayout.tsx` — wraps the menu button in `position: absolute; left: 3/6/8 (responsive); top: 50%; -translate-y-1/2` inside a `relative` container. Logo gets `pl-12 sm:pl-14` *only when a menu button is rendered*, so the logo's left edge sits at the same x-coordinate as the leftmost image (both anchored at `.container` left padding). When no menu button (e.g. classic controls style), the logo is flush with the container — no extra padding.

### Download CTA (new)
- New props on `GalleryLayout`: `showHeaderDownload?: boolean` and `onHeaderDownload?: () => void`. When set, render a button with:
  - `style={{ backgroundColor: 'var(--color-accent)', color: '#ffffff' }}` — accent colour pulled from CSS variable, so the button automatically tracks whatever palette the admin has chosen (legacy `--color-accent: #22c55e` today, the user's CI accent once [#400](https://github.com/the-luap/picpeak/pull/400) lands).
  - Icon-only on mobile (`<span className="hidden sm:inline">Download</span>`).
  - `aria-label="Download"`, focus ring, disabled+loading states.
- Rendered in the standard, hero, and minimal header variants. **Not** in the no-header variant.
- Old `showDownloadAll` is kept on `GalleryLayout` for back-compat, but `GalleryView` now passes `showDownloadAll={false}` so only the new accent button renders in the header. The sidebar's own Download All is untouched.

## Migration safety

- All visible labels and visible behaviour change in the gallery header are the explicit design intent of #386. No backend schema changes.
- `var(--color-accent)` already exists on `upstream/beta` (default `#22c55e`), so the new Download button renders without depending on PR #400.
- No new settings, no migrations, no API surface changes.

## Files changed

```
frontend/src/components/gallery/GalleryView.tsx        (icon-only menu, drop old DownloadAll, wire new button)
frontend/src/components/gallery/GalleryLayout.tsx      (menu absolute-left, new Download button in std/hero/minimal headers, props)
```

## Test plan

- [x] Standard header — menu icon at far left, logo flush with leftmost image, Download button left of Logout in accent colour
- [x] Hero header — menu + headerExtra on left, accent Download + Logout on right
- [x] Minimal header — menu + title on left, accent Download + Logout on right
- [x] No-header — no Download button (intentional)
- [x] `controlsStyle: 'classic'` — no menu icon, logo flush with container left
- [x] Mobile (`<sm`) — Download button shrinks to icon-only
- [x] Disabled / loading state on Download button (during ZIP build) — opacity + no double-click
- [x] `npm run build` (frontend) passes
