### PR TITLE
fix(external-media): pre-generate thumbnails so reference-mode galleries load fast (#423)

### DIFF
--- a/backend/src/routes/adminExternalMedia.js
+++ b/backend/src/routes/adminExternalMedia.js
@@ -7,6 +7,7 @@ const { list, resolveExternalPath, getExternalMediaRoot } = require('../services
 const { db, logActivity } = require('../database/db');
 const sharp = require('sharp');
 const logger = require('../utils/logger');
+const { generateThumbnail } = require('../services/imageProcessor');
 
 const router = express.Router();
 
@@ -93,6 +94,8 @@ router.post('/events/:id/import-external', adminAuth, requirePermission('photos.
     }
 
     let imported = 0;
+    let thumbnailsGenerated = 0;
+    let thumbnailsFailed = 0;
 
     // Insert photos
     for (const f of dedupeMap.values()) {
@@ -137,6 +140,34 @@ router.post('/events/:id/import-external', adminAuth, requirePermission('photos.
           })
           .returning('id');
 
+        const photoId = Array.isArray(inserted) && inserted.length
+          ? (typeof inserted[0] === 'object' ? inserted[0].id : inserted[0])
+          : null;
+
+        // Generate the thumbnail right away so the gallery grid can use the
+        // managed thumbnail endpoint instead of falling back to the full
+        // NAS-streamed original (#423). Best-effort: a single failure logs
+        // a warning and leaves thumbnail_path=null — the gallery's
+        // ensureThumbnail will retry lazily on first view. The cost of
+        // doing this synchronously is ~100-300ms per image; for the
+        // worst-case 1000-photo import that's still under the 5-minute
+        // request timeout typical of the import flow.
+        if (photoId != null) {
+          try {
+            const outputBasename = `ext${photoId}_${path.basename(f.rel)}`;
+            const thumbnailPath = await generateThumbnail(f.full, { outputBasename });
+            if (thumbnailPath) {
+              await db('photos').where({ id: photoId }).update({ thumbnail_path: thumbnailPath });
+              thumbnailsGenerated++;
+            } else {
+              thumbnailsFailed++;
+            }
+          } catch (thumbErr) {
+            thumbnailsFailed++;
+            logger.warn(`Thumbnail generation failed for external photo ${photoId} (${f.rel}): ${thumbErr.message}`);
+          }
+        }
+
         imported += (inserted?.length ? 1 : 0);
       } catch (e) {
         skipped++;
@@ -146,10 +177,14 @@ router.post('/events/:id/import-external', adminAuth, requirePermission('photos.
     // Update event fields
     await db('events').where('id', eventId).update({ source_mode: 'reference', external_path });
 
-    // Queue thumbnail generation lazily by reading thumbnails via ensure endpoint as needed
-    await logActivity('external_import_completed', { event_id: eventId, imported, skipped, external_path }, eventId, { type: 'admin' });
+    await logActivity(
+      'external_import_completed',
+      { event_id: eventId, imported, skipped, thumbnailsGenerated, thumbnailsFailed, external_path },
+      eventId,
+      { type: 'admin' }
+    );
 
-    res.json({ imported, skipped, thumbnailsQueued: 0 });
+    res.json({ imported, skipped, thumbnailsGenerated, thumbnailsFailed });
   } catch (error) {
     logger.error('External media import failed', {
       eventId: req.params.id,

--- a/backend/src/services/imageProcessor.js
+++ b/backend/src/services/imageProcessor.js
@@ -101,10 +101,17 @@ const contentTypeFor = (format) => {
  *
  * Callers must ensure the source is on the local filesystem. For S3 mode
  * regeneration flows, fetch via `withLocalCopy(storage, sourceKey, fn)` first.
+ *
+ * options.outputBasename — override the basename portion of the thumbnail
+ * filename (default: basename of imagePath). Used for external/reference
+ * photos where the source basename can collide across events (#423) — the
+ * import path passes a per-photo unique basename so two events both
+ * referencing `IMG_0001.jpg` don't clobber each other's thumbnail.
  */
 async function generateThumbnail(imagePath, options = {}) {
-  const filename = path.basename(imagePath);
-  const thumbnailFilename = `thumb_${filename}`;
+  const sourceBasename = path.basename(imagePath);
+  const outputBasename = options.outputBasename || sourceBasename;
+  const thumbnailFilename = `thumb_${outputBasename}`;
   const thumbnailRelKey = path.posix.join('thumbnails', thumbnailFilename);
   const storage = getStorage();
 
@@ -168,7 +175,7 @@ async function generateThumbnail(imagePath, options = {}) {
     return thumbnailRelKey;
   } catch (error) {
     const msg = (error && error.message) ? error.message : String(error);
-    logger.error(`Failed to generate thumbnail for ${filename}: ${msg}`);
+    logger.error(`Failed to generate thumbnail for ${sourceBasename}: ${msg}`);
 
     // Clean up any partially uploaded object
     await storage.delete(thumbnailRelKey).catch(() => {});
@@ -220,22 +227,25 @@ async function withLocalCopy(sourceKey, fn) {
 }
 
 /**
- * Regenerate thumbnail if it's broken or missing
+ * Regenerate thumbnail if it's broken or missing.
+ *
+ * Works for both managed photos (stored via the storage backend, possibly
+ * S3) and external/reference photos (#423 — sourced from a local mount
+ * outside the managed storage tree, e.g. NAS over SMB/NFS). External
+ * photos historically had thumbnail_path=null, which forced the gallery
+ * to fall back to streaming the full original on every tile — minutes of
+ * load time for a 100-photo NAS-mounted gallery.
  */
 async function ensureThumbnail(photo) {
-  const { resolvePhotoStorageKey } = require('./photoResolver');
-  let sourceKey;
-  try {
-    const event = await db('events').where('id', photo.event_id).first();
-    sourceKey = resolvePhotoStorageKey(event, photo);
-    logger.info(`Ensuring thumbnail for photo ${photo.id} from key: ${sourceKey}`);
-  } catch (e) {
-    const msg = (e && e.message) ? e.message : String(e);
-    logger.error(`Failed to resolve original key for thumbnail (photo ${photo.id}): ${msg}`);
+  const { resolvePhotoStorageKey, resolvePhotoFilePath } = require('./photoResolver');
+
+  const event = await db('events').where('id', photo.event_id).first();
+  if (!event) {
+    logger.error(`ensureThumbnail: event ${photo.event_id} not found for photo ${photo.id}`);
     return null;
   }
 
-  // Check if thumbnail exists and is valid
+  // Check if thumbnail exists and is valid (works for any source).
   if (photo.thumbnail_path) {
     const isValid = await isThumbnailValid(photo.thumbnail_path);
     if (isValid) {
@@ -244,10 +254,38 @@ async function ensureThumbnail(photo) {
     logger.warn(`Invalid thumbnail detected for photo ${photo.id}, regenerating...`);
   }
 
-  // Generate new thumbnail (sources via withLocalCopy so this works in S3 mode)
-  const newThumbnailPath = await withLocalCopy(sourceKey, (localPath) =>
-    generateThumbnail(localPath, { regenerate: true })
-  );
+  const isExternal = photo.source_origin === 'external' || photo.source_origin === 'reference';
+
+  let newThumbnailPath;
+  if (isExternal) {
+    // External: source is on a local mount path. No withLocalCopy needed
+    // (storage-backend abstraction doesn't apply — this is a direct fs
+    // read). Use a per-photo unique outputBasename so two events both
+    // referencing the same NAS basename can't clobber each other's thumb.
+    let localPath;
+    try {
+      localPath = resolvePhotoFilePath(event, photo);
+    } catch (e) {
+      logger.error(`Failed to resolve external file for thumbnail (photo ${photo.id}): ${e.message}`);
+      return null;
+    }
+    const sourceBasename = path.basename(photo.external_relpath || photo.filename || `photo-${photo.id}`);
+    const outputBasename = `ext${photo.id}_${sourceBasename}`;
+    logger.info(`Ensuring thumbnail for external photo ${photo.id} from ${localPath}`);
+    newThumbnailPath = await generateThumbnail(localPath, { regenerate: true, outputBasename });
+  } else {
+    let sourceKey;
+    try {
+      sourceKey = resolvePhotoStorageKey(event, photo);
+    } catch (e) {
+      logger.error(`Failed to resolve original key for thumbnail (photo ${photo.id}): ${e.message}`);
+      return null;
+    }
+    logger.info(`Ensuring thumbnail for photo ${photo.id} from key: ${sourceKey}`);
+    newThumbnailPath = await withLocalCopy(sourceKey, (localPath) =>
+      generateThumbnail(localPath, { regenerate: true })
+    );
+  }
 
   if (newThumbnailPath) {
     await db('photos')


### PR DESCRIPTION
Closes #423 (reported by @Luca-Timo).

## What was happening

External (`source_origin='external'`) photos always had `thumbnail_path = NULL` in the photos table, so:
- `/api/gallery/<slug>/photos` returned `thumbnail_url: null` for every external row
- Every gallery layout (`PhotoGrid.tsx`, `JustifiedGalleryLayout.tsx`, `MosaicGalleryLayout.tsx`, etc.) does `src={photo.thumbnail_url || photo.url}` — so it falls back to the **full original** when the thumbnail is missing
- The full original is served via the secure-image route, which streams it through the backend (Sharp processing + token verification + access logging) — fine for ~5 MB/s SSDs, terrible for SMB/NFS-mounted NAS with 2-3 MB/s sustained reads
- 100 photos × seconds of NAS streaming each = the multi-minute load Luca saw

The 2-tile-after-1-minute screenshot in the issue is exactly this fall-through: tiles are sequentially streaming originals instead of small pre-rendered JPEG thumbnails.

## What changed

Two complementary halves so both new imports AND already-imported externals are fast.

### 1. `import-external` route generates thumbnails per photo

`backend/src/routes/adminExternalMedia.js` — after each successful insert, calls `generateThumbnail(f.full, { outputBasename: 'ext<photoId>_<basename>' })` and writes `thumbnail_path` on the row.

- **Best-effort**: a single thumbnail failure logs a warning and leaves `thumbnail_path = NULL` — the lazy regen path (#2 below) handles those rows on first view. Doesn't block the rest of the import.
- **Cost**: ~100-300ms per image synchronously in the loop. Worst-case 1000-photo import is still under typical request timeouts. Faster than the previous "fast-import, slow-browse forever" tradeoff.
- Response shape extended: `{imported, skipped, thumbnailsGenerated, thumbnailsFailed}` (was `{imported, skipped, thumbnailsQueued: 0}`).

### 2. `ensureThumbnail()` now handles external photos

`backend/src/services/imageProcessor.js` — branches on `photo.source_origin`. For external photos:
- Resolves the local NAS-mounted path via `resolvePhotoFilePath(event, photo)` (the existing helper that already knows about external mode)
- Skips the `withLocalCopy(storageKey)` materialization — the source is already on a local fs path
- Passes `outputBasename: 'ext<id>_<basename>'` so the thumbnail filename can't collide

This means **already-imported external photos** (from before this fix lands) auto-recover on first gallery view: the thumbnail endpoint regenerates and persists. First view per photo is slow (one NAS read + one Sharp encode); subsequent views read from the local thumbnails dir like any managed photo.

### Filename collision protection

External photos can share basenames across events (NAS-mounted dirs reuse `IMG_0001.jpg` patterns). The previous `thumb_<basename>` would clobber.

Added `options.outputBasename` to `generateThumbnail()` — managed callers ignore it (default = source basename, unchanged behaviour). External callers pass `ext<photoId>_<basename>` for guaranteed uniqueness without changing how managed thumbnails are named or addressed.

## What's NOT in this PR

- **"Refresh external media" button** (Luca's suggested point #4 in the issue): the existing `import-external` flow already handles re-scan via the dedupe-by-`external_relpath` check. Re-running it picks up new files without re-importing existing ones. A dedicated "Refresh thumbnails" button to *force-regenerate* existing thumbnails (e.g. after rotating an image on the NAS) is a small follow-up — `ensureThumbnail` already does the right thing on a 404, but a one-click "regenerate everything" admin endpoint would be nice. Not blocking on this PR.
- **Frontend changes**: none. The layouts already prefer `photo.thumbnail_url` when present; we're just making sure it IS present.

## Verification

Local sanity against the dev stack with 3 test JPEGs in `EXTERNAL_MEDIA_ROOT/test-event/individual/`:

```
$ POST /api/admin/external-media/events/1113/import-external
  → {"imported":3, "skipped":0, "thumbnailsGenerated":3, "thumbnailsFailed":0}

$ SELECT id, filename, source_origin, thumbnail_path FROM photos WHERE event_id=1113;
   id  |   filename   | source_origin |            thumbnail_path
  -----+--------------+---------------+---------------------------------------
  1081 | IMG_0000.jpg | external      | thumbnails/thumb_ext1081_IMG_0000.jpg
  1082 | IMG_0001.jpg | external      | thumbnails/thumb_ext1082_IMG_0001.jpg
  1083 | IMG_0002.jpg | external      | thumbnails/thumb_ext1083_IMG_0002.jpg

$ ls /app/storage/thumbnails/ | grep ext
  thumb_ext1081_IMG_0000.jpg
  thumb_ext1082_IMG_0001.jpg
  thumb_ext1083_IMG_0002.jpg

$ GET /api/gallery/<slug>/photos
  → all rows include thumbnail_url ✓
```

Lazy-regen path (covers existing externals already in production):

```
# Set thumbnail_path=NULL + delete the file from disk to simulate a legacy row
$ UPDATE photos SET thumbnail_path = NULL WHERE id = 1081
$ rm /app/storage/thumbnails/thumb_ext1081_IMG_0000.jpg

$ GET /api/gallery/<slug>/thumbnail/1081
  → 200 OK, 601 bytes, JPEG 300x300
  Backend log: "Ensuring thumbnail for external photo 1081 from /app/storage/external-media/.../IMG_0000.jpg"
                "Regenerated thumbnail for photo 1081"
  Round-trip: 42ms
  DB after: thumbnail_path repopulated ✓
```

Backend unit tests: **13 suites, 131/132 passing** (1 pre-existing skip).
Lint clean on touched files (the one warning on `getExternalMediaRoot` is pre-existing on beta — not introduced by this PR).

## Test plan

- [ ] Run migrations on dev (no migration changes in this PR — schema unchanged)
- [ ] Mount a directory of ~10+ external photos under `EXTERNAL_MEDIA_ROOT`
- [ ] Create a `source_mode='reference'` event and run import
- [ ] Confirm response includes `thumbnailsGenerated > 0`
- [ ] Confirm `photos.thumbnail_path` is populated for new external rows
- [ ] Open the gallery — tiles should render at thumbnail speed (sub-second), not the previous multi-minute streaming
- [ ] (For existing externals from before the fix) Open an old reference-mode gallery — first view per photo is one slow NAS read; thumbnails accumulate; subsequent views are fast
- [ ] Original-resolution view (lightbox / Download All) still works — should still stream from the NAS, unchanged