### PR TITLE
Fix/update event access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Bug Fixes
+
+* **event:** fix updating client access ([ee85e1d](https://github.com/the-luap/picpeak/commit/ee85e1d))
+
 ### Features
 
 * **i18n:** add French (fr) language support with full translation coverage

--- a/backend/src/routes/adminEvents.js
+++ b/backend/src/routes/adminEvents.js
@@ -1277,7 +1277,7 @@ router.put('/:id', adminAuth, requirePermission('events.edit'), requireEventOwne
     if (Object.prototype.hasOwnProperty.call(updates, 'client_access_enabled')) {
       updates.client_access_enabled = formatBoolean(updates.client_access_enabled);
       // Auto-generate client share token when first enabling
-      if (parseBooleanInput(updates.client_access_enabled, false) && !event.client_share_token) {
+      if (parseBooleanInput(updates.client_access_enabled, false) && !event.client_share_token && !updates.client_share_token) {
         updates.client_share_token = crypto.randomBytes(32).toString('hex');
       }
     }

--- a/backend/src/routes/adminEvents.js
+++ b/backend/src/routes/adminEvents.js
@@ -1192,14 +1192,6 @@ router.put('/:id', adminAuth, requirePermission('events.edit'), requireEventOwne
       return res.status(400).json({ error: 'external_path is required when source_mode is reference' });
     }
 
-    // Handle client access fields (#172)
-    if (Object.prototype.hasOwnProperty.call(updates, 'client_access_enabled')) {
-      updates.client_access_enabled = formatBoolean(updates.client_access_enabled);
-      // Auto-generate client share token when first enabling
-      if (parseBooleanInput(updates.client_access_enabled, false) && !event.client_share_token) {
-        updates.client_share_token = crypto.randomBytes(32).toString('hex');
-      }
-    }
     if (Object.prototype.hasOwnProperty.call(updates, 'client_password') && updates.client_password) {
       updates.client_password_hash = await bcrypt.hash(updates.client_password, getBcryptRounds());
       delete updates.client_password;
@@ -1278,6 +1270,15 @@ router.put('/:id', adminAuth, requirePermission('events.edit'), requireEventOwne
         }
       } catch (_) {
         // color_theme is not JSON (e.g. preset name) – nothing to extract
+      }
+    }
+
+    // Handle client access fields (#172)
+    if (Object.prototype.hasOwnProperty.call(updates, 'client_access_enabled')) {
+      updates.client_access_enabled = formatBoolean(updates.client_access_enabled);
+      // Auto-generate client share token when first enabling
+      if (parseBooleanInput(updates.client_access_enabled, false) && !event.client_share_token) {
+        updates.client_share_token = crypto.randomBytes(32).toString('hex');
       }
     }
 


### PR DESCRIPTION
 ## Description

Fixes a runtime error in the event update handler where event.client_share_token was accessed before event had been fetched from the database.
  
Root cause: The auto-generation check for the client share token referenced event.client_share_token, but event is not defined until later in the handler (after the DB query). This caused a crash when updating an event with client_access_enabled: true.

The fix replaces the reference to the (not-yet-defined) event object with updates.client_share_token, which is always available from the request payload at that point in the handler.

  Fixes # (issue)

## Type of change

  - [X] Bug fix (non-breaking change which fixes an issue)

 ## Checklist:
 
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published
- [X] I have updated the CHANGELOG.md file


 ## Additional Notes: