### PR TITLE
fix(auth): default COOKIE_SECURE to 'auto' in production + first-install UX (#427)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -10,18 +10,31 @@ PORT=3001
 JWT_SECRET=your-very-secure-jwt-secret-at-least-32-characters-long-example123456
 
 # Auth cookie Secure flag
-#   unset  - default: follows NODE_ENV (production=true, dev=false)
-#   true   - always set Secure (HTTPS-only cookies; breaks plain-HTTP access)
+#   unset  - default: 'auto' in production, false in dev (#427)
+#   true   - always set Secure (HTTPS-only cookies; breaks plain-HTTP access —
+#            login appears to succeed but the browser silently drops the
+#            cookie, leaving you in a redirect loop. Only set this if you
+#            ALWAYS reach the site via HTTPS)
 #   false  - never set Secure (allows HTTP; cookies not protected on HTTPS)
-#   auto   - decide per request: Secure on HTTPS, not on HTTP
+#   auto   - decide per request: Secure on HTTPS, not on HTTP. Reads
+#            req.secure from Express which respects X-Forwarded-Proto from a
+#            trusted reverse proxy. This is the default and is the right
+#            choice for most deployments.
 #
-# Use COOKIE_SECURE=auto if your deployment is reachable over both HTTPS
-# (via a reverse proxy like Nginx Proxy Manager, Traefik, Caddy) AND plain
-# HTTP (e.g. LAN access at http://192.168.x.x:3001). The backend reads
-# req.secure from Express, which respects the X-Forwarded-Proto header
-# when the proxy is in the trust list.
+# Why 'auto' is the default in production:
+#   - On real HTTPS (reverse proxy with X-Forwarded-Proto), req.secure is
+#     true → Secure flag is still emitted. No security regression vs. true.
+#   - On plain HTTP (LAN access, first-time install before reverse proxy is
+#     wired up), req.secure is false → Secure flag is omitted → login works
+#     instead of silently looping back to /admin/login.
 #
-# Requirements for auto mode:
+# When you'd set this explicitly:
+#   - COOKIE_SECURE=true → strict HTTPS-only deployments where you want
+#     defense in depth against accidentally serving over HTTP.
+#   - COOKIE_SECURE=false → you intentionally only ever serve over HTTP and
+#     don't want the per-request check (rare).
+#
+# Requirements for 'auto' mode to detect HTTPS correctly:
 #   1. Your reverse proxy MUST send X-Forwarded-Proto: https on HTTPS
 #      requests. Standard configs for NPM/Traefik/Caddy do this by default.
 #   2. The proxy must be on a trusted IP range. By default PicPeak trusts

--- a/backend/src/utils/tokenUtils.js
+++ b/backend/src/utils/tokenUtils.js
@@ -7,15 +7,24 @@ const DEFAULT_MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24 hours
 
 /**
  * Cookie "Secure" flag mode:
- *   - true   → always set Secure (HTTPS-only)
- *   - false  → never set Secure (allow plain HTTP)
+ *   - true   → always set Secure (HTTPS-only — cookie won't be sent over HTTP at all)
+ *   - false  → never set Secure (allow plain HTTP — cookie has no in-flight protection)
  *   - 'auto' → decide per-request based on req.secure (X-Forwarded-Proto
- *              via Express `trust proxy`). Useful when the same deployment
- *              is reachable over both HTTPS (via reverse proxy) and LAN HTTP.
+ *              via Express `trust proxy`). Emits Secure when actual HTTPS is
+ *              detected, omits it on plain HTTP. This is the right default
+ *              for deployments reachable via both HTTPS (reverse proxy) and
+ *              LAN HTTP, and for first-time installs that haven't set up a
+ *              reverse proxy yet.
  *
- * Default: follows NODE_ENV (production → true, dev → false) — unchanged
- * from previous behavior. Users who want the auto mode must opt in with
- * COOKIE_SECURE=auto in their .env.
+ * Default:
+ *   - production → 'auto'  (#427: previously hard `true`, which caused silent
+ *                  login loops over HTTP because the browser drops the
+ *                  Secure cookie. 'auto' is strictly more lenient than `true`
+ *                  on real HTTPS — req.secure is true → Secure flag still
+ *                  emitted — so this is not a security regression for
+ *                  reverse-proxy deployments. Users who explicitly want the
+ *                  HTTPS-only behaviour can still set COOKIE_SECURE=true.)
+ *   - dev → false (allow http://localhost in browsers without HSTS gymnastics)
  */
 const secureCookieMode = (() => {
   const raw = typeof process.env.COOKIE_SECURE === 'string'
@@ -24,8 +33,10 @@ const secureCookieMode = (() => {
   if (raw === 'auto') return 'auto';
   if (raw === 'true') return true;
   if (raw === 'false') return false;
-  // No env var set → legacy default
-  return process.env.NODE_ENV === 'production';
+  // No env var set → infer from NODE_ENV. Production defaults to 'auto'
+  // (per-request) rather than hard `true` so first-time HTTP installs don't
+  // silently fail (#427).
+  return process.env.NODE_ENV === 'production' ? 'auto' : false;
 })();
 const sameSiteDefault = process.env.COOKIE_SAMESITE || 'Lax';
 const cookieDomain = process.env.COOKIE_DOMAIN;

--- a/scripts/picpeak-setup.sh
+++ b/scripts/picpeak-setup.sh
@@ -490,6 +490,13 @@ SMTP_FROM=${SMTP_USER:-noreply@localhost}
 FRONTEND_URL=${DOMAIN_NAME:+https://$DOMAIN_NAME}
 ADMIN_URL=${DOMAIN_NAME:+https://$DOMAIN_NAME}
 
+# Auth cookie behavior — 'auto' emits Secure on HTTPS, omits it on HTTP.
+# Without this, first-time HTTP installs (no reverse proxy yet) silently
+# fail at login because the browser drops Secure cookies over HTTP (#427).
+# On HTTPS via reverse proxy, req.secure is true → Secure flag is still
+# emitted, so this is not a security regression for production deploys.
+COOKIE_SECURE=auto
+
 # Features
 ENABLE_FILE_WATCHER=true
 ENABLE_EXPIRATION_CHECKER=true
@@ -499,27 +506,27 @@ EOF
 
     # Ensure bind mounts are writable by mapped user
     chown -R "$host_uid":"$host_gid" "$app_dir"/storage "$app_dir"/logs "$app_dir"/backup "$app_dir"/data "$app_dir"/events 2>/dev/null || true
-    
+
     # Create docker-compose.yml if it doesn't exist
     if [[ ! -f "$app_dir/docker-compose.yml" ]]; then
         log_step "Creating Docker Compose configuration..."
         create_docker_compose_file "$app_dir"
     fi
-    
+
     # Set up SSL if requested
     if [[ "$ENABLE_SSL" == "true" ]] && [[ -n "$DOMAIN_NAME" ]]; then
         setup_ssl_docker "$app_dir"
     fi
-    
+
     # Start services
     log_step "Starting services..."
     cd "$app_dir"
     docker compose up -d
-    
+
     # Wait for services to be ready
     log_step "Waiting for services to initialize..."
     sleep 10
-    
+
     # Run database migrations
     log_step "Running database migrations..."
     docker compose exec -T backend npm run migrate
@@ -532,7 +539,28 @@ EOF
             log_warn "Automatic admin password reset failed; run reset-admin-password.js inside the backend container."
         fi
     fi
-    
+
+    # Always surface the admin credentials file (#427: iSchumi reported
+    # admins couldn't find the generated password — the migration writes it
+    # to the in-container path and we never copied it to the host unless
+    # --reset-admin-password was used). Best-effort: a missing file just
+    # means the migration ran on a pre-existing DB and didn't generate one.
+    if docker compose cp backend:/app/data/ADMIN_CREDENTIALS.txt "$app_dir/data/ADMIN_CREDENTIALS.txt" 2>/dev/null; then
+        chown "$host_uid":"$host_gid" "$app_dir/data/ADMIN_CREDENTIALS.txt" 2>/dev/null || true
+        chmod 600 "$app_dir/data/ADMIN_CREDENTIALS.txt" 2>/dev/null || true
+        log_step "Admin credentials saved to: $app_dir/data/ADMIN_CREDENTIALS.txt"
+        # Show the password in the install output so the operator can log
+        # in immediately. The file remains as a backup record.
+        echo
+        echo "--------------------------------------------------"
+        grep -E '^Email:|^Password:' "$app_dir/data/ADMIN_CREDENTIALS.txt" 2>/dev/null || true
+        echo "--------------------------------------------------"
+        echo "  Login URL: ${DOMAIN_NAME:+https://$DOMAIN_NAME}${DOMAIN_NAME:-http://YOUR_HOST_IP:3000}/admin"
+        echo "  Full credentials file: $app_dir/data/ADMIN_CREDENTIALS.txt"
+        echo "  Delete the file after recording the password."
+        echo
+    fi
+
     log_success "Docker installation completed!"
 }
 
@@ -766,6 +794,9 @@ SMTP_FROM=${SMTP_USER:-noreply@localhost}
 FRONTEND_URL=${DOMAIN_NAME:+https://$DOMAIN_NAME}
 ADMIN_URL=${DOMAIN_NAME:+https://$DOMAIN_NAME}
 
+# Auth cookie behavior — see Docker .env block above for rationale (#427).
+COOKIE_SECURE=auto
+
 # Features
 ENABLE_FILE_WATCHER=true
 ENABLE_EXPIRATION_CHECKER=true
@@ -780,11 +811,11 @@ LOG_LEVEL=info
 SERVE_FRONTEND=true
 FRONTEND_DIR=$NATIVE_APP_DIR/app/frontend/dist
 EOF
-    
+
     # Set permissions
     chown -R $NATIVE_APP_USER:$NATIVE_APP_USER "$NATIVE_APP_DIR"
     chmod 600 "$NATIVE_APP_DIR/app/backend/.env"
-    
+
     # Run database migrations
     log_step "Initializing database..."
     cd "$NATIVE_APP_DIR/app/backend"
@@ -796,7 +827,22 @@ EOF
             log_warn "Automatic admin password reset failed; please run reset-admin-password.js manually."
         fi
     fi
-    
+
+    # Always surface the admin credentials file (#427).
+    local creds_path="$NATIVE_APP_DIR/app/backend/data/ADMIN_CREDENTIALS.txt"
+    if [[ -f "$creds_path" ]]; then
+        chmod 600 "$creds_path" 2>/dev/null || true
+        log_step "Admin credentials saved to: $creds_path"
+        echo
+        echo "--------------------------------------------------"
+        grep -E '^Email:|^Password:' "$creds_path" 2>/dev/null || true
+        echo "--------------------------------------------------"
+        echo "  Login URL: ${DOMAIN_NAME:+https://$DOMAIN_NAME}${DOMAIN_NAME:-http://YOUR_HOST_IP:${CUSTOM_PORT:-$DEFAULT_PORT}}/admin"
+        echo "  Full credentials file: $creds_path"
+        echo "  Delete the file after recording the password."
+        echo
+    fi
+
     # Create systemd services
     create_systemd_services
     


### PR DESCRIPTION
Fixes #427 (reported by @iSchumi6210, also confirmed by @Rekoo-PS in the comments).

## What was broken

Two intertwined bugs that made first-install UX painful:

### 1. Login silently fails over HTTP

- Backend defaulted `COOKIE_SECURE` to `true` whenever `NODE_ENV=production`
- `picpeak-setup.sh` writes `NODE_ENV=production` and never writes `COOKIE_SECURE`
- Over plain HTTP the browser drops the `Secure` cookie → next `/auth/session` request returns 401 → redirect back to `/admin/login` → no error shown
- Backend log shows nothing because the `/auth/session` request never hits the auth path

DevTools is the only way to diagnose this. New users without DevTools experience just see the login page bouncing.

### 2. Admin credentials are generated but invisible

The `001_init.js` migration writes the generated random password to `data/ADMIN_CREDENTIALS.txt` inside the backend container. But `picpeak-setup.sh` only copies that file out to the host when `--reset-admin-password` is passed. Default-path users never see the file → resort to manually updating the bcrypt hash in psql to log in.

iSchumi noted both in the issue + comment thread.

## What changed

### `backend/src/utils/tokenUtils.js`

Production default goes from `true` → `'auto'`.

- On real HTTPS via reverse proxy: `req.secure` is `true` → `Secure` flag still emitted. **No security regression** for HTTPS deployments.
- On plain HTTP: `req.secure` is `false` → `Secure` flag omitted → login works.
- Users who explicitly want strict HTTPS-only behavior can still set `COOKIE_SECURE=true`.

### `backend/.env.example`

Rewrite the `COOKIE_SECURE` block to make the new default obvious and explain *when* you'd override:
- Leave unset → `auto` in production. Right for almost everyone.
- `=true` → strict HTTPS-only (defense in depth on a deployment where you know HTTPS is the only access path)
- `=false` → opt-out of the per-request check entirely (rare)

### `scripts/picpeak-setup.sh` (both Docker and native install paths)

- Write `COOKIE_SECURE=auto` explicitly to the generated `.env`. Defense in depth — even if the backend default ever flips back, the user's `.env` says what they want.
- After migrations, **always** copy `ADMIN_CREDENTIALS.txt` from the backend data dir to the host, `chmod 600`, and print email + password to the install output. The credentials file stays as a backup record that the operator should delete after noting the password.

## Why 'auto' as the default isn't a security regression

`auto` mode reads `req.secure`, which Express derives from `X-Forwarded-Proto` when the proxy is in the trust list. The trust list (`127.0.0.1`, `10.x`, `172.16-31.x`, `192.168.x`, link-local) is the same one that's been in production for a long time.

- HTTPS via trusted proxy → `req.secure=true` → `Secure` flag → identical behaviour to old `true` default
- HTTP → `req.secure=false` → no `Secure` flag → cookie works (was previously a silent loop)
- HTTPS via untrusted proxy that doesn't forward `X-Forwarded-Proto` → `req.secure=false` → no `Secure` flag → degraded but still works (and this is the same misconfiguration you'd have to fix anyway for correct downstream `https` URL generation, etc.)

The risk vector is "MITM between proxy and backend on a misconfigured deploy." That risk already exists because the proxy → backend traffic is plain HTTP regardless of cookie flag. The Secure flag only protects the *browser → proxy* leg, which `auto` correctly handles when the proxy is configured even minimally.

## Verification

Tested all 4 permutations of `NODE_ENV` × `COOKIE_SECURE` in the dev container:

| `NODE_ENV` | `COOKIE_SECURE` | HTTPS req | HTTP req |
|---|---|---|---|
| production | (unset)  | `secure: true` ✓ | `secure: false` ✓ ← **was broken before** |
| production | `=true`  | `secure: true` | `secure: true` ← strict opt-in preserved |
| production | `=auto`  | `secure: true` | `secure: false` ← already-correct case |
| development | (unset) | `secure: false` | `secure: false` ← dev unchanged |

Lint clean on touched file.

## Test plan

- [ ] Fresh `picpeak-setup.sh` install on an HTTP-only test box (e.g. LXC without reverse proxy)
- [ ] Verify `.env` contains `COOKIE_SECURE=auto`
- [ ] Verify install output prints the admin email + password and writes `data/ADMIN_CREDENTIALS.txt` with `chmod 600`
- [ ] Verify login works over `http://IP:3000/admin` without DevTools workaround
- [ ] Network tab: `Set-Cookie` should NOT have `Secure` flag on HTTP, SHOULD have it on HTTPS
- [ ] Existing HTTPS-via-reverse-proxy deployments: behaviour unchanged (Secure flag still emitted via `req.secure`)
- [ ] Strict mode opt-in: setting `COOKIE_SECURE=true` in `.env` still forces Secure on every cookie