### PR TITLE
docs(contributing): update branch reference from main to beta

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ Unsure where to begin? You can start by looking through these issues:
 
 ### Pull Requests
 
-1. **Fork the repo** and create your branch from `main`
+1. **Fork the repo** and create your branch from `beta`
 2. **Install dependencies**:
    ```bash
    cd backend && npm install


### PR DESCRIPTION
## Summary

  - Update the CONTRIBUTING.md guide to instruct contributors to fork from `beta` instead of `main`

 ## Why

  Contributions should target the `beta` branch, not `main`, as `main` is reserved for stable releases. The previous instruction was misleading contributors to base their PRs on the wrong branch.

 ## Test plan

  - Confirm the branch name `beta` is accurate