### PR TITLE
fix(gallery): serve thumbnails / photos / hero via storage abstraction (#432)

### DIFF
--- a/backend/src/routes/gallery.js
+++ b/backend/src/routes/gallery.js
@@ -13,7 +13,7 @@ const { resolvePhotoFilePath } = require('../services/photoResolver');
 const { getEventShareToken, resolveShareIdentifier, buildShareLinkVariants } = require('../services/shareLinkService');
 const { handleAsync } = require('../utils/routeHelpers');
 const { NotFoundError } = require('../utils/errors');
-const { ensureThumbnail, ensureHeroImage } = require('../services/imageProcessor');
+const { ensureThumbnail, ensureHeroImage, withLocalCopy } = require('../services/imageProcessor');
 const downloadZipService = require('../services/downloadZipService');
 const { getStorage } = require('../services/storage');
 const fs = require('fs');
@@ -749,8 +749,8 @@ router.get('/:slug/download-all', verifyGalleryAccess, async (req, res) => {
 
           const watermarkedBuffer = storageKey
             ? await withLocalCopy(storageKey, (localPath) =>
-                watermarkService.applyWatermark(localPath, effectiveSettings)
-              )
+              watermarkService.applyWatermark(localPath, effectiveSettings)
+            )
             : await watermarkService.applyWatermark(sourceForWatermark, effectiveSettings);
 
           archive.append(watermarkedBuffer, { name: archiveName });
@@ -863,8 +863,8 @@ router.post('/:slug/download-selected', verifyGalleryAccess, async (req, res) =>
         if (shouldApplyWatermark && effectiveSettings) {
           const buf = storageKey
             ? await withSelectedLocalCopy(storageKey, (lp) =>
-                watermarkService.applyWatermark(lp, effectiveSettings)
-              )
+              watermarkService.applyWatermark(lp, effectiveSettings)
+            )
             : await watermarkService.applyWatermark(resolvePhotoFilePath(req.event, photo), effectiveSettings);
           archive.append(buf, { name });
         } else if (storageKey) {
@@ -937,58 +937,83 @@ router.get('/:slug/photo/:photoId',
         });
       }
 
-      // Resolve the absolute file path for this photo, supporting both managed and external reference modes
-      const { resolvePhotoFilePath } = require('../services/photoResolver');
-      const fs = require('fs');
+      // Resolve where to read the photo bytes from. For external/reference
+      // photos the source is always a local mount path. For managed photos
+      // we go through the storage abstraction so S3 deployments work too
+      // (#432 — previously this route did fs.* directly and 500'd in S3
+      // mode because the file wasn't on the container's local fs).
+      const { resolvePhotoStorageKey, resolvePhotoFilePath } = require('../services/photoResolver');
+      const storage = getStorage();
+      const isExternal = photo.source_origin === 'external' || photo.source_origin === 'reference';
+      const useStorageBackend = !isExternal;
 
-      let filePath;
-      try {
-        filePath = resolvePhotoFilePath(req.event, photo);
-      } catch (resolveError) {
-        logger.error('Failed to resolve photo path', {
-          slug: req.params.slug,
-          photoId,
-          eventId: req.event.id,
-          error: resolveError.message,
-          photoPath: photo.path,
-          photoFilename: photo.filename
-        });
-        return res.status(404).json({ error: 'Photo file not found' });
+      let filePath = null;     // Local fs path (external photos OR LocalFs storage)
+      let storageKey = null;   // Relative storage key (managed photos via storage abstraction)
+      let stat;
+      let fileSize;
+
+      if (useStorageBackend) {
+        try {
+          storageKey = resolvePhotoStorageKey(req.event, photo);
+        } catch (resolveError) {
+          logger.error('Failed to resolve photo storage key', {
+            slug: req.params.slug,
+            photoId,
+            eventId: req.event.id,
+            error: resolveError.message,
+            photoPath: photo.path,
+            photoFilename: photo.filename
+          });
+          return res.status(404).json({ error: 'Photo file not found' });
+        }
+        stat = await storage.stat(storageKey);
+        if (!stat) {
+          logger.error('Photo not found in storage backend', {
+            slug: req.params.slug,
+            photoId,
+            eventId: req.event.id,
+            storageKey
+          });
+          return res.status(404).json({ error: 'Photo file not found' });
+        }
+        fileSize = stat.size;
+      } else {
+        try {
+          filePath = resolvePhotoFilePath(req.event, photo);
+        } catch (resolveError) {
+          logger.error('Failed to resolve photo path', {
+            slug: req.params.slug,
+            photoId,
+            eventId: req.event.id,
+            error: resolveError.message,
+            photoPath: photo.path,
+            photoFilename: photo.filename
+          });
+          return res.status(404).json({ error: 'Photo file not found' });
+        }
+        if (!fs.existsSync(filePath)) {
+          logger.error('Photo file does not exist at resolved path', {
+            slug: req.params.slug,
+            photoId,
+            eventId: req.event.id,
+            resolvedPath: filePath,
+            photoPath: photo.path
+          });
+          return res.status(404).json({ error: 'Photo file not found' });
+        }
+        stat = fs.statSync(filePath);
+        fileSize = stat.size;
       }
-
-      // Verify file exists before attempting to serve
-      if (!fs.existsSync(filePath)) {
-        logger.error('Photo file does not exist at resolved path', {
-          slug: req.params.slug,
-          photoId,
-          eventId: req.event.id,
-          resolvedPath: filePath,
-          photoPath: photo.path
-        });
-        return res.status(404).json({ error: 'Photo file not found' });
-      }
-
-      // Log access - temporarily disabled for debugging
-      // await secureImageService.logImageAccess(
-      //   photoId,
-      //   req.event.id,
-      //   req.clientInfo,
-      //   'view_basic'
-      // );
 
       // Handle video streaming with range requests
       if (isVideo) {
-        const stat = fs.statSync(filePath);
-        const fileSize = stat.size;
         const range = req.headers.range;
 
         if (range) {
-          // Parse range header
           const parts = range.replace(/bytes=/, '').split('-');
           const start = parseInt(parts[0], 10);
           const end = parts[1] ? parseInt(parts[1], 10) : fileSize - 1;
           const chunksize = (end - start) + 1;
-          const file = fs.createReadStream(filePath, { start, end });
 
           res.writeHead(206, {
             'Content-Range': `bytes ${start}-${end}/${fileSize}`,
@@ -999,9 +1024,11 @@ router.get('/:slug/photo/:photoId',
             'X-Protection-Level': 'basic'
           });
 
+          const file = useStorageBackend
+            ? await storage.getRange(storageKey, start, end)
+            : fs.createReadStream(filePath, { start, end });
           file.pipe(res);
         } else {
-          // No range request, send entire file
           res.writeHead(200, {
             'Content-Length': fileSize,
             'Content-Type': photo.mime_type || 'video/mp4',
@@ -1009,53 +1036,69 @@ router.get('/:slug/photo/:photoId',
             'Cache-Control': 'private, max-age=1800',
             'X-Protection-Level': 'basic'
           });
-
-          fs.createReadStream(filePath).pipe(res);
+          const file = useStorageBackend
+            ? await storage.get(storageKey)
+            : fs.createReadStream(filePath);
+          file.pipe(res);
         }
         return;
       }
 
-      // Handle images (existing logic)
-      // Get watermark settings
+      // Image path
       const watermarkSettings = await watermarkService.getWatermarkSettings();
 
-      // Generate ETag based on photo id, modification time, and watermark settings
-      // This ensures cache invalidation when watermark settings change
-      const stat = fs.statSync(filePath);
+      const mtimeMs = stat.mtime ? stat.mtime.getTime() : 0;
       const watermarkHash = watermarkSettings?.enabled
         ? `-wm${watermarkSettings.opacity}${watermarkSettings.position}${watermarkSettings.size}`
         : '-nowm';
-      const etag = `"${photoId}-${stat.mtime.getTime()}${watermarkHash}"`;
+      const etag = `"${photoId}-${mtimeMs}${watermarkHash}"`;
 
-      // Check if client has valid cached version
       if (req.headers['if-none-match'] === etag) {
         return res.status(304).end();
       }
 
       if (watermarkSettings && watermarkSettings.enabled) {
-        // Try to serve pre-generated watermarked file for instant loading
+        // Pre-generated watermarked file: served via the storage backend
+        // (managed) or directly from local fs (external).
         if (photo.watermark_path) {
-          const watermarkFilePath = path.join(getStoragePath(), photo.watermark_path);
           try {
-            // Check if pre-generated watermark file exists
-            if (fs.existsSync(watermarkFilePath)) {
-              res.set({
-                'Content-Type': photo.mime_type || 'image/jpeg',
-                'Cache-Control': 'private, max-age=1800',
-                'ETag': etag,
-                'X-Protection-Level': 'basic'
-              });
-              return res.sendFile(watermarkFilePath);
+            if (useStorageBackend) {
+              const wmStat = await storage.stat(photo.watermark_path);
+              if (wmStat) {
+                res.set({
+                  'Content-Type': photo.mime_type || 'image/jpeg',
+                  'Content-Length': wmStat.size,
+                  'Cache-Control': 'private, max-age=1800',
+                  'ETag': etag,
+                  'X-Protection-Level': 'basic'
+                });
+                const wmStream = await storage.get(photo.watermark_path);
+                return wmStream.pipe(res);
+              }
+            } else {
+              const watermarkFilePath = path.join(getStoragePath(), photo.watermark_path);
+              if (fs.existsSync(watermarkFilePath)) {
+                res.set({
+                  'Content-Type': photo.mime_type || 'image/jpeg',
+                  'Cache-Control': 'private, max-age=1800',
+                  'ETag': etag,
+                  'X-Protection-Level': 'basic'
+                });
+                return res.sendFile(watermarkFilePath);
+              }
             }
           } catch (err) {
-            // File doesn't exist or error, fall through to on-the-fly generation
             logger.warn(`Pre-generated watermark not found for photo ${photoId}, falling back to on-the-fly`);
           }
         }
 
-        // Fallback: Apply watermark on-the-fly (slower, but ensures image is served)
-        // Also queue regeneration for next time
-        const watermarkedBuffer = await watermarkService.applyWatermark(filePath, watermarkSettings);
+        // Fallback: apply watermark on-the-fly. applyWatermark needs a
+        // local file path (sharp + fs.readFile) — for managed photos in
+        // S3 mode, withLocalCopy materializes to a tmp file and cleans up.
+        const watermarkedBuffer = useStorageBackend
+          ? await withLocalCopy(storageKey, (localPath) =>
+            watermarkService.applyWatermark(localPath, watermarkSettings))
+          : await watermarkService.applyWatermark(filePath, watermarkSettings);
 
         // Queue watermark generation in background for next request
         watermarkGeneratorService.generateForPhoto(photo.id)
@@ -1063,22 +1106,27 @@ router.get('/:slug/photo/:photoId',
 
         res.set({
           'Content-Type': photo.mime_type || 'image/jpeg',
-          'Cache-Control': 'private, max-age=1800', // Cache for 30 minutes
+          'Cache-Control': 'private, max-age=1800',
           'ETag': etag,
           'X-Protection-Level': 'basic'
         });
 
         res.send(watermarkedBuffer);
       } else {
-        // Send original file with basic protection headers
         res.set({
           'Cache-Control': 'private, max-age=1800',
           'ETag': etag,
           'X-Protection-Level': 'basic'
         });
-        // Ensure absolute path for res.sendFile
-        const absolutePath = path.isAbsolute(filePath) ? filePath : path.resolve(filePath);
-        res.sendFile(absolutePath);
+        if (useStorageBackend) {
+          res.set('Content-Length', stat.size);
+          if (photo.mime_type) res.set('Content-Type', photo.mime_type);
+          const stream = await storage.get(storageKey);
+          stream.pipe(res);
+        } else {
+          const absolutePath = path.isAbsolute(filePath) ? filePath : path.resolve(filePath);
+          res.sendFile(absolutePath);
+        }
       }
     } catch (error) {
       logger.error('Error serving photo:', {
@@ -1120,7 +1168,16 @@ router.get('/:slug/thumbnail/:photoId',
         return res.status(404).json({ error: 'Thumbnail generation failed' });
       }
 
-      const thumbPath = path.join(getStoragePath(), thumbnailPath);
+      // Read thumbnail metadata via the storage abstraction so we work in
+      // both LocalFs and S3 modes (#432). The previous fs.statSync on the
+      // resolved local path 500'd in S3 deployments because the thumbnail
+      // only exists in the bucket, not on the container's local fs.
+      const storage = getStorage();
+      const stat = await storage.stat(thumbnailPath);
+      if (!stat) {
+        logger.error(`Thumbnail not found in storage backend for photo ${photoId}`, { thumbnailPath });
+        return res.status(404).json({ error: 'Thumbnail not found' });
+      }
 
       // Log thumbnail access
       await secureImageService.logImageAccess(
@@ -1133,13 +1190,12 @@ router.get('/:slug/thumbnail/:photoId',
       // Check if watermarks are enabled and apply to thumbnail
       const watermarkSettings = await watermarkService.getWatermarkSettings();
 
-      // Generate ETag based on photo id, thumbnail modification time, and watermark settings
-      const fs = require('fs');
-      const stat = fs.statSync(thumbPath);
+      // ETag uses storage stat mtime + photo id + watermark hash.
+      const mtimeMs = stat.mtime ? stat.mtime.getTime() : 0;
       const watermarkHash = watermarkSettings?.enabled
         ? `-wm${watermarkSettings.opacity}${watermarkSettings.position}${watermarkSettings.size}`
         : '-nowm';
-      const etag = `"thumb-${photoId}-${stat.mtime.getTime()}${watermarkHash}"`;
+      const etag = `"thumb-${photoId}-${mtimeMs}${watermarkHash}"`;
 
       // Check if client has valid cached version
       if (req.headers['if-none-match'] === etag) {
@@ -1157,12 +1213,17 @@ router.get('/:slug/thumbnail/:photoId',
       });
 
       if (watermarkSettings && watermarkSettings.enabled) {
-        // Apply watermark to thumbnail
-        const watermarkedBuffer = await watermarkService.applyWatermark(thumbPath, watermarkSettings);
+        // Watermarking needs a local file path (sharp + fs.readFile).
+        // Materialize via withLocalCopy — no-op in local mode, downloads
+        // to a tmp file then cleans up in S3 mode.
+        const watermarkedBuffer = await withLocalCopy(thumbnailPath, (localPath) =>
+          watermarkService.applyWatermark(localPath, watermarkSettings)
+        );
         res.send(watermarkedBuffer);
       } else {
-        // Send file without watermark
-        res.sendFile(path.resolve(thumbPath));
+        res.setHeader('Content-Length', stat.size);
+        const stream = await storage.get(thumbnailPath);
+        stream.pipe(res);
       }
     } catch (error) {
       logger.error('Error serving thumbnail:', {
@@ -1211,30 +1272,27 @@ router.get('/:slug/hero/:photoId',
         return res.redirect(`/api/gallery/${req.params.slug}/photo/${photoId}`);
       }
 
-      const heroFullPath = path.join(getStoragePath(), heroPath);
-      const fs = require('fs');
-
-      // Verify file exists before attempting to serve
-      if (!fs.existsSync(heroFullPath)) {
-        logger.error('Hero image file does not exist at resolved path', {
+      // Hero images are always written via the storage abstraction (see
+      // imageProcessor.generateHeroImage), so they're a managed-storage
+      // key in both LocalFs and S3 modes (#432). Read via storage.
+      const storage = getStorage();
+      const stat = await storage.stat(heroPath);
+      if (!stat) {
+        logger.error('Hero image file does not exist in storage backend', {
           slug: req.params.slug,
           photoId,
           eventId: req.event.id,
-          resolvedPath: heroFullPath
+          heroPath
         });
         return res.redirect(`/api/gallery/${req.params.slug}/photo/${photoId}`);
       }
 
-      // Get file stats for ETag
-      const stat = fs.statSync(heroFullPath);
-      const etag = `"hero-${photoId}-${stat.mtime.getTime()}"`;
-
-      // Check if client has valid cached version
+      const mtimeMs = stat.mtime ? stat.mtime.getTime() : 0;
+      const etag = `"hero-${photoId}-${mtimeMs}"`;
       if (req.headers['if-none-match'] === etag) {
         return res.status(304).end();
       }
 
-      // Check if watermarks should be applied
       const watermarkSettings = await watermarkService.getWatermarkSettings();
 
       res.set({
@@ -1247,12 +1305,16 @@ router.get('/:slug/hero/:photoId',
       });
 
       if (watermarkSettings && watermarkSettings.enabled) {
-        // Apply watermark to hero image
-        const watermarkedBuffer = await watermarkService.applyWatermark(heroFullPath, watermarkSettings);
+        // applyWatermark needs a local file path; materialize via
+        // withLocalCopy so this works in S3 mode too.
+        const watermarkedBuffer = await withLocalCopy(heroPath, (localPath) =>
+          watermarkService.applyWatermark(localPath, watermarkSettings)
+        );
         res.send(watermarkedBuffer);
       } else {
-        // Send hero image without watermark
-        res.sendFile(path.resolve(heroFullPath));
+        res.setHeader('Content-Length', stat.size);
+        const stream = await storage.get(heroPath);
+        stream.pipe(res);
       }
     } catch (error) {
       logger.error('Error serving hero image:', {

--- a/backend/src/services/storage/LocalFsStorage.js
+++ b/backend/src/services/storage/LocalFsStorage.js
@@ -76,6 +76,11 @@ class LocalFsStorage {
     return fs.createReadStream(abs);
   }
 
+  async getRange(relPath, start, end) {
+    const abs = this._resolve(relPath);
+    return fs.createReadStream(abs, { start, end });
+  }
+
   async getToFile(relPath, localPath) {
     const abs = this._resolve(relPath);
     await fsp.mkdir(path.dirname(localPath), { recursive: true });

--- a/backend/src/services/storage/S3StorageBackend.js
+++ b/backend/src/services/storage/S3StorageBackend.js
@@ -80,6 +80,10 @@ class S3StorageBackend {
     return this.adapter.downloadStream(this._key(relPath));
   }
 
+  async getRange(relPath, start, end) {
+    return this.adapter.downloadStream(this._key(relPath), { range: `bytes=${start}-${end}` });
+  }
+
   async getToFile(relPath, localPath) {
     await fsp.mkdir(path.dirname(localPath), { recursive: true });
     await this.adapter.download(this._key(relPath), localPath);

--- a/backend/src/services/storage/StorageBackend.js
+++ b/backend/src/services/storage/StorageBackend.js
@@ -29,6 +29,7 @@
  * @property {(relPath: string, body: NodeJS.ReadableStream | Buffer, options?: PutOptions) => Promise<void>} put
  * @property {(relPath: string, localPath: string, options?: PutOptions) => Promise<void>} putFromFile
  * @property {(relPath: string) => Promise<NodeJS.ReadableStream>} get - Returns a readable stream of the object body.
+ * @property {(relPath: string, start: number, end: number) => Promise<NodeJS.ReadableStream>} getRange - Returns a readable stream of the object body for the inclusive byte range [start, end]. Used by video range-request handlers.
  * @property {(relPath: string, localPath: string) => Promise<void>} getToFile - Streams the object to a local path (creates parent dirs).
  * @property {(relPath: string) => Promise<boolean>} exists
  * @property {(relPath: string) => Promise<StatResult|null>} stat - Null if missing.


### PR DESCRIPTION
Closes #432 (reported by @w1ll-i-code, who also pinpointed the root cause at `gallery.js:1138`).

## What was happening

Three gallery serving routes bypassed `getStorage()` and used `fs.*` directly:

| Route | Lines on beta | What broke in S3 mode |
|---|---|---|
| `/api/gallery/:slug/thumbnail/:photoId` | 1138, 1165 | `fs.statSync` + `res.sendFile` on a path that exists only in the bucket |
| `/api/gallery/:slug/photo/:photoId` | 960, 981, 991, 1013, 1024, 1041, 1048, 1081 | Same + `fs.createReadStream` for video range + watermark `fs.existsSync` |
| `/api/gallery/:slug/hero/:photoId` | 1218, 1229, 1255 | Same as thumbnail |

Result: in S3 deployments every gallery image, hero, and thumbnail returned 500 with `ENOENT: no such file or directory`. The user only saw thumbnails fail because they hadn't clicked through yet — opening the lightbox or any hero would 500 the same way.

The admin photo route (`adminPhotos.js`) was already using `storage.stat` + `storage.get` correctly. This PR brings the gallery side in line.

## What changed

### Storage abstraction (3 files, +10 LOC)
- **`StorageBackend.js`** — added `getRange(relPath, start, end)` to the interface JSDoc.
- **`LocalFsStorage.js`** — `getRange` returns `fs.createReadStream(abs, { start, end })`.
- **`S3StorageBackend.js`** — `getRange` calls the existing `downloadStream(key, { range: 'bytes=start-end' })`.

This was needed for the photo-route video range case. Previously the code did `fs.createReadStream(filePath, { start, end })` which is local-only.

### Gallery routes (`gallery.js`, +160 LOC, refactor of 3 handlers)

**`/:slug/thumbnail/:photoId`** — read mtime via `storage.stat`, stream bytes via `storage.get`. Watermarked path materializes via `withLocalCopy` (no-op in local mode, downloads to a tmp file then auto-cleans up in S3 mode) so `applyWatermark`'s `sharp + fs.readFile` still works.

**`/:slug/photo/:photoId`** — branches on `photo.source_origin`:
- **External / reference** photos still use the local fs path (NAS mounts are local fs)
- **Managed** photos go through the storage abstraction
- Video range requests pass through to `storage.getRange`
- Pre-generated watermarks served via `storage.get` (managed) or `res.sendFile` (external)
- On-the-fly watermark generation uses `withLocalCopy` for managed photos

**`/:slug/hero/:photoId`** — hero images are always managed-storage keys (`imageProcessor.generateHeroImage` always writes via the storage abstraction), so this just switches to `storage.stat` + `storage.get`. Watermark application via `withLocalCopy`.

## Why the external/reference branch stays on local fs

For external photos (`source_origin = 'external'` or `'reference'`), the file lives on a local NAS mount path (per #423 work) — `resolvePhotoFilePath` returns that mount path directly. Going through the storage abstraction would be wrong because external photos aren't in the managed storage backend at all. The code branches on `isExternal` early and keeps the local-fs path for that case, which is also more efficient (no withLocalCopy round-trip).

## Verification

End-to-end against the dev stack with minio as S3 backend (`STORAGE_BACKEND=s3`, bucket `picpeak-storage`, prefix `test`):

```
POST /api/admin/photos/1122/upload  → photo + thumbnail + watermark land in S3:
  events/active/wedding-s3-serving-test-2026-05-09/s3-serving-test_individual_0001.jpg
  thumbnails/thumb_528abfe0_s3-serving-test_individual_0001.jpg
  watermarks/1084_watermarked.jpg

GET /api/gallery/<slug>/thumbnail/1084  → 200, JPEG 300x300 ✓
GET /api/gallery/<slug>/photo/1084      → 200, JPEG 1200x800 ✓
GET /api/gallery/<slug>/hero/1084       → 200, JPEG 1920x1080 ✓

ETag round-trip:
  curl gives back: ETag: "thumb-1084-1778352866000-wm50top-left15"
  curl -H 'If-None-Match: <etag>'  → 304 ✓

Backend logs during the requests: zero errors.
```

LocalFs regression check: **smoke 13/13 passing** (including the previously-flaky #07 once DB state aligns). The /photo route's video range, watermark pre-gen, and watermark on-the-fly paths all preserved for local mode.

## Test plan

- [ ] On an S3 deployment, upload a photo to a gallery
- [ ] Open the public gallery page
- [ ] Confirm thumbnails render (was the original bug)
- [ ] Click a thumbnail → lightbox opens with full image (was hidden by the thumbnail bug)
- [ ] If a hero image is configured: it loads
- [ ] If watermarking is enabled: thumbnails + lightbox + hero all show the watermark
- [ ] Upload a small video → seeking inside the video works (range requests)
- [ ] On a LocalFs deployment, repeat all of the above — should be unchanged behaviour