### PR TITLE
fix(events): admins can clear expiration on edit even when 'Require expiration' is ON (#426)

### DIFF
--- a/backend/src/routes/adminEvents.js
+++ b/backend/src/routes/adminEvents.js
@@ -1237,14 +1237,13 @@ router.put('/:id', adminAuth, requirePermission('events.edit'), requireEventOwne
     }
 
     // Enforce expires_at requirement based on app settings
-    if (Object.prototype.hasOwnProperty.call(updates, 'expires_at')) {
-      if (!updates.expires_at) {
-        const fieldReqs = await getEventFieldRequirements();
-        if (fieldReqs.require_expiration) {
-          return res.status(400).json({ error: 'Expiration date is required.' });
-        }
-        updates.expires_at = null;
-      }
+    // Allow admins to clear `expires_at` on edit even when the global
+    // `event_require_expiration` setting is ON (#426). The setting now
+    // controls only the create-time default — once an event exists, an
+    // admin editing it can override and remove the expiration. Empty /
+    // null values normalize to NULL in the column ("never expires").
+    if (Object.prototype.hasOwnProperty.call(updates, 'expires_at') && !updates.expires_at) {
+      updates.expires_at = null;
     }
 
     // Format hero logo settings if provided

--- a/frontend/src/pages/admin/EventDetailsPage.tsx
+++ b/frontend/src/pages/admin/EventDetailsPage.tsx
@@ -459,7 +459,6 @@ export const EventDetailsPage: React.FC = () => {
   }, [showMediaFilter, photoFilters.media_type]);
 
   const { data: publicSettings } = usePublicSettings();
-  const requireExpiration = publicSettings?.event_require_expiration !== false;
   const phoneFieldEnabled = publicSettings?.event_phone_field_enabled === true;
 
   // Fetch categories for the event
@@ -686,10 +685,11 @@ export const EventDetailsPage: React.FC = () => {
       return;
     }
 
-    if (requireExpiration && !editForm.expires_at) {
-      toast.error(t('validation.expirationRequired', 'Expiration date is required.'));
-      return;
-    }
+    // No expiration-required validation on edit (#426). The global
+    // `event_require_expiration` setting only enforces a default at
+    // create-time — once an event exists, an admin can clear the
+    // expiration via this form. The matching backend gate was dropped
+    // in adminEvents.js.
 
     // Clean up the data - remove undefined values
     const updateData: any = {


### PR DESCRIPTION
Fixes #426 (reported by @iSchumi6210).

## What was happening

With the global "Require expiration date" toggle ON, an admin couldn't clear the expiration on an existing event via the Edit Event form. PUT returned `400 "Expiration date is required."`

The cause was intentional in the original code: the global setting was enforced on **both create AND edit**, so once flipped ON, no event could ever be cleared of its expiration — not even by admins editing one-by-one.

Reproduced byte-for-byte against current beta:

```
Toggle ON → POST /admin/events {expiration_days: 30} → 200 created
Toggle ON → PUT /admin/events/:id {expires_at: null} → 400 rejected
```

## What changed

The setting now controls only the **create-time default**. On edit, an admin can clear the field and the value persists as NULL ("never expires"). Matches CMS-style admin tool conventions where field-required-by-default doesn't lock the field after creation.

- **Backend** (`adminEvents.js` PUT /:id): dropped the `getEventFieldRequirements()` enforcement on the `expires_at` branch. Empty/null on edit normalizes to NULL.
- **Frontend** (`EventDetailsPage.tsx`): dropped the matching `requireExpiration && !editForm.expires_at` toast. The variable is no longer referenced; declaration removed too.

Net diff: 2 files, +12 / -13.

## What's NOT affected

- **Create flow**: `event_require_expiration` setting still enforced. `POST /admin/events` without an expiration on an instance with the toggle ON auto-applies the default `expiration_days: 30`. Verified.
- **Other field requirements**: `event_require_customer_name`, `event_require_customer_email`, `event_require_admin_email`, `event_require_event_date` are unchanged. They still enforce on create.
- **CreateEventPage**: unchanged. The expiration field is still gated by `requireExpiration` there.

## Verification

End-to-end against dev backend with toggle ON:

```
STEP 1: create with expiration                      → 200, expires_at set       ✓
STEP 2: create without expiration                   → 200, default 30d applied   ✓ (create-time enforcement intact)
STEP 3: PUT {expires_at: null} on existing event    → "Event updated successfully" ✓ (was 400 before fix)
STEP 4: DB column expires_at                        → NULL                       ✓
STEP 5: PUT {expires_at: ""}                        → "Event updated successfully" ✓ (matches what an HTML date input sends when cleared)
```

Smoke 13/13 green; no regressions on existing flows.

## Test plan

- [ ] Settings → Events → "Require expiration date" toggle ON, Save
- [ ] Create new event without setting expiration date → form prevents/auto-applies (create-time enforcement preserved)
- [ ] Create new event with expiration → succeeds
- [ ] Open the just-created event in Edit mode → clear the expiration field → click Save → expect success toast (was previously a "Expiration date is required" error)
- [ ] Reload the event → "Expires" shows "Never" (or empty)
- [ ] Toggle the setting back OFF → behavior unchanged