### PR TITLE
fix(events): clamp page state when totalPages drops below current page (#442)

### DIFF
--- a/frontend/src/pages/admin/EventsListPage.tsx
+++ b/frontend/src/pages/admin/EventsListPage.tsx
@@ -104,6 +104,17 @@ export const EventsListPage: React.FC = () => {
     setPage(1);
   }, [statusFilter, debouncedSearchTerm]);
 
+  // Clamp the active page when the result count shrinks (#442 — bulk
+  // delete of an entire page would leave the user on a now-empty
+  // page=N where N > totalPages, with no auto-correction). Triggers
+  // after each successful refetch when totalPages drops below the
+  // current page (bulk delete, individual delete, archive, anything).
+  useEffect(() => {
+    if (data?.pagination && page > data.pagination.totalPages) {
+      setPage(Math.max(1, data.pagination.totalPages));
+    }
+  }, [data?.pagination, page]);
+
   // Close dropdown when clicking outside
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {


### PR DESCRIPTION
Fixes #442 (reported by @Rekoo-PS).

## What was happening

After bulk-deleting an entire page of events on the events list, the React Query refetch returned `events: []` with a smaller `totalPages`, but the local `page` state was stuck on the old (now out-of-range) page index. The backend correctly serves an empty page for `page > totalPages`, but the UI had no logic to step back.

```
# Reproduce
GET /api/admin/events?page=999&limit=20
→ {"events": [], "pagination": {"page": 999, "total": 983, "totalPages": 50}}
```

User had to manually reload to drop back to a valid page.

## What changed

One additional useEffect in `EventsListPage.tsx` that watches `data.pagination.totalPages` against the current `page` and resets `page = max(1, totalPages)` whenever totalPages drops below the active page index. Fires after every refetch so it covers bulk delete, individual delete, archive, and any filter change that shrinks the result set — same one-line guarantee.

```ts
useEffect(() => {
  if (data?.pagination && page > data.pagination.totalPages) {
    setPage(Math.max(1, data.pagination.totalPages));
  }
}, [data?.pagination, page]);
```

Net diff: 1 file, +11 LOC.

## Test plan
- [ ] Navigate to /admin/events, paginate to the last page (or any page that has fewer than 20 events relative to a known-shrinking filter)
- [ ] Select all events on that page
- [ ] Click "Delete Selected" → type DELETE → confirm
- [ ] Without the fix: list goes empty, you have to click Previous or reload
- [ ] With the fix: list automatically jumps back to the new last page (or page 1 if the table is empty)
- [ ] Same behavior on individual delete from the last page
- [ ] No effect when bulk-deleting from a non-last page (page state unchanged because totalPages still ≥ page)