### PR TITLE
fix(create-event): branding-default theme survives eventTypes refetch (#323-B)

### DIFF
--- a/frontend/src/pages/admin/CreateEventPage.tsx
+++ b/frontend/src/pages/admin/CreateEventPage.tsx
@@ -283,11 +283,23 @@ export const CreateEventPage: React.FC = () => {
     }));
   }, [settings]);
 
-  // Update theme when event type changes — but only when the event type has
-  // an explicit recommended preset. Skip the generic 'default' so the global
-  // Branding theme isn't clobbered by Classic Grid for event types like
-  // "Other" (#323).
+  // Update theme when the user actively changes the event type — but only
+  // when the new type has an explicit recommended preset. Skips both the
+  // generic 'default' (so types like "Other" don't clobber the global
+  // Branding theme with Classic Grid) and the very first render (so the
+  // wedding default doesn't out-race the Branding-default effect above
+  // when eventTypes resolves AFTER settings — #323-B / smoke spec 07).
+  const prevEventTypeRef = useRef<string | null>(null);
   useEffect(() => {
+    const prev = prevEventTypeRef.current;
+    prevEventTypeRef.current = formData.event_type;
+    // First render: just record the initial value and let the
+    // Branding-default effect own the theme. Without this guard the
+    // initial-mount fire of this effect (and any later eventTypes
+    // refetch that swaps `availableEventTypes` identity) would
+    // overwrite the Branding theme with the wedding preset.
+    if (prev === null || prev === formData.event_type) return;
+
     const selectedType = availableEventTypes.find(t => t.value === formData.event_type);
     const recommendedPreset = selectedType?.theme_preset;
 


### PR DESCRIPTION
## Summary

Restores the green state of smoke spec 07 / issue #323-B. Discovered while shipping #450 — pre-existing race, unrelated to that PR.

### Root cause

Two effects in `CreateEventPage` race on first render of `/admin/events/new`:

1. **Branding-default effect** — applies the global `theme_config` from `/admin/settings` so the form starts with whatever the admin set in Branding.
2. **Recommended-preset effect** — applies the event-type's recommended theme (e.g. `wedding → elegantWedding`) when the user picks a different type.

The second effect was firing on **initial mount** AND every time `availableEventTypes` recomputed (which happens whenever the eventTypes API resolves and changes the memoised reference). On a cold load with the eventTypes query resolving *after* settings, the second effect overwrote the just-applied Branding theme with the wedding default — so an admin who set "Dark Modern" in Branding still saw "Elegant Wedding" on every new event.

The bug was non-deterministic — depended on which query resolved first.

### Fix

Track the previous `event_type` in a `useRef`. Bail out of the recommended-preset effect unless `event_type` actually changed value. The Branding-default effect now wins on first paint, and the recommended-preset behaviour still kicks in when the user manually picks a different event type later.

## Test plan

- [x] `tests/e2e/local/smoke/07-branding-default-on-create-event.spec.ts` passes (was failing on `beta` before this PR).
- [x] All 13 local smoke tests green.
- [ ] Manual: Branding → set Dark Modern → Save → open Create Event → preset card shows "Dark Modern".
- [ ] Manual: Create Event → click "Birthday" event type → preset switches to the recommended one for birthdays (regression check that the effect still fires on real changes).