### PR TITLE
fix(branding): socials + promo round-trip from DB to form (#460)

### DIFF
--- a/frontend/src/services/settings.service.ts
+++ b/frontend/src/services/settings.service.ts
@@ -323,7 +323,20 @@ export const settingsService = {
       login_logo_frame_enabled: this._parseBoolean(rawSettings.branding_login_logo_frame_enabled, true),
       login_logo_size: ['small', 'medium', 'large', 'xlarge'].includes(rawSettings.branding_login_logo_size)
         ? rawSettings.branding_login_logo_size
-        : 'medium'
+        : 'medium',
+      // Footer overhaul (#441 + #440 / #460). These were added to the
+      // BrandingSettings interface but not to the read mapper, so the
+      // BrandingPage form initialised them as empty strings on every
+      // load. The next save then sent the empty form back to the
+      // backend and wiped the saved values from the DB — even though
+      // the gallery footer kept rendering them until the next save.
+      facebook_url: rawSettings.branding_facebook_url || '',
+      instagram_url: rawSettings.branding_instagram_url || '',
+      whatsapp_url: rawSettings.branding_whatsapp_url || '',
+      twitter_url: rawSettings.branding_twitter_url || '',
+      youtube_url: rawSettings.branding_youtube_url || '',
+      promo_markdown: rawSettings.branding_promo_markdown || '',
+      promo_position: rawSettings.branding_promo_position === 'below_footer' ? 'below_footer' : 'above_footer'
     };
   },
 


### PR DESCRIPTION
## Summary

Closes #460. Fix for the "socials disappear from BrandingPage and get wiped on next save" bug — root cause is a stale read mapper.

When the footer-overhaul fields landed in #441 / #440, the `BrandingSettings` interface was updated and the BrandingPage form now reads/writes them — but `formatBrandingSettings` (the function that maps the raw `app_settings` rows to the form shape on load) was not updated. So:

1. User saves socials → backend persists ✅
2. User reloads /admin/branding → form initialises from `formatBrandingSettings`, which doesn't read the new keys → socials appear empty in the form ❌
3. User saves any other field → form's empty socials get sent → backend writes empty strings → DB wiped, public footer goes blank on next render

The asymmetric "visible to galleries, gone from admin" behaviour comes from step 2: the public footer keeps rendering the saved values until step 3 wipes them.

## Fix

Add the seven missing read mappings to `formatBrandingSettings`:
- `branding_facebook_url`, `branding_instagram_url`, `branding_whatsapp_url`, `branding_twitter_url`, `branding_youtube_url`
- `branding_promo_markdown`, `branding_promo_position`

Same pattern as the existing fields — `|| ''` for strings, narrowed enum for `promo_position`.

## Test plan

- [ ] On an install with socials configured: visit /admin/branding → socials populated in the form (regression check).
- [ ] Save the form without changing socials → reload → socials still there.
- [ ] Clear a social URL → save → reload → field shows empty (intentional empty save).
- [ ] Promo banner content + position round-trip the same way.

## Smoke

Local smoke gate is currently 3/13 red on `origin/beta` itself (`CustomerDashboardBrandingCard` adds a competing `Save changes` button on /admin/branding that breaks two specs, and `CustomerAccountPicker` has a Rules of Hooks violation that crashes /admin/events/new — both flagged on PR #458). Pushed with `PUSH_SKIP_E2E=1`. The failures are not caused by this PR — verified by snapshot check, the relevant page state matches plain beta.

Targets `beta`. Closes #460.