### PR TITLE
fix(ci): pin TRIVY_PLATFORM per matrix arch (post-#477 follow-up)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -173,6 +173,17 @@ jobs:
     - name: Run Trivy vulnerability scanner (per-arch, by digest)
       if: steps.push-decision.outputs.push == 'true'
       uses: aquasecurity/trivy-action@v0.36.0
+      env:
+        # docker/build-push-action wraps every push in an OCI index
+        # (carries the SLSA provenance attestation alongside the
+        # actual image). Trivy's remote backend defaults to
+        # linux/amd64 regardless of host arch when resolving an
+        # index, which makes the arm64 leg crash with "no child
+        # with platform linux/amd64". Telling Trivy which child to
+        # scan keeps the provenance attestation intact and fixes
+        # the resolver crash. Pin to matrix.platform so each leg
+        # scans its own arch.
+        TRIVY_PLATFORM: ${{ matrix.platform }}
       with:
         image-ref: ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE_NAME }}@${{ steps.build.outputs.digest }}
         format: 'sarif'
@@ -379,6 +390,12 @@ jobs:
     - name: Run Trivy vulnerability scanner (per-arch, by digest)
       if: steps.push-decision.outputs.push == 'true'
       uses: aquasecurity/trivy-action@v0.36.0
+      env:
+        # See build-backend for the rationale — pin Trivy's platform
+        # to the matrix arch so its remote-index resolver picks the
+        # right child instead of defaulting to linux/amd64 and
+        # crashing on the arm64 leg.
+        TRIVY_PLATFORM: ${{ matrix.platform }}
       with:
         image-ref: ${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE_NAME }}@${{ steps.build.outputs.digest }}
         format: 'sarif'


### PR DESCRIPTION
## Summary

Hot-fix for the build failures on \`beta\` after PR #477 merged. The arm64 build leg of both \`build-backend\` and \`build-frontend\` is failing with:

\`\`\`
remote error: no child with platform linux/amd64 in index
ghcr.io/.../<image>@sha256:<digest>
\`\`\`

## Root cause (subtler than #476's surface)

\`docker/build-push-action\` wraps every \`push-by-digest=true\` push in an **OCI index** — the actual image manifest sits next to a **SLSA provenance attestation** manifest as siblings under the digest. So the digest in \`steps.build.outputs.digest\` is an index, not a direct image manifest.

Trivy's remote backend, when it resolves an index, defaults to \`linux/amd64\` regardless of host arch:

- **amd64 leg** → looks for amd64 child → finds the amd64 image → ✅
- **arm64 leg** → looks for amd64 child → finds NO amd64 child (the only platform child is arm64) → ✘

That's why amd64 was green but arm64 was red — same code, same workflow, different host arch hitting Trivy's amd64 default.

## Fix

\`env: TRIVY_PLATFORM: \${{ matrix.platform }}\` on each Trivy step. Each scanner now asks for its own arch and finds it.

## Why not \`provenance: false\` instead

Disabling provenance on the build step would also fix the resolver crash (the digest would point directly at the single-platform manifest). But provenance attestations are real supply-chain visibility that we'd be giving up. The TRIVY_PLATFORM fix is one line per leg, keeps SLSA provenance attached, and is the standard mitigation in the trivy-action / build-push-action combination.

## Test plan

- [ ] Merge → next beta build → both legs of build-backend AND build-frontend pass.
- [ ] Trivy SARIF lands in the Security tab under both \`<area>-vulnerabilities-linux-amd64\` AND \`<area>-vulnerabilities-linux-arm64\` categories.
- [ ] No regression on amd64 (which was passing under PR #477).

Targets \`beta\`. Restores full green across the matrix.