### PR TITLE
fix(install): defer events.hero_photo_id FK to break circular reference (#484)

### DIFF
--- a/backend/src/database/db.js
+++ b/backend/src/database/db.js
@@ -86,7 +86,16 @@ async function initializeDatabase() {
       table.boolean('disable_right_click').defaultTo(false);
       table.boolean('watermark_downloads').defaultTo(false);
       table.text('watermark_text');
-      table.integer('hero_photo_id').references('id').inTable('photos').onDelete('SET NULL');
+      // events.hero_photo_id → photos.id is a forward reference (the
+      // photos table is created later in this same function). Postgres
+      // rejects FK declarations that reference a non-existent table at
+      // CREATE TABLE time, so the constraint is added below as an
+      // ALTER TABLE *after* the photos table exists. SQLite previously
+      // tolerated the inline declaration because its FK enforcement is
+      // lazy — the inline form silently became a column with no FK
+      // metadata. Both backends now go through the same code path.
+      // (#484, MrGabri's reproduction.)
+      table.integer('hero_photo_id');
       table.boolean('require_password').defaultTo(true);
     });
   } else {
@@ -213,6 +222,25 @@ async function initializeDatabase() {
       table.integer('view_count').defaultTo(0);
       table.integer('download_count').defaultTo(0);
     });
+
+    // Deferred FK: events.hero_photo_id → photos.id. See the comment
+    // on the events createTable above for why this can't be inline.
+    // Wrapped in try/catch so a re-run path or an SQLite install that
+    // already accepted the inline (no-op) declaration doesn't fail
+    // boot when the constraint already exists in some shape.
+    try {
+      await db.schema.alterTable('events', (table) => {
+        table.foreign('hero_photo_id')
+          .references('id').inTable('photos')
+          .onDelete('SET NULL');
+      });
+    } catch (err) {
+      const msg = err?.message || '';
+      if (!/already exists|duplicate|exists/i.test(msg)) {
+        throw err;
+      }
+      // Constraint already in place — fine, carry on.
+    }
   }
 
   // Access logs table


### PR DESCRIPTION
## Summary

Closes the actual install failure in #484 — separate from #488's healthcheck noise fixes. MrGabri's second log dump after #488 merged showed the install was still crashing with:

\`\`\`
Initial setup failed: error: alter table "events" add constraint
"events_hero_photo_id_foreign" foreign key ("hero_photo_id")
references "photos" ("id") on delete SET NULL
- relation "photos" does not exist
\`\`\`

This is a real circular-FK ordering bug that's been latent since 2024.

## Root cause

\`initializeDatabase()\` in \`src/database/db.js\` creates tables in this order:

1. \`events\` (line 61) — declares \`hero_photo_id\` with FK to \`photos.id\` **inline**
2. \`photos\` (line 203) — created **later**, declares \`event_id\` with FK to \`events.id\`

Postgres rejects FK declarations to tables that don't exist yet (it checks at \`CREATE TABLE\` time). The forward reference in step 1 → \`relation "photos" does not exist\` → the entire init fails.

SQLite silently tolerated it because:
- FK enforcement in SQLite is lazy by default.
- An inline FK to a non-existent table just becomes a column with no FK metadata recorded — no error, no constraint either.

So **SQLite installs worked but had no actual FK on `hero_photo_id`**. Postgres installs crashed during init.

## Why no other Postgres user reported this

The createTable block is gated on \`if (!hasEventsTable)\`. Once a deployment has the events table from any prior run, that path is skipped. The bug only fires on a **truly fresh** Postgres install — exactly MrGabri's scenario. Our smoke suite runs against a long-lived dev stack with persistent volumes, so it never exercises the cold-start path.

## Fix

- \`events\` createTable: drop the inline FK, declare as a plain integer with an inline comment explaining why.
- After both tables exist (post-\`photos\` createTable): \`db.schema.alterTable('events').foreign('hero_photo_id').references('id').inTable('photos').onDelete('SET NULL')\`. Wrapped in a try/catch that swallows "already exists" so any re-run path doesn't fail boot.

Both backends now go through the same code path. The FK ends up declared on Postgres, and SQLite installs that previously had no FK metadata on this column gain it on the next boot.

## Verification

\`\`\`bash
docker compose -f docker-compose.dev.yml down -v
docker compose -f docker-compose.dev.yml up -d --build backend
\`\`\`

- Backend boots cleanly. No "Initial setup failed". All workers start.
- \`pg_constraint\` confirms the FK landed correctly:

\`\`\`
conname                      | on_table | references_table | definition
events_hero_photo_id_foreign | events   | photos           | FOREIGN KEY (hero_photo_id) REFERENCES photos(id) ON DELETE SET NULL
\`\`\`

## Out of scope

Auditing the rest of \`initializeDatabase()\` for other forward references — \`grep references | inTable\` shows only this one circular dependency (every other FK references \`events\`, which exists by then). Worth a one-pass audit later for defence in depth, but no other forward references exist today.

Targets \`beta\`. Closes the actual #484 root cause.