### PR TITLE
feat(api/v1): accept category_id on POST /events/:id/photos

### DIFF
--- a/backend/src/routes/v1/__tests__/events.category.test.js
+++ b/backend/src/routes/v1/__tests__/events.category.test.js
@@ -1,0 +1,147 @@
+/**
+ * Regression test for PR the_luap/picpeak#500.
+ *
+ * The v1 upload endpoint POST /events/:id/photos used to accept any
+ * photo_categories.id, including ones belonging to a different event.
+ * apiTokenAuth has no per-event scoping, so this let a programmatic
+ * uploader silently mis-file photos under a category that doesn't
+ * belong to the target event.
+ *
+ * The fix scopes the lookup to (event_id = event.id OR is_global = true)
+ * — see backend/migrations/legacy/004_add_categories_and_cms.js for the
+ * photo_categories columns. These tests verify both that the scoping
+ * clause is exactly that, and that the 400 response carries the new
+ * "Unknown or out-of-scope category_id" error string.
+ *
+ * Pattern lifted from src/routes/__tests__/adminAuth.test.js.
+ */
+
+const request = require('supertest');
+const express = require('express');
+
+const buildChain = ({ firstResult, insertResult } = {}) => ({
+  where: jest.fn().mockReturnThis(),
+  andWhere: jest.fn().mockReturnThis(),
+  orWhere: jest.fn().mockReturnThis(),
+  select: jest.fn().mockReturnThis(),
+  first: jest.fn().mockResolvedValue(firstResult),
+  insert: jest.fn().mockResolvedValue(insertResult ?? [1]),
+});
+
+jest.mock('../../../database/db', () => {
+  const dbMock = jest.fn();
+  dbMock.raw = jest.fn();
+  dbMock.__setImplementations = (...chains) => {
+    dbMock.mockReset();
+    chains.forEach((chain) => {
+      dbMock.mockImplementationOnce(() => chain);
+    });
+  };
+  return {
+    db: dbMock,
+    logActivity: jest.fn().mockResolvedValue(undefined),
+  };
+});
+
+jest.mock('../../../middleware/apiTokenAuth', () => ({
+  apiTokenAuth: (req, _res, next) => {
+    req.apiToken = { id: 1, admin_id: 1, scopes: ['write'] };
+    req.admin = { id: 1, username: 'token-admin' };
+    next();
+  },
+  requireApiScope: () => (_req, _res, next) => next(),
+}));
+
+// photoUpload is built inside events.js (multer({...})), not imported
+// from a shared module. Mock the multer factory so .single(field)
+// returns middleware that injects a stub req.file synchronously.
+//
+// Caveat: `path` points at a file that doesn't exist on disk. The
+// current 400-path tests short-circuit before the handler touches the
+// filesystem. Any future test that exercises a happy-path category
+// match must either create the file under beforeAll() or stub the
+// `fs`/`fsSync` modules — otherwise `fsSync.statSync(tempPath)` will
+// throw and the test will surface a misleading 500.
+jest.mock('multer', () => {
+  const fakeUpload = {
+    single: () => (req, _res, next) => {
+      req.file = {
+        path: '/tmp/fake-v1-upload.jpg',
+        originalname: 'fake.jpg',
+        size: 1,
+        mimetype: 'image/jpeg',
+      };
+      next();
+    },
+  };
+  const factory = jest.fn(() => fakeUpload);
+  factory.diskStorage = jest.fn(() => ({}));
+  return factory;
+});
+
+const { db } = require('../../../database/db');
+const eventsRouter = require('../events');
+
+const buildApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/', eventsRouter);
+  return app;
+};
+
+describe('v1 POST /events/:id/photos — category scoping', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('scopes the category lookup to event-owned or global rows', async () => {
+    const eventChain = buildChain({ firstResult: { id: 42, slug: 'wedding-2026' } });
+    const categoryChain = buildChain({ firstResult: null });
+    db.__setImplementations(eventChain, categoryChain);
+
+    // Use JSON body (express.json parses it before the mocked multer
+    // middleware runs). The route reads req.body.category_id either
+    // way — multer would have parsed the field as a string, json sends
+    // a string too.
+    // .expect(400) also pins the response status — without it a future
+    // regression that swallowed the error and returned 500 would still
+    // satisfy the scoping-call assertions below.
+    await request(buildApp())
+      .post('/events/42/photos')
+      .send({ category_id: '7' })
+      .expect(400);
+
+    // The category lookup chain receives the id filter…
+    expect(categoryChain.where).toHaveBeenCalledWith({ id: 7 });
+    // …and a single andWhere() with the scoping callback.
+    expect(categoryChain.andWhere).toHaveBeenCalledTimes(1);
+    const scopingCb = categoryChain.andWhere.mock.calls[0][0];
+    expect(typeof scopingCb).toBe('function');
+
+    // Invoke the callback against a knex-shaped builder spy and verify
+    // the OR-clause it builds: event_id = 42 OR is_global = true.
+    const builderSpy = {
+      where: jest.fn().mockReturnThis(),
+      orWhere: jest.fn().mockReturnThis(),
+    };
+    scopingCb.call(builderSpy);
+    expect(builderSpy.where).toHaveBeenCalledWith({ event_id: 42 });
+    expect(builderSpy.orWhere).toHaveBeenCalledWith('is_global', true);
+  });
+
+  it('returns 400 with out-of-scope error when no category row matches', async () => {
+    db.__setImplementations(
+      buildChain({ firstResult: { id: 42, slug: 'wedding-2026' } }),
+      buildChain({ firstResult: null }),
+    );
+
+    const response = await request(buildApp())
+      .post('/events/42/photos')
+      .send({ category_id: '7' })
+      .expect(400);
+
+    expect(response.body).toEqual({
+      error: 'Unknown or out-of-scope category_id 7',
+    });
+  });
+});

--- a/backend/src/routes/v1/events.js
+++ b/backend/src/routes/v1/events.js
@@ -338,6 +338,13 @@ router.get('/events/:id', apiTokenAuth, requireApiScope('read'), async (req, res
  *             required: [photo]
  *             properties:
  *               photo: { type: string, format: binary }
+ *               category_id:
+ *                 type: integer
+ *                 description: |
+ *                   Optional. If provided, the photo is filed under the
+ *                   given photo_categories.id (must belong to the event
+ *                   or be a global category). If omitted, the photo
+ *                   lands uncategorized.
  *     responses:
  *       201:
  *         description: Photo uploaded
@@ -351,6 +358,7 @@ router.get('/events/:id', apiTokenAuth, requireApiScope('read'), async (req, res
  *                 path: { type: string }
  *                 thumbnail_path: { type: string, nullable: true }
  *                 size_bytes: { type: integer }
+ *                 category_id: { type: integer, nullable: true }
  *       400: { description: No file or invalid type }
  *       404: { description: Event not found }
  */
@@ -367,6 +375,25 @@ router.post(
 
       const event = await db('events').where({ id: req.params.id }).first();
       if (!event) return res.status(404).json({ error: 'Event not found' });
+
+      // Optional category assignment, mirroring the admin upload route
+      // (adminPhotos.js). Multipart form field `category_id`. If the
+      // category looks up to a "collage" slug, the photo's `type` flips
+      // accordingly so existing collage-aware UI paths still work.
+      const rawCategoryId = req.body?.category_id;
+      const parsedCategoryId = rawCategoryId ? parseInt(rawCategoryId, 10) : NaN;
+      let categoryId = null;
+      let photoType = 'individual';
+      if (!Number.isNaN(parsedCategoryId)) {
+        const category = await db('photo_categories').where({ id: parsedCategoryId }).first();
+        if (!category) {
+          return res.status(400).json({ error: `Unknown category_id ${parsedCategoryId}` });
+        }
+        categoryId = category.id;
+        if (category.slug === 'collage' || category.slug === 'collages') {
+          photoType = 'collage';
+        }
+      }
 
       const ext = path.extname(req.file.originalname);
       const finalName = `${Date.now()}_${crypto.randomBytes(4).toString('hex')}${ext}`;
@@ -408,7 +435,8 @@ router.post(
         original_filename: req.file.originalname,
         path: relPath,
         thumbnail_path: thumbRel,
-        type: 'individual',
+        type: photoType,
+        category_id: categoryId,
         size_bytes: stat.size,
         width,
         height,
@@ -432,7 +460,14 @@ router.post(
         });
       } catch (e) { /* non-fatal */ }
 
-      res.status(201).json({ id, filename: finalName, path: relPath, thumbnail_path: thumbRel, size_bytes: stat.size });
+      res.status(201).json({
+        id,
+        filename: finalName,
+        path: relPath,
+        thumbnail_path: thumbRel,
+        size_bytes: stat.size,
+        category_id: categoryId
+      });
     } catch (error) {
       logger.error('v1 POST /events/:id/photos failed', { error: error.message });
       if (tempPath) await fs.unlink(tempPath).catch(() => {});

--- a/backend/src/routes/v1/events.js
+++ b/backend/src/routes/v1/events.js
@@ -385,9 +385,22 @@ router.post(
       let categoryId = null;
       let photoType = 'individual';
       if (!Number.isNaN(parsedCategoryId)) {
-        const category = await db('photo_categories').where({ id: parsedCategoryId }).first();
+        // Scope to categories owned by this event (event_id = event.id) or
+        // marked global (is_global = true) — see migration
+        // backend/migrations/legacy/004_add_categories_and_cms.js. An API
+        // token inherits its owning admin's powers (no per-event scoping
+        // in apiTokenAuth), so accepting any category_id would silently
+        // mis-file uploads under a category belonging to a different event.
+        const category = await db('photo_categories')
+          .where({ id: parsedCategoryId })
+          .andWhere(function () {
+            this.where({ event_id: event.id }).orWhere('is_global', true);
+          })
+          .first();
         if (!category) {
-          return res.status(400).json({ error: `Unknown category_id ${parsedCategoryId}` });
+          return res.status(400).json({
+            error: `Unknown or out-of-scope category_id ${parsedCategoryId}`,
+          });
         }
         categoryId = category.id;
         if (category.slug === 'collage' || category.slug === 'collages') {


### PR DESCRIPTION
## Description

`POST /api/v1/events/:id/photos` currently ignores any `category_id` sent in the request and inserts photos with `category_id = NULL`. That means programmatic uploaders (in my case a self-hosted photobooth kiosk that talks to picpeak via a `pp_live_` API token) end up with every photo in the "uncategorized" bucket, and the operator has to bulk-assign category in the admin UI after each event.

This PR mirrors the existing `routes/adminPhotos.js` handling on the v1 route so an API client can file a photo into the right category at upload time — same capability the gallery user-upload path already has via its own `category_id` form field.

Fixes # (no upstream issue tracked; happy to open one if you prefer)

## Type of change

- [x] **New feature (non-breaking change which adds functionality)**

(Backwards compatible: omitting `category_id` keeps the prior behavior — `NULL` category, `type='individual'`.)

## How Has This Been Tested?

- [x] Manual testing completed
- [x] Tested on Docker deployment (the fork's GHA build of this branch, `ghcr.io/munin92/picpeak/backend:sha-a5b63e4`, deployed against a live picpeak instance with a real event + categories)
- [ ] Unit tests pass (`npm test`) — backend's existing v1 suite has no tests; I didn't add new tests in this PR, happy to do so as a follow-up or in this PR if you prefer
- [x] `npm run lint` clean on the changed file (`npx eslint backend/src/routes/v1/events.js` → 0 problems)

**Verified end-to-end** by issuing a real `pp_live_` API token + uploading sample JPEGs/PNGs to a live wedding event:

| Scenario | Expected | Result |
|---|---|---|
| `category_id=6` (existing category) | 201 + `\"category_id\": 6` in response | ✅ |
| `category_id=7` (different existing category) | 201 + `\"category_id\": 7` | ✅ |
| `category_id=99999` (nonexistent) | 400 with helpful error | ✅ `{\"error\":\"Unknown category_id 99999\"}` |
| **No** `category_id` (backwards-compat) | 201 + `\"category_id\": null` | ✅ |
| Real 1MB PNG (incl. thumbnail generation) | 201 + correct size_bytes + thumbnail_path | ✅ |

Photos with assigned categories show up in the admin UI under the chosen category exactly like admin-uploaded photos do.

**Test Configuration:**
- PicPeak Version: branch `feat/v1-upload-category-id` off recent `main` (commit `a5b63e4`, post-3.43.1)
- Node.js Version: image is upstream's `node:22-alpine`
- Database: PostgreSQL 15
- Browser: not applicable (API-only change)

## Checklist

- [x] My code follows the style guidelines of this project (mirrors `adminPhotos.js` category logic)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas (the parse + lookup + collage-slug branch has an explanatory comment referencing the adminPhotos parallel)
- [x] I have made corresponding changes to the documentation (OpenAPI spec in the JSDoc above the route + 201 response body updated to include `category_id`)
- [x] My changes generate no new warnings (`npx eslint backend/src/routes/v1/events.js` clean)
- [ ] I have added tests that prove my fix is effective or that my feature works — see Note below
- [x] New and existing unit tests pass locally with my changes (no regressions in the existing suite — the 43 baseline failures on a fresh checkout are environment-dependent (MinIO, etc.) and unchanged by this patch)
- [x] Any dependent changes have been merged and published (none)
- [ ] I have updated the CHANGELOG.md file — left to release-please based on the `feat(api/v1):` commit message

### Note on tests

The existing `backend/__tests__/routes/` directory has no test for `/api/v1/events/:id/photos` (or any v1 route), so adding a Jest integration test would mean introducing new test scaffolding rather than extending an existing one. Happy to do that in this PR if you'd prefer — let me know which direction (e.g., spin up postgres in jest via testcontainers, or mock-`db`-and-multer unit-style). The manual end-to-end coverage above hit the four behavioral branches (happy path, nonexistent category, missing field, collage-slug rewrite is structurally the same as the admin path's tested logic).

## Try it

```sh
TOKEN=pp_live_…
curl -X POST -H \"Authorization: Bearer \$TOKEN\" \\
  -F \"photo=@sample.jpg\" \\
  -F \"category_id=6\" \\
  https://picpeak.example/api/v1/events/1/photos
# → 201
# {\"id\":42,\"filename\":\"…\",\"path\":\"…\",\"thumbnail_path\":\"…\",\"size_bytes\":12345,\"category_id\":6}
```

## Additional Notes

First contribution here — let me know if there's anything you'd like reshaped (commit style, test scaffolding, naming). The patch is intentionally minimal and behaviorally identical to the admin route on this point.