### PR TITLE
fix(categories): strip diacritics from auto-generated slugs

### DIFF
--- a/backend/src/routes/adminCategories.js
+++ b/backend/src/routes/adminCategories.js
@@ -56,7 +56,9 @@ router.post('/', adminAuth, requirePermission('settings.edit'), [
     const { name, slug, is_global = true, event_id = null } = req.body;
     
     // Generate slug if not provided
-    const categorySlug = slug || name.toLowerCase()
+    const categorySlug = slug || name
+      .normalize('NFD').replace(/[̀-ͯ]/g, '')
+      .toLowerCase()
       .replace(/[^\w\s-]/g, '')
       .replace(/\s+/g, '-')
       .replace(/-+/g, '-')
@@ -128,7 +130,9 @@ router.put('/:id', adminAuth, requirePermission('settings.edit'), [
 
     const updateData = {
       name,
-      slug: name.toLowerCase()
+      slug: name
+        .normalize('NFD').replace(/[̀-ͯ]/g, '')
+        .toLowerCase()
         .replace(/[^\w\s-]/g, '')
         .replace(/\s+/g, '-')
         .replace(/-+/g, '-')


### PR DESCRIPTION
## Description

When creating or renaming a category with accented characters (e.g. Portuguese, French, Spanish), the slug generation silently drops those characters instead of converting them to their ASCII equivalents.

**Before:**
- `Decoração` → `/decorao`
- `Recepção` → `/recepo`
- `Família` → `/famlia`

**After:**
- `Decoração` → `/decoracao`
- `Recepção` → `/recepcao`
- `Família` → `/familia`

**Root cause:** The slug regex `/[^\w\s-]/g` strips any non-ASCII character because `\w` in JavaScript only matches `[a-zA-Z0-9_]`. Accented letters are entirely removed rather than transliterated.

**Fix:** Apply Unicode NFD normalization before the regex. NFD decomposes characters like `ã` into the base letter `a` plus a combining diacritical mark (`̀–ͯ`). A second replace then strips those combining marks, leaving only the ASCII base letter. The existing slug pipeline then handles the rest (lowercase, spaces → hyphens, etc.).

The fix is applied to both the POST (create) and PUT (update) handlers in `adminCategories.js`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Verified with Node.js REPL:

```js
const slug = (name) => name
  .normalize('NFD').replace(/[̀-ͯ]/g, '')
  .toLowerCase()
  .replace(/[^\w\s-]/g, '')
  .replace(/\s+/g, '-')
  .replace(/-+/g, '-')
  .trim();

slug('Decoração')  // 'decoracao'
slug('Recepção')   // 'recepcao'
slug('Família')    // 'familia'
```

- [x] Manual testing completed
- [x] Tested on production-like environment (self-hosted LXC, SQLite)

**Test Configuration**:
* PicPeak Version: 3.51.0-beta.0
* Node.js Version: v20.20.2
* Database: SQLite
* Browser: Chrome

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Additional Notes:

This affects any language with diacritical marks: Portuguese (ã, ç, õ), French (é, è, ê), Spanish (ñ, á), German (ü, ö, ä), etc.