### PR TITLE
fix(email): parse JSON-encoded language setting before using as locale

### DIFF
--- a/backend/src/services/emailProcessor.js
+++ b/backend/src/services/emailProcessor.js
@@ -116,7 +116,9 @@ async function getRecipientLanguage(email, eventId = null) {
       .where('setting_key', 'general_default_language')
       .first();
     if (langSetting && langSetting.setting_value) {
-      return langSetting.setting_value;
+      let lang = langSetting.setting_value;
+      try { lang = JSON.parse(lang); } catch (_) {}
+      if (typeof lang === 'string' && lang.trim()) return lang.trim();
     }
   } catch (error) {
     logger.error('Error fetching app settings language:', error);


### PR DESCRIPTION
## Description

Emails always send in English regardless of the language configured in **Settings → General → Default Language**.

**Root cause:** `app_settings` stores all values as JSON-encoded strings (e.g. `"pt"` is stored as `\"pt\"` including the quotes). `getRecipientLanguage()` returned the raw `setting_value` without parsing it, so the language passed to `processTemplate()` was `'"pt"'` (with surrounding quotes) instead of `'pt'`. The translation lookup `WHERE language = '"pt"'` matched nothing and fell through to the English fallback.

**Fix:** Apply `JSON.parse()` with a try/catch fallback before returning the setting value — the same pattern used by `readSetting()` in `wrapEmailHtml()` and `getFrontendBaseUrl()` elsewhere in the codebase.

**Before:**
```js
if (langSetting && langSetting.setting_value) {
  return langSetting.setting_value; // returns '"pt"' with quotes
}
```

**After:**
```js
if (langSetting && langSetting.setting_value) {
  let lang = langSetting.setting_value;
  try { lang = JSON.parse(lang); } catch (_) {}
  if (typeof lang === 'string' && lang.trim()) return lang.trim(); // returns 'pt'
}
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Verified by inspecting the DB value (`"pt"` with quotes) and tracing the lookup through `processTemplate()`. Confirmed emails now use the correct language translation after the fix.

- [x] Manual testing completed
- [x] Tested on production-like environment (self-hosted LXC, SQLite)

**Test Configuration**:
* PicPeak Version: 3.51.0-beta.0
* Node.js Version: v20.20.2
* Database: SQLite
* Browser: Chrome

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Additional Notes:

The same `JSON.parse` pattern is already used in `wrapEmailHtml()` (`readSetting` helper) and `getFrontendBaseUrl()`. This fix makes `getRecipientLanguage()` consistent with the rest of the codebase.