### PR TITLE
fix(feedback): three guest-mode bugs from #538 (filter, like state, count leak)

### DIFF
--- a/frontend/src/components/gallery/GalleryView.tsx
+++ b/frontend/src/components/gallery/GalleryView.tsx
@@ -23,6 +23,7 @@ import { useDevToolsProtection } from '../../hooks/useDevToolsProtection';
 import { api } from '../../config/api';
 import { Upload, Menu, Eye, EyeOff, Shield } from 'lucide-react';
 import { galleryService } from '../../services/gallery.service';
+import { feedbackService } from '../../services/feedback.service';
 import { useWatermarkSettings } from '../../hooks/useWatermarkSettings';
 import { useGalleryCustomCss } from '../../hooks/useGalleryCustomCss';
 import { usePublicSettings } from '../../hooks/usePublicSettings';
@@ -228,6 +229,46 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event }) => {
       setFeedbackEnabled(feedbackSettings.feedback_enabled || false);
     }
   }, [feedbackSettings]);
+
+  // In guest identity mode both the "Liked / Favorited / Rated /
+  // Commented" filters AND the matching chip-count labels need to scope
+  // to the *current guest's* interactions, not the global aggregates on
+  // each photo row (#538 bug 1). Pull the current guest's feedback via
+  // /my-feedback (already keyed by x-guest-token in the api interceptor)
+  // and build per-type photo-id sets so both consumers below can do
+  // O(1) lookups.
+  //
+  // Always-on in guest mode (not gated on the active filter) because
+  // the chip counts render whether or not a feedback filter is selected
+  // — gating on filterType would leave "Liked (0)" stale until the user
+  // clicks the chip, which is the same UX cliff bug 1 was reporting.
+  const isGuestIdentityMode = feedbackSettings?.identity_mode === 'guest';
+  const { data: myFeedbackRows } = useQuery<Array<{
+    photo_id: number;
+    feedback_type: 'like' | 'favorite' | 'rating' | 'comment';
+  }>>({
+    queryKey: ['my-feedback', slug],
+    queryFn: () => feedbackService.getMyFeedback(slug),
+    enabled: isGuestIdentityMode && !!slug,
+    staleTime: 30 * 1000,
+  });
+
+  const myFeedbackPhotoIds = useMemo(() => {
+    const sets = {
+      liked: new Set<number>(),
+      favorited: new Set<number>(),
+      rated: new Set<number>(),
+      commented: new Set<number>(),
+    };
+    if (!myFeedbackRows) return sets;
+    for (const row of myFeedbackRows) {
+      if (row.feedback_type === 'like') sets.liked.add(row.photo_id);
+      else if (row.feedback_type === 'favorite') sets.favorited.add(row.photo_id);
+      else if (row.feedback_type === 'rating') sets.rated.add(row.photo_id);
+      else if (row.feedback_type === 'comment') sets.commented.add(row.photo_id);
+    }
+    return sets;
+  }, [myFeedbackRows]);
 
   // Apply branding settings
   useEffect(() => {
@@ -444,19 +485,33 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event }) => {
       );
     }
     
-    // Apply feedback filter
+    // Apply feedback filter. In guest identity mode the filter has to
+    // scope to the *current guest's* interactions (#538 bug 1) — the
+    // aggregate counts on each photo row are global across all guests,
+    // which gave an empty grid when the guest had liked photos that
+    // nobody else had touched. Falls back to the aggregate-count check
+    // in simple/non-guest mode where there's no per-person identity to
+    // scope by.
     switch (filterType) {
       case 'liked':
-        photos = photos.filter(photo => (photo.like_count || 0) > 0);
+        photos = isGuestIdentityMode
+          ? photos.filter(photo => myFeedbackPhotoIds.liked.has(photo.id))
+          : photos.filter(photo => (photo.like_count || 0) > 0);
         break;
       case 'favorited':
-        photos = photos.filter(photo => (photo.favorite_count || 0) > 0);
+        photos = isGuestIdentityMode
+          ? photos.filter(photo => myFeedbackPhotoIds.favorited.has(photo.id))
+          : photos.filter(photo => (photo.favorite_count || 0) > 0);
         break;
       case 'rated':
-        photos = photos.filter(photo => (photo.average_rating || 0) > 0 || (photo.total_ratings || 0) > 0);
+        photos = isGuestIdentityMode
+          ? photos.filter(photo => myFeedbackPhotoIds.rated.has(photo.id))
+          : photos.filter(photo => (photo.average_rating || 0) > 0 || (photo.total_ratings || 0) > 0);
         break;
       case 'commented':
-        photos = photos.filter(photo => (photo.comment_count || 0) > 0);
+        photos = isGuestIdentityMode
+          ? photos.filter(photo => myFeedbackPhotoIds.commented.has(photo.id))
+          : photos.filter(photo => (photo.comment_count || 0) > 0);
         break;
       default:
         break;
@@ -502,22 +557,29 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event }) => {
     }
     
     return photos;
-  }, [data?.photos, selectedCategoryId, searchTerm, sortBy, sortDesc, watermarkEnabled, slug, filterType, mediaFilter]);
+  }, [data?.photos, selectedCategoryId, searchTerm, sortBy, sortDesc, watermarkEnabled, slug, filterType, mediaFilter, isGuestIdentityMode, myFeedbackPhotoIds]);
 
-  const likeCount = useMemo(
-    () => data?.photos?.filter(p => (p.like_count ?? 0) > 0).length || 0,
-    [data?.photos]
-  );
+  // Counts shown in the filter chips ("Liked (N)", etc.). In guest
+  // mode these need to mirror the per-guest filter behaviour above —
+  // otherwise the chip says "Liked (5)" globally but clicking it
+  // surfaces 3 (the guest's own subset), which is the same confusing
+  // mismatch #538 reported for the filter itself. Fall back to the
+  // global aggregate in simple mode where no per-person identity
+  // exists.
+  const likeCount = useMemo(() => {
+    if (isGuestIdentityMode) return myFeedbackPhotoIds.liked.size;
+    return data?.photos?.filter(p => (p.like_count ?? 0) > 0).length || 0;
+  }, [data?.photos, isGuestIdentityMode, myFeedbackPhotoIds]);
 
-  const favoriteCount = useMemo(
-    () => data?.photos?.filter(p => (p.favorite_count ?? 0) > 0).length || 0,
-    [data?.photos]
-  );
+  const favoriteCount = useMemo(() => {
+    if (isGuestIdentityMode) return myFeedbackPhotoIds.favorited.size;
+    return data?.photos?.filter(p => (p.favorite_count ?? 0) > 0).length || 0;
+  }, [data?.photos, isGuestIdentityMode, myFeedbackPhotoIds]);
 
-  const ratedCount = useMemo(
-    () => data?.photos?.filter(p => (p.total_ratings || 0) > 0 || (p.average_rating || 0) > 0).length || 0,
-    [data?.photos]
-  );
+  const ratedCount = useMemo(() => {
+    if (isGuestIdentityMode) return myFeedbackPhotoIds.rated.size;
+    return data?.photos?.filter(p => (p.total_ratings || 0) > 0 || (p.average_rating || 0) > 0).length || 0;
+  }, [data?.photos, isGuestIdentityMode, myFeedbackPhotoIds]);
 
   // Check if downloads are allowed (both event setting and not expired)
   const allowDownloads = !isExpired && (data?.event?.allow_downloads === true);

--- a/frontend/src/components/gallery/PhotoLightbox.tsx
+++ b/frontend/src/components/gallery/PhotoLightbox.tsx
@@ -78,6 +78,7 @@ export const PhotoLightbox: React.FC<PhotoLightboxProps> = ({
     allow_likes?: boolean;
     allow_ratings?: boolean;
     allow_comments?: boolean;
+    show_feedback_to_guests?: boolean;
     require_name_email?: boolean;
   } | null>(null);
   const [myLiked, setMyLiked] = useState<boolean>(false);
@@ -663,7 +664,13 @@ export const PhotoLightbox: React.FC<PhotoLightboxProps> = ({
                 >
                   <Heart className={`w-5 h-5 ${myLiked ? 'text-white' : 'text-white'}`} />
                 </button>
-                <span className="text-white text-xs min-w-[1.5rem] text-center select-none">{likeCount}</span>
+                {/* Aggregate like count is admin-only when the admin
+                    has hidden feedback from guests (#538 bug 3). Without
+                    this gate, a guest could see how many other guests
+                    liked a photo even with show_feedback_to_guests off. */}
+                {feedbackSettings?.show_feedback_to_guests && (
+                  <span className="text-white text-xs min-w-[1.5rem] text-center select-none">{likeCount}</span>
+                )}
               </div>
             )}
 

--- a/frontend/src/components/gallery/PhotoLikes.tsx
+++ b/frontend/src/components/gallery/PhotoLikes.tsx
@@ -111,8 +111,12 @@ export const PhotoLikes: React.FC<PhotoLikesProps> = ({
       onClick={handleLikeClick}
       disabled={isSubmitting}
       className={`group flex items-center gap-2 px-3 py-2 rounded-lg transition-all ${
-        isLiked 
-          ? 'bg-red-50 text-red-600 hover:bg-red-100' 
+        // Filled solid-red state matches the lightbox toolbar (#538 bug
+        // 2). The previous `bg-red-50 text-red-600` was almost invisible
+        // — particularly on dark themes and coloured gallery backgrounds
+        // — so the user couldn't tell the like had registered.
+        isLiked
+          ? 'bg-red-500/80 text-white hover:bg-red-500'
           : 'bg-surface text-muted-theme hover:bg-black/10'
       } ${isSubmitting ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'}`}
       aria-label={isLiked ? t('feedback.unlike', 'Unlike') : t('feedback.like', 'Like')}


### PR DESCRIPTION
## Summary

Picks up three of the four bugs from @Tietge86's [report in #538](https://github.com/the-luap/picpeak/issues/538). Bug 4 (recovery flow) is deferred pending network-tab data from the reporter — commented on the issue asking for the HTTP status from \`POST /gallery/:slug/guest/recover\`.

### Bug 1 — \"Liked\" filter empty in guest identity mode

\`GalleryView.tsx\` was scoping the feedback filter by \`photo.like_count > 0\` (global aggregate across all guests). In guest identity mode the filter intent is \"show MY picks\" — guests who'd liked photos that nobody else had touched got an empty grid.

Fix: pull the current guest's interactions from \`/my-feedback\` (already keyed by \`x-guest-token\` in the api interceptor) into per-type photo-id Sets and filter against those when \`identity_mode === 'guest'\`. Falls back to the aggregate-count check in simple mode (no per-person identity to scope by). Same per-guest scoping applied to the chip-count labels so they match what the filter actually surfaces.

### Bug 2 — Liked state on PhotoLikes button invisible

\`bg-red-50 text-red-600\` is barely visible on dark or brand-coloured backgrounds. Switched to the same filled state the lightbox toolbar already uses (\`bg-red-500/80 text-white\`).

### Bug 3 — Aggregate like count leaks in lightbox toolbar

\`PhotoLightbox.tsx\` rendered \`{likeCount}\` unconditionally next to the inline heart button — when the admin has \`show_feedback_to_guests\` off, guests still saw how many others liked a photo. Gated the span on \`feedbackSettings?.show_feedback_to_guests\`, matching the rest of the toolbar.

## Test plan

- [x] \`tsc --noEmit\` clean
- [ ] Manual: enable feedback with \`identity_mode = 'guest'\`, like 2-3 photos as a guest, click the Liked filter chip — confirms my picks appear (was empty before)
- [ ] Manual: in simple mode (\`identity_mode = 'simple'\`), confirm the Liked filter still shows photos with any global likes — falls back to the aggregate path
- [ ] Manual: like a photo in the gallery grid and confirm the heart button now shows solid red on both light and dark themes
- [ ] Manual: with \`show_feedback_to_guests = false\` and another guest's likes recorded, open the lightbox and confirm no aggregate count number appears next to the heart icon
- [ ] CI green

## Out of scope

**Bug 4** — guest recovery flow / 6-digit code dialog not opening. Reporter speculated several causes (401 from \`verifyGalleryAccess\`, stale slug, CORS) but can't confirm without network-tab logs. Asked on the issue for the HTTP status + response body from \`POST /gallery/:slug/guest/recover\` so the fix is targeted instead of speculative.

Refs: #538