### PR TITLE
fix(lightbox): fill the heart icon when liked (#538 follow-up)

### DIFF
--- a/frontend/src/components/gallery/PhotoLightbox.tsx
+++ b/frontend/src/components/gallery/PhotoLightbox.tsx
@@ -662,7 +662,11 @@ export const PhotoLightbox: React.FC<PhotoLightboxProps> = ({
                   aria-label={myLiked ? 'Unlike photo' : 'Like photo'}
                   title={myLiked ? 'Unlike' : 'Like'}
                 >
-                  <Heart className={`w-5 h-5 ${myLiked ? 'text-white' : 'text-white'}`} />
+                  {/* fill-current on the liked state so the heart is
+                      actually visible against the red background — both
+                      branches were `text-white` only (#538 follow-on
+                      bug from @Tietge86). */}
+                  <Heart className={`w-5 h-5 text-white ${myLiked ? 'fill-current' : ''}`} />
                 </button>
                 {/* Aggregate like count is admin-only when the admin
                     has hidden feedback from guests (#538 bug 3). Without


### PR DESCRIPTION
## Summary

Follow-up to #539 — picks up the heart-icon visibility bug @Tietge86 spotted in their second comment on #538, which was pushed after #539 had already been squash-merged. The commit sat on the (now-orphaned) \`fix/guest-feedback-multi-538\` branch instead of landing on beta; this PR brings it across cleanly.

## What changed

\`frontend/src/components/gallery/PhotoLightbox.tsx:665\` — both branches of the heart-icon className were \`text-white\` (the conditional was a no-op), and the \`fill-current\` class that would actually fill the heart was missing entirely. The button background was turning red on like, but the icon stayed as a white outline against the red → nearly invisible.

Before:
\`\`\`tsx
<Heart className={\`w-5 h-5 \${myLiked ? 'text-white' : 'text-white'}\`} />
\`\`\`

After:
\`\`\`tsx
<Heart className={\`w-5 h-5 text-white \${myLiked ? 'fill-current' : ''}\`} />
\`\`\`

\`text-white\` factored outside the conditional (always white against the red / dark-translucent backgrounds the button uses), \`fill-current\` only applied in the liked state.

Same shape as bug 2 of the original #538 report — the like state needs to be visually unambiguous. PhotoLikes.tsx (the grid heart button) was already fixed in #539; this catches the equivalent latent bug in the inline lightbox toolbar.

## Test plan

- [x] \`tsc --noEmit\` clean
- [ ] Manual: open a photo in the lightbox, like it, confirm the heart icon fills solid white against the red background
- [ ] CI green

Refs: #538