### PR TITLE
fix(nginx): honour outer X-Forwarded-Proto when behind a reverse proxy (#547)

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,3 +1,14 @@
+# Honour the outer reverse proxy's X-Forwarded-Proto when present (e.g. NPM,
+# Traefik, Caddy in front of PicPeak). Falls back to nginx's own $scheme when
+# the header is absent (direct access / no outer proxy). Without this the
+# inner nginx was always forwarding "http" to the backend because the outer
+# proxy → inner nginx hop is plain HTTP, breaking Secure cookies and HTTPS
+# URL generation in the backend. See issue #547.
+map $http_x_forwarded_proto $real_proto {
+    default $http_x_forwarded_proto;
+    ""      $scheme;
+}
+
 server {
     listen 80;
     server_name localhost;
@@ -80,7 +91,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $real_proto;
         proxy_cache_bypass $http_upgrade;
         proxy_read_timeout 86400;
 
@@ -97,7 +108,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $real_proto;
 
         # Cache photos
         proxy_cache_valid 200 302 1d;
@@ -112,7 +123,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $real_proto;
 
         # Cache thumbnails
         proxy_cache_valid 200 302 7d;
@@ -128,7 +139,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $real_proto;
 
         # Cache uploads
         proxy_cache_valid 200 302 7d;
@@ -146,7 +157,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $real_proto;
 
         # Fonts rarely change; cache aggressively (matches backend Cache-Control).
         proxy_cache_valid 200 302 7d;
@@ -161,7 +172,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $real_proto;
     }
 
     # Delegate root requests to backend for public landing page handling
@@ -175,7 +186,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $real_proto;
         proxy_read_timeout 60s;
     }
 
@@ -203,7 +214,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $real_proto;
     }
 
     # SPA fallback

--- a/frontend/nginx.dev.conf
+++ b/frontend/nginx.dev.conf
@@ -1,3 +1,10 @@
+# Honour outer reverse-proxy's X-Forwarded-Proto when present (see #547 /
+# frontend/nginx.conf for full rationale).
+map $http_x_forwarded_proto $real_proto {
+    default $http_x_forwarded_proto;
+    ""      $scheme;
+}
+
 server {
     listen 80;
     server_name localhost;
@@ -10,7 +17,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $real_proto;
     }
 
     # Photos proxy to backend
@@ -41,7 +48,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $real_proto;
     }
 
     # SPA fallback


### PR DESCRIPTION
Closes #547

## Summary
When PicPeak runs behind another reverse proxy (NPM, Traefik, Caddy, etc.), the bundled inner nginx receives plain HTTP from the outer proxy. The previous `proxy_set_header X-Forwarded-Proto \$scheme` therefore always told the backend "http", even when the public URL was HTTPS. Express has `trust proxy` enabled for loopback/linklocal/uniquelocal (where the inner nginx container lives), so `req.secure` came back \`false\`, the Secure cookie flag wasn't set, and generated URLs ended up as \`http://\`.

The standard fix: a top-of-file \`map\` that honours the incoming \`X-Forwarded-Proto\` when present and falls back to \`\$scheme\` otherwise (so direct access without an outer proxy still works).

\`\`\`nginx
map \$http_x_forwarded_proto \$real_proto {
    default \$http_x_forwarded_proto;
    ""      \$scheme;
}
\`\`\`

Then every \`proxy_set_header X-Forwarded-Proto \$scheme\` becomes \`\$real_proto\`. Applied to both files:
- \`frontend/nginx.conf\` (bundled production image — 8 occurrences)
- \`frontend/nginx.dev.conf\` (dev image — 2 occurrences)

Thanks @Tietge86 for the report and the precise diagnosis.

## Trust boundary note
The fix unconditionally honours \`X-Forwarded-Proto\` from the incoming hop. That's safe in the typical Docker self-host setup where the frontend container is only reachable via the outer proxy on an internal network. If someone exposes the frontend port directly to the internet alongside a proxy, a client could spoof the protocol — but that's an unusual deployment that already requires manual exposure of the container port.

## Test plan
- [x] \`docker run nginx:1.28-alpine nginx -t\` against the patched \`frontend/nginx.conf\` — syntax OK
- [x] Same validation against \`frontend/nginx.dev.conf\` (with \`--add-host backend:127.0.0.1\` so the upstream lookup at validation time succeeds) — syntax OK
- [ ] Functional verification behind a real reverse proxy (NPM/Traefik/Caddy) — would appreciate confirmation from #547 reporter after this lands on a beta tag