### PR TITLE
docs: list CRM under Beta Features + note dev-compose rebuild gotcha

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,15 @@ cp .env.example .env
 docker-compose -f docker-compose.dev.yml up
 ```
 
+**After pulling changes that touch `backend/package.json` / `backend/package-lock.json` (or the frontend equivalents)**, rebuild the affected image so the live-mounted source can `require()` the new deps:
+
+```bash
+docker compose -f docker-compose.dev.yml up -d --build backend
+# (or `frontend`, or both)
+```
+
+The dev compose bakes `node_modules` into the image while live-mounting `./backend/src` and `./frontend/src` from disk. A dep added on disk won't be picked up until the image is rebuilt — typical symptom is a `MODULE_NOT_FOUND` restart loop on the affected container.
+
 ### Running Tests
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -401,6 +401,7 @@ These features are currently in beta testing and may have limited functionality 
 
 | Feature | Description | Status |
 |---------|-------------|--------|
+| **CRM Module** | Quotes, contracts, invoices, hours logging, calendar, and tax report — feature-flagged off by default. Seeded contract blocks, payment terms, and IBAN / tax defaults are **examples only** and need legal / financial review before customer-facing use. See [docs.picpeak.app/features/crm](https://docs.picpeak.app/features/crm). | 🧪 Beta |
 | **Simple Deployment Script** | One-click deployment script for quick server setup with automated configuration and dependency installation | 🧪 Beta |
 
 ### 📋 Future Enhancements


### PR DESCRIPTION
Two related docs improvements bundled because they trace to the same root event (PR #555 / CRM module landing on beta).

## Commit 1 — README CRM mention

Adds one row to the **"🚧 Beta Features (Use at your own risk)"** table linking to the new [docs.picpeak.app/features/crm](https://docs.picpeak.app/features/crm) section. Mirrors the structure of the existing Simple Deployment Script row.

CRM is intentionally **NOT** added to the top-of-README "Key Features" list — those are stable production features. Mixing the beta CRM in there would undermine the same stable / beta distinction we just documented in [RELEASING.md](RELEASING.md) (PR #576).

## Commit 2 — Dev compose rebuild gotcha note

Real bug surfaced today: when PR #555 added `pdfkit`, `swissqrbill`, `pdf-lib`, and `qrcode` to `backend/package.json`, every dev with an already-built dev image hit `MODULE_NOT_FOUND` on the next pull. Root cause: `docker-compose.dev.yml` bakes `node_modules` into the image while live-mounting `./backend/src` (and the frontend equivalent) from disk. A dep added on disk isn't visible to the running container until the image is rebuilt.

The symptom (cryptic require error in a restart loop) doesn't point at the cause. Adding a short note to the Local Development section of `CONTRIBUTING.md` so future devs hitting this can see the fix immediately.

## Follow-up out of scope

A **self-healing entrypoint** (compare `node_modules/.package-lock.json` vs `/app/package-lock.json` on boot, run `npm ci` if they differ) would fix this at the runtime layer too — no doc-reading required. Not in this PR; happy to file as a separate issue if you want.

## Test plan

- [x] README renders correctly on GitHub.
- [x] CONTRIBUTING.md renders correctly.
- [x] Pre-push hook (which checks backend health) passes — verified after rebuilding my local dev backend with the same command the new docs recommend.
- [ ] Manual: cold-cloning the repo and following CONTRIBUTING gets to a working dev env without hitting the MODULE_NOT_FOUND wall on the first package.json-changing pull.

## Related

- Full CRM docs (`features/crm/*` + `guides/admin-settings/crm`) shipped to the docs repo on branch `docs/crm-module` — Gitea MR pending your review there.