### PR TITLE
fix(notifications): restore /clear-all route the frontend already calls (#597)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,9 +60,9 @@ jobs:
           #   integration/webhookDelivery         — supertest fixture
           #   services/backupService.enhanced     — knex mock chain
           #   routes/__tests__/adminAuth          — supertest fixture
-          #   routes/__tests__/adminNotifications — supertest fixture
+          # (adminNotifications was excluded; #597 fix re-enables it.)
           npx jest \
-            --testPathIgnorePatterns='/node_modules/|adminSettings\.logo\.test|integration/adminPhotos\.reference|integration/webhookDelivery|backupService\.enhanced|routes/__tests__/adminAuth|routes/__tests__/adminNotifications' \
+            --testPathIgnorePatterns='/node_modules/|adminSettings\.logo\.test|integration/adminPhotos\.reference|integration/webhookDelivery|backupService\.enhanced|routes/__tests__/adminAuth' \
             --ci
 
   frontend:

--- a/backend/src/routes/__tests__/adminNotifications.test.js
+++ b/backend/src/routes/__tests__/adminNotifications.test.js
@@ -28,6 +28,13 @@ jest.mock('../../middleware/auth', () => ({
   adminAuth: (_req, _res, next) => next(),
 }));
 
+// requirePermission is its own module — without this mock the real
+// implementation runs, queries role_permissions on the mocked db, and
+// 403s before we ever reach the handler.
+jest.mock('../../middleware/permissions', () => ({
+  requirePermission: () => (_req, _res, next) => next(),
+}));
+
 const { db } = require('../../database/db');
 const notificationsRouter = require('../adminNotifications');
 

--- a/backend/src/routes/adminNotifications.js
+++ b/backend/src/routes/adminNotifications.js
@@ -98,62 +98,22 @@ router.put('/read-all', adminAuth, requirePermission('settings.edit'), async (re
   }
 });
 
-// Delete old notifications (older than 30 days and read)
-router.delete('/clear-old', adminAuth, requirePermission('settings.edit'), async (req, res) => {
+// Clear all notifications (#597).
+//
+// The frontend AdminHeader "Clear All" button hits this — its service
+// at `notifications.service.ts` does DELETE /admin/notifications/clear-all.
+// The previous /clear-old route was named for an "older than 30 days
+// and read" semantic but had a fallback that deleted EVERYTHING when
+// nothing matched the date filter, so it was effectively a confusingly
+// named Clear All anyway. Drop the rename and the branching, return
+// the simple deletedCount the existing test (and frontend toast) expect.
+router.delete('/clear-all', adminAuth, requirePermission('settings.edit'), async (req, res) => {
   try {
-    // Use database-agnostic date calculation
-    const thirtyDaysAgo = new Date();
-    thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
-
-    let deletedCount = 0;
-    const client = db?.client?.config?.client;
-
-    if (client === 'pg') {
-      const primaryResult = await db.raw(
-        `
-          WITH deleted AS (
-            DELETE FROM activity_logs
-            WHERE read_at IS NOT NULL OR created_at < ?
-            RETURNING id
-          )
-          SELECT COUNT(*)::int AS count FROM deleted
-        `,
-        [thirtyDaysAgo.toISOString()]
-      );
-      deletedCount = primaryResult.rows?.[0]?.count || 0;
-
-      if (deletedCount === 0) {
-        const fallbackResult = await db.raw(
-          `
-            WITH deleted AS (
-              DELETE FROM activity_logs
-              RETURNING id
-            )
-            SELECT COUNT(*)::int AS count FROM deleted
-          `
-        );
-        deletedCount = fallbackResult.rows?.[0]?.count || 0;
-      }
-    } else {
-      deletedCount = await db('activity_logs')
-        .where(function () {
-          this.whereNotNull('read_at')
-            .orWhere('created_at', '<', thirtyDaysAgo);
-        })
-        .delete();
-
-      if (deletedCount === 0) {
-        deletedCount = await db('activity_logs').delete();
-      }
-    }
-
-    res.json({ 
-      message: deletedCount > 0 ? 'Old notifications cleared' : 'No notifications to clear',
-      deletedCount 
-    });
+    const deletedCount = await db('activity_logs').delete();
+    res.json({ message: 'All notifications cleared', deletedCount });
   } catch (error) {
-    console.error('Clear old notifications error:', error);
-    res.status(500).json({ error: 'Failed to clear old notifications' });
+    console.error('Clear notifications error:', error);
+    res.status(500).json({ error: 'Failed to clear notifications' });
   }
 });
 


### PR DESCRIPTION
## Summary

Closes #597.

The AdminHeader "Clear All" notifications button has been silently 404'ing. Frontend `notifications.service.ts` calls `DELETE /admin/notifications/clear-all`, backend only defined `DELETE /admin/notifications/clear-old`. Renaming the route + dropping the tiered fallback logic restores the behavior the frontend (and the existing test) expect.

### Root cause

- `frontend/src/services/notifications.service.ts:44` → `api.delete('/admin/notifications/clear-all')`
- `backend/src/routes/adminNotifications.js:102` → `router.delete('/clear-old', ...)`

So every click returned 404. The "Clear All" button has effectively been dead.

### Why it slipped past CI

There's an existing test (`backend/src/routes/__tests__/adminNotifications.test.js`) that correctly expects `DELETE /clear-all` and asserts the simple `{ message: 'All notifications cleared', deletedCount }` shape. It was failing locally for two reasons — (1) the route mismatch, (2) the mock only stubbed `adminAuth`, while `requirePermission` lives in its own middleware module and ran for real, 403'ing before the handler. So someone added it to CI's `--testPathIgnorePatterns` ignore list in `tests.yml` instead of fixing it. With the route fixed and the permissions middleware mocked passthrough, both assertions in the file pass.

### The /clear-old curiosity

The previous `/clear-old` handler tried to delete read OR >30-days-old rows, then had a fallback that nuked EVERY row when nothing matched the filter. So it was effectively a confusingly-named Clear All anyway — nobody calling it actually wanted the tiered logic. Drop both branches, do a single `db('activity_logs').delete()`, return the deletedCount.

### Changes

- `backend/src/routes/adminNotifications.js` — replace the `/clear-old` handler with a small `/clear-all` handler that does what the frontend and test agree on.
- `backend/src/routes/__tests__/adminNotifications.test.js` — add a passthrough mock for `../../middleware/permissions` alongside the existing auth mock.
- `.github/workflows/tests.yml` — drop `routes/__tests__/adminNotifications` from `--testPathIgnorePatterns` so future regressions in this route fail CI loudly instead of going to ground.

## Test plan

- [x] `npx jest src/routes/__tests__/adminNotifications.test.js` passes both cases locally (clears all + handles DB error)
- [x] Pre-push smoke tests passed (13/13)
- [ ] **Manual:** open admin → bell icon → "Clear All" → notifications list empties + success toast fires with the cleared count