### PR TITLE
fix(admin/events): delete cascade orphaned photo folders because it read a non-existent column (#608)

### DIFF
--- a/backend/src/routes/adminEvents.js
+++ b/backend/src/routes/adminEvents.js
@@ -286,9 +286,25 @@ async function deleteEventCascade(eventId, adminContext) {
     // Best-effort filesystem cleanup. Failures are logged but don't unwind
     // the transaction — the canonical state lives in the DB; orphan files
     // are recoverable noise, a half-deleted DB row is a permanent mess.
-    if (event.folder_path) {
-      const storagePath = process.env.STORAGE_PATH || path.join(__dirname, '../../../storage');
-      const eventFolderPath = path.join(storagePath, 'events', 'active', event.folder_path);
+    //
+    // #608 — previous code read `event.folder_path`, but that column is
+    // never written anywhere in the codebase (grep confirms: two reads in
+    // this function, zero writes). It's always undefined, so the
+    // `if (event.folder_path)` branch silently no-op'd and every event
+    // delete since this cascade landed left its photos orphaned on disk.
+    // jodrmx's Pi report (v3.44.0) was the first surfacing.
+    //
+    // Files actually live at:
+    //   {STORAGE_PATH}/events/active/{slug}/...      (uploaded photos)
+    //   {STORAGE_PATH}/events/archived/{slug}/...    (after the event
+    //     was archived — folder copy survives the archive flow)
+    //
+    // `event.slug` is NOT NULL on the events table and is slugify-sanitized
+    // on every write (lower-case ASCII + dashes only via utils/slug.js),
+    // so path-traversal isn't a concern.
+    const storagePath = process.env.STORAGE_PATH || path.join(__dirname, '../../../storage');
+    for (const sub of ['active', 'archived']) {
+      const eventFolderPath = path.join(storagePath, 'events', sub, event.slug);
       try {
         await fs.rm(eventFolderPath, { recursive: true, force: true });
       } catch (fsErr) {


### PR DESCRIPTION
## Summary

Closes #608.

jodrmx (v3.44.0, Pi Lite, Docker compose) reported admin-UI event delete removes the DB row but leaves `storage/events/active/<event>/` intact on disk.

Root cause: `deleteEventCascade` reads `event.folder_path` and gates the per-folder `fs.rm` on it. That column is **never written anywhere** in the codebase — grep confirms two reads in this one function, zero writes elsewhere. So `event.folder_path` was always `undefined`, the `if (event.folder_path)` branch silently no-op'd, and every event delete since this cascade landed left its photos orphaned on disk. The DB transaction itself ran fine, so the symptom has always been "row gone, files stay" — exactly what jodrmx hit.

Everything else in the codebase uses `event.slug` as the per-event folder name:
- `adminPhotos.js:260` writes uploads to `events/active/{slug}/...`
- `adminEvents.js:610`, `events.js:155`, `adminThumbnails.js:153`, `adminArchives.js:171` read from `events/active/{slug}`
- `photoResolver.js:14-15` documents the layout

The delete cascade was the only path looking at the non-existent column.

## What changed

`backend/src/routes/adminEvents.js` — drop the `if (event.folder_path)` guard, read `event.slug` instead, remove from both `events/active/{slug}` (active gallery folder) and `events/archived/{slug}` (the post-archive copy that survives the archive flow). `event.slug` is NOT NULL and slugify-sanitized (lower-case ASCII + dashes only via `utils/slug.js`), so the path is well-formed and path-traversal-safe.

Best-effort `fs.rm` semantics + try/catch unchanged — failures still log a warning rather than unwinding the DB transaction, since orphan files are recoverable noise compared to a half-deleted DB row.

## Forward fix only

This does NOT retroactively clean up the orphans that have accumulated on existing installs (jodrmx's Pi, anyone else who deleted events on stable). Those need a manual `rm -rf storage/events/active/<old-slug>` ritual on the host. Not worth a migration script for a one-time deploy cleanup.

## Test plan

- [x] ESLint clean on changed file (existing pre-fix lint errors in adminEvents.js are unrelated — `hero_logo_size` / `hero_logo_position` unused vars from the #594 batch)
- [x] Pre-push smoke tests passed (13/13)
- [ ] **Manual:** create an event, upload some photos, delete from admin UI → confirm `storage/events/active/{slug}/` is gone on host disk
- [ ] **Manual archived path:** create an event, archive it (so `events/archived/{slug}/` exists), delete from admin UI → confirm both `events/active/{slug}` and `events/archived/{slug}` are gone
- [ ] **Manual STORAGE_PATH override:** with `STORAGE_PATH=/custom/path` env, repeat above and confirm the cleanup targets the custom root
