### PR TITLE
Enabling maintenance mode locks every admin out of the panel

### DIFF
--- a/backend/src/middleware/maintenance.js
+++ b/backend/src/middleware/maintenance.js
@@ -64,10 +64,15 @@ async function checkMaintenanceMode() {
 
 // Middleware to enforce maintenance mode
 async function maintenanceMiddleware(req, res, next) {
-  // Skip maintenance check for certain paths
+  // Skip maintenance check for certain paths. Admin auth MUST work during
+  // maintenance — otherwise enabling it locks every admin out, including
+  // already-logged-in ones (their /auth/session check would 503 and read as
+  // logged-out). These are the REAL endpoints: the admin login + session
+  // routes live under /api/auth, NOT /api/admin (the old /api/admin/login
+  // entries here matched nothing, which is exactly why the lockout happened).
   const skipPaths = [
-    '/api/admin/login',
-    '/api/admin/auth/login',
+    '/api/auth/admin/login',
+    '/api/auth/session',
     '/api/public/settings',
     '/health'
   ];

--- a/frontend/src/components/MaintenanceWrapper.tsx
+++ b/frontend/src/components/MaintenanceWrapper.tsx
@@ -1,58 +1,31 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import { MaintenanceMode } from './MaintenanceMode';
 import { useMaintenanceMode } from '../contexts/MaintenanceContext';
-import { setMaintenanceModeCallback, api } from '../config/api';
+import { setMaintenanceModeCallback } from '../config/api';
 
 interface MaintenanceWrapperProps {
   children: React.ReactNode;
 }
 
-// Maintenance detection now lives in two places:
+// Maintenance detection lives in two places:
 //   1. The axios interceptor in config/api.ts flips the flag on any 503 response.
 //   2. MaintenanceContext polls /public/settings every 30s and reads the explicit
 //      maintenance_mode field (via the shared usePublicSettings hook).
-// This wrapper only needs to gate the rendered tree on the resulting state.
+//
+// The maintenance screen ONLY blocks customer/gallery/public routes. Admin
+// routes (/admin/*) are never blocked: an admin must always be able to reach
+// the panel to turn maintenance back off, and the admin auth layer already
+// handles access (AdminLayout redirects a logged-out admin to /admin/login).
+// Gating /admin/* here on an "is the admin logged in?" check is what caused the
+// lockout — it hid the login page itself, and after login the check went stale
+// (login → dashboard is a client-side nav within /admin, so it never re-ran),
+// leaving a logged-in admin stuck on the maintenance screen.
 export const MaintenanceWrapper: React.FC<MaintenanceWrapperProps> = ({ children }) => {
   const location = useLocation();
   const { isMaintenanceMode, setMaintenanceMode } = useMaintenanceMode();
-  const [hasAdminSession, setHasAdminSession] = useState(false);
 
   const isAdminRoute = location.pathname.startsWith('/admin');
-  // The admin login page must ALWAYS render during maintenance — it's how an
-  // admin gets a session to bypass it. Without this exemption a logged-out
-  // admin sees the maintenance screen over the login form (catch-22: needs a
-  // session to get past maintenance, but the login page that grants one is
-  // hidden).
-  const isAdminLoginRoute = location.pathname.startsWith('/admin/login');
-
-  useEffect(() => {
-    let isMounted = true;
-
-    const checkAdminSession = async () => {
-      if (!isAdminRoute) {
-        setHasAdminSession(false);
-        return;
-      }
-
-      try {
-        const response = await api.get<{ valid: boolean; type: string }>('/auth/session');
-        if (isMounted) {
-          setHasAdminSession(Boolean(response.data?.valid && response.data.type === 'admin'));
-        }
-      } catch {
-        if (isMounted) {
-          setHasAdminSession(false);
-        }
-      }
-    };
-
-    checkAdminSession();
-
-    return () => {
-      isMounted = false;
-    };
-  }, [isAdminRoute]);
 
   useEffect(() => {
     setMaintenanceModeCallback((enabled: boolean) => {
@@ -60,7 +33,7 @@ export const MaintenanceWrapper: React.FC<MaintenanceWrapperProps> = ({ children
     });
   }, [setMaintenanceMode]);
 
-  if (isMaintenanceMode && !isAdminLoginRoute && (!isAdminRoute || !hasAdminSession)) {
+  if (isMaintenanceMode && !isAdminRoute) {
     return <MaintenanceMode />;
   }
 

--- a/frontend/src/components/MaintenanceWrapper.tsx
+++ b/frontend/src/components/MaintenanceWrapper.tsx
@@ -19,6 +19,12 @@ export const MaintenanceWrapper: React.FC<MaintenanceWrapperProps> = ({ children
   const [hasAdminSession, setHasAdminSession] = useState(false);
 
   const isAdminRoute = location.pathname.startsWith('/admin');
+  // The admin login page must ALWAYS render during maintenance — it's how an
+  // admin gets a session to bypass it. Without this exemption a logged-out
+  // admin sees the maintenance screen over the login form (catch-22: needs a
+  // session to get past maintenance, but the login page that grants one is
+  // hidden).
+  const isAdminLoginRoute = location.pathname.startsWith('/admin/login');
 
   useEffect(() => {
     let isMounted = true;
@@ -54,7 +60,7 @@ export const MaintenanceWrapper: React.FC<MaintenanceWrapperProps> = ({ children
     });
   }, [setMaintenanceMode]);
 
-  if (isMaintenanceMode && (!isAdminRoute || !hasAdminSession)) {
+  if (isMaintenanceMode && !isAdminLoginRoute && (!isAdminRoute || !hasAdminSession)) {
     return <MaintenanceMode />;
   }
 


### PR DESCRIPTION
Fixes #617

### Summary
Turning on **System Maintenance mode** (Settings → General) locks out **all** admins — including ones already logged in — with no way back into the panel from the browser. As reported in #617, the only recovery is editing `app_settings` in the database directly. Reproduced on a live install (Docker Compose, latest beta).

### Root cause
Two compounding bugs:

**1. Backend — stale allow-list (`backend/src/middleware/maintenance.js`)**
The maintenance middleware 503s every non-`/api/admin/*` request, with a hardcoded `skipPaths` allow-list. But that list pointed at `/api/admin/login` and `/api/admin/auth/login`, which **don't exist** — the real admin auth routes live under `/api/auth`:
- `POST /api/auth/admin/login` (login)
- `GET /api/auth/session` (session validation)

So during maintenance both the login POST and the session check returned 503. The 503 on `/auth/session` made the frontend read every admin as logged-out, and also tripped the axios interceptor that force-enables maintenance globally.

**2. Frontend — `/admin/*` gated on a session check (`frontend/src/components/MaintenanceWrapper.tsx`)**
The wrapper rendered the maintenance screen over every `/admin/*` route unless an admin session was detected via `/auth/session`. This:
- hid the `/admin/login` page itself (catch-22: you need a session to get past maintenance, but the page that grants one is hidden), and
- the session-check effect depended on the `isAdminRoute` boolean, so the client-side `login → dashboard` navigation (both under `/admin`) never re-ran it — a freshly logged-in admin landed on the maintenance screen with a stale `hasAdminSession === false`.

### Fix
- **Backend:** correct `skipPaths` to the real endpoints (`/api/auth/admin/login`, `/api/auth/session`) so login and session validation work during maintenance. `/api/admin/*` already passes through (only non-admin routes are 503'd); admin data endpoints are unaffected.
- **Frontend:** the maintenance screen now blocks **only** customer/gallery/public routes — `/admin/*` is never covered. The admin auth layer already handles access (`AdminLayout` redirects a logged-out admin to `/admin/login`, the login page redirects an authenticated one to the dashboard), so the wrapper needs no `/auth/session` probe at all. Removes the fragile session dependency entirely.

### Behavior after the fix
| | Maintenance ON |
|---|---|
| Customer / gallery / public routes | maintenance screen (unchanged) |
| `/admin/login` (logged out) | login form |
| `/admin/*` (logged in) | normal panel — admin can turn maintenance back off |

### Recovering an already-locked-out install (pre-fix)
For anyone who hits this before the fix ships, flip the flag in the DB and restart the backend:
```bash
docker compose exec postgres psql -U "$DB_USER" -d "$DB_NAME" \
  -c "UPDATE app_settings SET setting_value='false' WHERE setting_key='general_maintenance_mode' AND setting_type='general';"
docker compose restart backend