### PR TITLE
fix(admin): stack publish-gallery dialog CTAs so the German label fits (#670)

### DIFF
--- a/frontend/src/components/admin/PublishGalleryDialog.tsx
+++ b/frontend/src/components/admin/PublishGalleryDialog.tsx
@@ -110,12 +110,21 @@ export const PublishGalleryDialog: React.FC<PublishGalleryDialogProps> = ({
           </div>
         )}
 
-        <div className="flex gap-3">
+        {/* Stack both buttons vertically (always). The German primary label
+            "Veröffentlichen & Kunden benachrichtigen" is ~40 chars including
+            the icon — at max-w-md, no side-by-side row layout fits it on one
+            line, and the base .btn class has @apply whitespace-nowrap (see
+            index.css:149) which overrides a whitespace-normal className via
+            CSS cascade order, so the text won't wrap either. Side-by-side
+            would silently push the button past the modal frame (#670).
+            col-reverse keeps the DOM order semantically secondary-then-primary
+            while putting the primary action visually on top — standard
+            confirmation-dialog pattern. */}
+        <div className="flex flex-col-reverse gap-3">
           <Button
             variant="outline"
             onClick={onClose}
             disabled={isPublishing}
-            className="flex-1"
           >
             {t('common.cancel', 'Cancel')}
           </Button>
@@ -125,7 +134,6 @@ export const PublishGalleryDialog: React.FC<PublishGalleryDialogProps> = ({
             disabled={isPublishing}
             isLoading={isPublishing}
             leftIcon={<Send className="w-4 h-4" />}
-            className="flex-1"
           >
             {t('events.publishAndNotify')}
           </Button>


### PR DESCRIPTION
Closes #670. The German `Veröffentlichen & Kunden benachrichtigen` primary CTA was overflowing the modal footer in the publish-gallery dialog. Two failure modes chained:

1. **Footer was `flex` with two `flex-1` buttons inside `max-w-md` (448 px).** Default `min-width: auto` on flex children meant the primary kept its content width (~340 px including the paper-airplane icon + padding) and pushed the row past the modal frame.
2. **Adding `min-w-0 whitespace-normal` doesn't help** — the base `.btn` class has `@apply ... whitespace-nowrap` (`index.css:149`) which wins over a utility className via Tailwind's CSS cascade order. So the text won't wrap; the button silently extends past the modal frame with no overflow indicator. Verified with `getComputedStyle().whiteSpace === 'normal'` and the button still rendering as one ~340 px line at ~224 px allocated space.

## Fix

Stack both buttons vertically (`flex flex-col-reverse gap-3`). Primary appears on top via `col-reverse` while the DOM keeps secondary-first ordering for tab semantics. Standard confirmation-dialog pattern — Material, Headless UI, Radix all do this for single-action dialogs. Works in every locale and viewport regardless of label length.

```diff
- <div className="flex gap-3">
+ <div className="flex flex-col-reverse gap-3">
    <Button variant="outline" ... className="flex-1">{cancel}</Button>
    <Button variant="primary" ... className="flex-1">{publishAndNotify}</Button>
  </div>
```

(plus removing the `flex-1` className from both since they're full-width by default in a column flex)

## Two prior shapes I tried and rejected

| Attempt | Why it failed |
| --- | --- |
| `flex-col-reverse sm:flex-row` + `sm:flex-1 min-w-0 whitespace-normal` on the primary | Overflowed silently because of the `whitespace-nowrap` cascade in `.btn` |
| `flex-col-reverse sm:flex-row sm:justify-end` with content-width buttons | `justify-end` doesn't constrain a row whose content sum exceeds the container; row pushes left of the modal |

Bumping `max-w-md` → `max-w-lg` (or wider) was also considered and rejected: asymmetric (every other admin dialog stays at `max-w-md`), and any locale longer than German would re-hit the wall. Stack-always is the only shape that handles every locale × every viewport without per-language tuning.

## Verification

End-to-end against a dockerised dev backend, 4 viewports × locales:

| Viewport | Locale | Result |
| --- | --- | --- |
| Desktop 1280×800 | DE | Primary "Veröffentlichen & Kunden benachrichtigen" single-line on top, "Abbrechen" full-width below, both inside modal ✓ |
| Desktop 1280×800 | EN | Primary "Publish & Notify Client" single-line on top, "Cancel" full-width below ✓ |
| Mobile 375×800 | DE | Same vertical layout, modal contained within viewport ✓ |
| Mobile 375×800 | EN | Same ✓ |

`tsc --noEmit` + `eslint` clean. Full vitest suite (84/84) still green. No i18n changes needed.

## Test plan

- [x] Backend unit suite untouched (no backend changes)
- [x] Frontend unit suite (84 cases) — green
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on changed file
- [x] End-to-end smoke against dockerised backend, 4 viewport × locale combos — all green
- [ ] **Manual** on a deployed beta: confirm same shape for a password-protected draft with a customer email set (where the dialog gets the password input + the full long primary CTA)
