### PR TITLE
fix(events): wire customer notifications into both public API entry points (#647)

### DIFF
--- a/backend/src/routes/events.js
+++ b/backend/src/routes/events.js
@@ -18,6 +18,24 @@ const { IDENTITY_PRESERVING_NORMALIZE_EMAIL } = require('../utils/emailNormaliza
 // Use parseStringInput from shared parsers for customer data extraction
 const getCustomerNameFromPayload = (payload = {}) => parseStringInput(payload.customer_name);
 const getCustomerEmailFromPayload = (payload = {}) => parseStringInput(payload.customer_email);
+const getCustomerPhoneFromPayload = (payload = {}) => parseStringInput(payload.customer_phone);
+
+// Whether the global "phone field" toggle (#322) is enabled. Same shape as
+// the helper in adminEvents.js — kept local so this route doesn't import
+// from a sibling route file.
+const isPhoneFieldEnabled = async () => {
+  try {
+    const row = await db('app_settings').where('setting_key', 'event_phone_field_enabled').first();
+    if (!row) return false;
+    let value = row.setting_value;
+    if (typeof value === 'string') {
+      try { value = JSON.parse(value); } catch { /* keep raw */ }
+    }
+    return value === true;
+  } catch {
+    return false;
+  }
+};
 
 const mapEventForApi = (event) => {
   if (!event || typeof event !== 'object') {
@@ -69,6 +87,9 @@ router.post('/', adminAuth, [
   body('event_date').isDate(),
   body('customer_name').notEmpty().trim(),
   body('customer_email').isEmail().normalizeEmail(IDENTITY_PRESERVING_NORMALIZE_EMAIL),
+  body('customer_phone').optional({ nullable: true, checkFalsy: true })
+    .isString().trim()
+    .isLength({ max: 32 }).withMessage('Phone number must be at most 32 characters'),
   body('admin_email').isEmail(),
   body('require_password').optional().isBoolean(),
   body('password').optional().isString().custom((value, { req }) => {
@@ -109,6 +130,8 @@ router.post('/', adminAuth, [
     }
 
     const customerColumnsAvailable = await hasCustomerContactColumns();
+    const phoneEnabled = await isPhoneFieldEnabled();
+    const customerPhone = phoneEnabled ? getCustomerPhoneFromPayload(req.body) : null;
 
     const requirePassword = parseBooleanInput(requirePasswordInput, true);
 
@@ -163,6 +186,7 @@ router.post('/', adminAuth, [
       event_name,
       event_date,
       ...(customerColumnsAvailable ? { customer_name: customerName, customer_email: customerEmail } : {}),
+      ...(customerPhone ? { customer_phone: customerPhone } : {}),
       host_name: customerName,
       host_email: customerEmail,
       admin_email,
@@ -192,6 +216,29 @@ router.post('/', adminAuth, [
       welcome_message: welcome_message || ''
     });
 
+    // WhatsApp gallery_ready notification (#647 follow-up). Mirrors the
+    // adminEvents.js path: fires when the customer supplied a phone, the
+    // feature is enabled, and a config exists. Non-fatal — a queue failure
+    // must never block gallery creation.
+    if (customerPhone) {
+      try {
+        const { queueWhatsapp, getWhatsAppConfig } = require('../services/whatsappProcessor');
+        const waConfig = await getWhatsAppConfig();
+        if (waConfig && waConfig.enabled) {
+          await queueWhatsapp(eventId, customerPhone, 'gallery_created', {
+            customer_name: customerName || '',
+            event_name,
+            gallery_link: shareUrl,
+            gallery_password: requirePassword ? password : '',
+            expiry_date: expires_at ? expires_at.toISOString() : null,
+            language: null,
+          });
+        }
+      } catch (waError) {
+        console.warn('Failed to queue WhatsApp notification on create', waError.message);
+      }
+    }
+
     // Webhook lifecycle (#327). Legacy public endpoint — events go live
     // immediately so created + published fire together. Payload uses the
     // canonical event subject (#341) — every event.* webhook now includes
@@ -208,6 +255,7 @@ router.post('/', adminAuth, [
         share_token: shareToken,
         customer_name: customerName,
         customer_email: customerEmail,
+        customer_phone: customerPhone,
       });
       await webhookService.fire('event.created', { event: eventSubject });
       await webhookService.fire('event.published', { event: eventSubject });

--- a/backend/src/routes/v1/events.js
+++ b/backend/src/routes/v1/events.js
@@ -308,6 +308,48 @@ router.post(
         type: 'admin', id: req.admin.id, name: req.admin.username
       });
 
+      // Customer notifications (#647 follow-up). v1 events go live in the
+      // same call (not draft-aware), so the gallery_created email + WhatsApp
+      // fire here — mirroring the adminEvents.js create-and-publish path.
+      // Both are best-effort: a queue failure must not block the API response.
+      const expiryIso = expires_at ? new Date(expires_at).toISOString() : null;
+      if (customer_email) {
+        try {
+          const { queueEmail } = require('../../services/emailProcessor');
+          await queueEmail(id, customer_email, 'gallery_created', {
+            customer_name: customer_name || '',
+            customer_email,
+            host_name: customer_name || '',
+            event_name,
+            event_date: event_date || null,
+            gallery_link: shareUrl,
+            gallery_password: require_password ? password : 'No password required',
+            expiry_date: expiryIso,
+            welcome_message: ''
+          });
+        } catch (emailError) {
+          logger.warn('v1 POST /events: failed to queue gallery_created email', { error: emailError.message });
+        }
+      }
+      if (persistPhone) {
+        try {
+          const { queueWhatsapp, getWhatsAppConfig } = require('../../services/whatsappProcessor');
+          const waConfig = await getWhatsAppConfig();
+          if (waConfig && waConfig.enabled) {
+            await queueWhatsapp(id, persistPhone, 'gallery_created', {
+              customer_name: customer_name || '',
+              event_name,
+              gallery_link: shareUrl,
+              gallery_password: require_password ? password : '',
+              expiry_date: expiryIso,
+              language: null,
+            });
+          }
+        } catch (waError) {
+          logger.warn('v1 POST /events: failed to queue WhatsApp notification', { error: waError.message });
+        }
+      }
+
       // Webhook lifecycle (#327). v1 events are not draft-aware, so they're
       // both created AND published in the same call. Canonical event
       // subject (#341) — customer contact + share_token always included.


### PR DESCRIPTION
## Summary

@Rekoo-PS reported that **WhatsApp notifications don't fire for API-created events** (#647 thread). Investigation found the symptom is real for both public event-creation entry points, and the v1 API is missing the **email** notification too — only the webhook fires today.

### Landscape before this PR

| Route | Email queued? | WhatsApp queued? |
|---|---|---|
| `/api/admin/events` (UI) | ✅ | ✅ |
| `/api/events` (legacy admin-auth alt — `events.js`) | ✅ | ❌ |
| `/api/v1/events` (bearer-token public API — `v1/events.js`) | ❌ | ❌ |

Both gaps share the same root cause: when WhatsApp was added (#640 part D) and when the email queue was extended in earlier work, only the admin UI path (`adminEvents.js`) was wired up. The two alternate entry points were forgotten.

### Fix

Both routes now mirror the `adminEvents.js` create-and-publish path:

- **`routes/events.js`** (the legacy admin-auth `POST /api/events`):
  - Added `customer_phone` to body validation + `getCustomerPhoneFromPayload` helper.
  - Added `isPhoneFieldEnabled` helper (mirrors the one in `adminEvents.js:202` — kept local rather than importing from a sibling route file).
  - Persists `customer_phone` to the row when the global toggle is on.
  - Queues `gallery_created` WhatsApp after the existing `queueEmail` call.
  - Webhook subject now includes `customer_phone`.

- **`routes/v1/events.js`** (the OpenAPI-spec'd bearer-token `POST /api/v1/events`):
  - Already accepted/validated/persisted `customer_phone` correctly. No body changes.
  - Added the `gallery_created` email queue (between the activity log and the webhook fire).
  - Added the `gallery_created` WhatsApp queue gated on `persistPhone` (the phone-flag-gated value, so disabling the toggle globally suppresses WhatsApp the same way it suppresses persistence).
  - Both blocks are best-effort try/catch — a queue failure must never block the API response.

### Behaviour

- v1: `customer_email` is optional in v1, so the email queue is gated on it. Same for `persistPhone` and WhatsApp. The `expires_at` ISO conversion handles the v1-specific case where the field can be null.
- All four notification calls share the same WhatsApp resolution semantics established in #649 + #650 — language pinned via `config.template_language`, slots picked via `config.template_params`, default Arabic locale supported.

### Out of scope (intentional)

- No schema change. `customer_phone` already exists on `events` (migration 080).
- No tests added — there's no existing `events.js` or `v1/events.js` route-level integration suite to extend, and `whatsappProcessor`/`buildComponents` are already covered by the 17 tests added in #650 (all still passing locally).
- The "API endpoints don't queue customer notifications" class is now closed for create. Update/lifecycle endpoints on v1 are not in scope here (v1 is intentionally narrow per its docstring at `v1/events.js:2-6`).

## Test plan

- [ ] Send `POST /api/v1/events` with `customer_email` + `customer_phone` → confirm both `email_queue` and `whatsapp_queue` get a row, and the WhatsApp row uses the configured `template_language`.
- [ ] Send `POST /api/v1/events` without `customer_email` → confirm no email row queued, no crash.
- [ ] Send `POST /api/v1/events` with `customer_phone` while the global phone toggle is OFF → confirm no WhatsApp row queued, phone not persisted.
- [ ] Send `POST /api/events` with `customer_phone` while the global phone toggle is ON → confirm WhatsApp row queued.
- [ ] Confirm `webhook_deliveries` rows from `/api/events` now carry `customer_phone` in the subject.
- [ ] Closing #647 once @Rekoo-PS validates the API path end-to-end after this lands.