### PR TITLE
chore: migrate Docker registry + GitHub URLs to PicPeak org

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,11 @@
 blank_issues_enabled: false
 contact_links:
   - name: 📚 Documentation
-    url: https://github.com/the-luap/picpeak/blob/main/DEPLOYMENT.md
+    url: https://github.com/PicPeak/picpeak/blob/main/DEPLOYMENT.md
     about: Please read the documentation before opening an issue
   - name: 💬 Discussions
-    url: https://github.com/the-luap/picpeak/discussions
+    url: https://github.com/PicPeak/picpeak/discussions
     about: Ask questions and discuss with the community
   - name: 🔒 Security Issues
-    url: https://github.com/the-luap/picpeak/blob/main/SECURITY.md
+    url: https://github.com/PicPeak/picpeak/blob/main/SECURITY.md
     about: Please review our security policy for reporting vulnerabilities

--- a/.github/ISSUE_TEMPLATE/security_vulnerability.md
+++ b/.github/ISSUE_TEMPLATE/security_vulnerability.md
@@ -9,7 +9,7 @@ assignees: ''
 
 ⚠️ **IMPORTANT: For serious security vulnerabilities, please DO NOT create a public issue.**
 
-Instead, please use [GitHub Private Vulnerability Reporting](https://github.com/the-luap/picpeak/security/advisories/new) or email **info@picpeak.app** with the details.
+Instead, please use [GitHub Private Vulnerability Reporting](https://github.com/PicPeak/picpeak/security/advisories/new) or email **info@picpeak.app** with the details.
 
 For minor security improvements or questions, you can use this template:
 

--- a/.github/workflows/README-DOCKER.md
+++ b/.github/workflows/README-DOCKER.md
@@ -42,16 +42,16 @@ Once published, images can be pulled using:
 
 ```bash
 # Pull backend image
-docker pull ghcr.io/the-luap/picpeak/backend:latest
+docker pull ghcr.io/picpeak/picpeak/backend:latest
 
 # Pull frontend image
-docker pull ghcr.io/the-luap/picpeak/frontend:latest
+docker pull ghcr.io/picpeak/picpeak/frontend:latest
 
 # Pull specific version
-docker pull ghcr.io/the-luap/picpeak/backend:v1.0.0
+docker pull ghcr.io/picpeak/picpeak/backend:v1.0.0
 
 # Pull for specific architecture
-docker pull --platform linux/arm64 ghcr.io/the-luap/picpeak/backend:latest
+docker pull --platform linux/arm64 ghcr.io/picpeak/picpeak/backend:latest
 ```
 
 ### Using in Docker Compose
@@ -61,14 +61,14 @@ version: '3.8'
 
 services:
   backend:
-    image: ghcr.io/the-luap/picpeak/backend:latest
+    image: ghcr.io/picpeak/picpeak/backend:latest
     environment:
       - NODE_ENV=production
     ports:
       - "3001:3000"
 
   frontend:
-    image: ghcr.io/the-luap/picpeak/frontend:latest
+    image: ghcr.io/picpeak/picpeak/frontend:latest
     ports:
       - "80:80"
 ```
@@ -86,7 +86,7 @@ spec:
     spec:
       containers:
       - name: backend
-        image: ghcr.io/the-luap/picpeak/backend:latest
+        image: ghcr.io/picpeak/picpeak/backend:latest
         imagePullPolicy: Always
 ```
 
@@ -149,8 +149,8 @@ If images aren't visible after successful push:
 ### View Packages
 
 Your Docker images are available at:
-- Backend: `https://github.com/users/the-luap/packages/container/package/picpeak%2Fbackend`
-- Frontend: `https://github.com/users/the-luap/packages/container/package/picpeak%2Ffrontend`
+- Backend: `https://github.com/orgs/PicPeak/packages/container/package/picpeak%2Fbackend`
+- Frontend: `https://github.com/orgs/PicPeak/packages/container/package/picpeak%2Ffrontend`
 
 ### Delete Old Versions
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -20,7 +20,7 @@ We are committed to providing a welcoming and inspiring community for all photog
 
 ## Enforcement
 
-Instances of unacceptable behavior may be reported by [opening an issue](https://github.com/the-luap/picpeak/issues/new?labels=conduct) on GitHub. All complaints will be reviewed and investigated promptly and fairly.
+Instances of unacceptable behavior may be reported by [opening an issue](https://github.com/PicPeak/picpeak/issues/new?labels=conduct) on GitHub. All complaints will be reviewed and investigated promptly and fairly.
 
 ## Attribution
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,8 +33,8 @@ Enhancement suggestions are tracked as GitHub issues. When creating an enhanceme
 
 Unsure where to begin? You can start by looking through these issues:
 
-* [Good first issues](https://github.com/the-luap/picpeak/labels/good%20first%20issue) - issues which should only require a few lines of code
-* [Help wanted issues](https://github.com/the-luap/picpeak/labels/help%20wanted) - issues which need extra attention
+* [Good first issues](https://github.com/PicPeak/picpeak/labels/good%20first%20issue) - issues which should only require a few lines of code
+* [Help wanted issues](https://github.com/PicPeak/picpeak/labels/help%20wanted) - issues which need extra attention
 
 ### Pull Requests
 
@@ -161,8 +161,8 @@ See [RELEASING.md](RELEASING.md) for the full operational doc (promotion criteri
 
 ## 📮 Contact
 
-- Create an [issue](https://github.com/the-luap/picpeak/issues) for bugs or features
-- Join [discussions](https://github.com/the-luap/picpeak/discussions) for questions
-- Security issues: Open a [security issue](https://github.com/the-luap/picpeak/issues/new?labels=security) on GitHub
+- Create an [issue](https://github.com/PicPeak/picpeak/issues) for bugs or features
+- Join [discussions](https://github.com/PicPeak/picpeak/discussions) for questions
+- Security issues: Open a [security issue](https://github.com/PicPeak/picpeak/issues/new?labels=security) on GitHub
 
 Thank you for contributing! 🎉

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Get PicPeak running in under 5 minutes:
 
 ```bash
 # Clone the repository
-git clone https://github.com/the-luap/picpeak.git
+git clone https://github.com/PicPeak/picpeak.git
 cd picpeak
 
 # Copy environment template
@@ -392,7 +392,7 @@ PicPeak takes security seriously:
 - 📝 Activity logging
 - 🔒 Secure file access
 
-Found a security issue? Please open a [security issue](https://github.com/the-luap/picpeak/issues/new?labels=security) on GitHub
+Found a security issue? Please open a [security issue](https://github.com/PicPeak/picpeak/issues/new?labels=security) on GitHub
 
 ## 📸 Screenshots
 
@@ -537,7 +537,7 @@ PicPeak is released under the [MIT License](LICENSE). Use it freely for personal
   <br>
   <a href="https://www.picpeak.app">Homepage</a> •
   <a href="https://demo.picpeak.app">Live Demo</a> •
-  <a href="https://github.com/the-luap/picpeak">GitHub</a> •
+  <a href="https://github.com/PicPeak/picpeak">GitHub</a> •
   <a href="https://docs.picpeak.app">Documentation</a> •
-  <a href="https://github.com/the-luap/picpeak/issues">Support</a>
+  <a href="https://github.com/PicPeak/picpeak/issues">Support</a>
 </p>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,7 +16,7 @@ We take the security of PicPeak seriously. If you have discovered a security vul
 ### 1. **Do NOT create a public GitHub issue**
 
 ### 2. Report the vulnerability privately by:
-- **Preferred:** Use [GitHub Private Vulnerability Reporting](https://github.com/the-luap/picpeak/security/advisories/new)
+- **Preferred:** Use [GitHub Private Vulnerability Reporting](https://github.com/PicPeak/picpeak/security/advisories/new)
 - **Alternative:** Email us at **info@picpeak.app** with the details
 - Include:
   - Description of the vulnerability
@@ -82,7 +82,7 @@ We believe in responsible disclosure. Once a vulnerability is fixed:
 
 ## Contact
 
-- Security issues: Email **info@picpeak.app** or use [GitHub Private Vulnerability Reporting](https://github.com/the-luap/picpeak/security/advisories/new)
-- General support: [GitHub Issues](https://github.com/the-luap/picpeak/issues)
+- Security issues: Email **info@picpeak.app** or use [GitHub Private Vulnerability Reporting](https://github.com/PicPeak/picpeak/security/advisories/new)
+- General support: [GitHub Issues](https://github.com/PicPeak/picpeak/issues)
 
 Thank you for helping keep PicPeak and its users safe!

--- a/SIMPLE_SETUP.md
+++ b/SIMPLE_SETUP.md
@@ -8,7 +8,7 @@ This guide provides easy installation instructions for PicPeak on Linux servers 
 
 ```bash
 # Download and run the unified setup script
-curl -fsSL https://raw.githubusercontent.com/the-luap/picpeak/main/scripts/picpeak-setup.sh -o picpeak-setup.sh && \
+curl -fsSL https://raw.githubusercontent.com/PicPeak/picpeak/main/scripts/picpeak-setup.sh -o picpeak-setup.sh && \
 chmod +x picpeak-setup.sh && \
 sudo ./picpeak-setup.sh
 ```
@@ -472,7 +472,7 @@ sudo -u picpeak node scripts/reset-admin-password.js
    - [Deployment Guide](https://docs.picpeak.app/deployment)
 
 3. **Support:**
-   - [GitHub Issues](https://github.com/the-luap/picpeak/issues)
+   - [GitHub Issues](https://github.com/PicPeak/picpeak/issues)
    - Include: Error messages, system info (`uname -a`), installation method
 
 ## 🔒 Security Best Practices
@@ -550,4 +550,4 @@ sudo ./picpeak-setup.sh --native \
 
 ---
 
-**PicPeak Setup v1.0** | [Documentation](https://github.com/the-luap/picpeak) | [Support](https://github.com/the-luap/picpeak/issues)
+**PicPeak Setup v1.0** | [Documentation](https://github.com/PicPeak/picpeak) | [Support](https://github.com/PicPeak/picpeak/issues)

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,7 +7,7 @@ ARG VCS_REF
 ARG VERSION
 
 # Add labels for GitHub Container Registry
-LABEL org.opencontainers.image.source="https://github.com/the-luap/picpeak"
+LABEL org.opencontainers.image.source="https://github.com/PicPeak/picpeak"
 LABEL org.opencontainers.image.description="PicPeak Backend Service"
 LABEL org.opencontainers.image.licenses="MIT"
 

--- a/backend/__tests__/services/updateCheckService.getReleasesSince.test.js
+++ b/backend/__tests__/services/updateCheckService.getReleasesSince.test.js
@@ -27,7 +27,7 @@ function release(tag, body = '', publishedAt = '2026-01-01T00:00:00Z') {
     name: tag,
     body,
     published_at: publishedAt,
-    html_url: `https://github.com/the-luap/picpeak/releases/tag/${tag}`,
+    html_url: `https://github.com/PicPeak/picpeak/releases/tag/${tag}`,
   };
 }
 
@@ -58,7 +58,7 @@ describe('updateCheckService.getReleasesSince', () => {
       tag: 'v3.55.0',
       name: 'v3.55.0',
       body: 'stable notes 3.55.0',
-      htmlUrl: 'https://github.com/the-luap/picpeak/releases/tag/v3.55.0',
+      htmlUrl: 'https://github.com/PicPeak/picpeak/releases/tag/v3.55.0',
     });
   });
 

--- a/backend/migrations/core/090_add_customer_accounts.js
+++ b/backend/migrations/core/090_add_customer_accounts.js
@@ -1,7 +1,7 @@
 /**
  * Migration: Add Customer Accounts (recurring user logins)
  *
- * Implements the customer tier from discussion the-luap/picpeak#354.
+ * Implements the customer tier from discussion PicPeak/picpeak#354.
  *
  * Three new tables:
  *  - customer_accounts        : the user record (email + bcrypt password)

--- a/backend/src/routes/adminSystem.js
+++ b/backend/src/routes/adminSystem.js
@@ -131,7 +131,7 @@ router.get('/updates/instructions', adminAuth, requirePermission('settings.view'
       channel: updateInfo.channel,
       environment: env,
       instructions,
-      releaseNotesUrl: `https://github.com/the-luap/picpeak/releases/tag/v${updateInfo.latest.forChannel}`
+      releaseNotesUrl: `https://github.com/PicPeak/picpeak/releases/tag/v${updateInfo.latest.forChannel}`
     });
   } catch (error) {
     logger.error('Error generating update instructions:', error);

--- a/backend/src/services/customerAccountsService.js
+++ b/backend/src/services/customerAccountsService.js
@@ -2,7 +2,7 @@
  * Customer Accounts Service
  *
  * Recurring user logins (the third user tier alongside admin and guest).
- * See discussion the-luap/picpeak#354 and migration 087 for context.
+ * See discussion PicPeak/picpeak#354 and migration 087 for context.
  *
  * Mirrors userManagementService.js for invitation lifecycle but operates
  * on customer_accounts / customer_invitations / event_customer_assignments

--- a/backend/src/services/environmentService.js
+++ b/backend/src/services/environmentService.js
@@ -154,7 +154,7 @@ function generateUpdateInstructions(env, targetVersion) {
       {
         description: 'Download release archive',
         command: `# Download v${targetVersion} from GitHub Releases`,
-        note: `https://github.com/the-luap/picpeak/releases/tag/v${targetVersion}`
+        note: `https://github.com/PicPeak/picpeak/releases/tag/v${targetVersion}`
       },
       {
         description: 'Backup current installation',

--- a/backend/src/services/updateCheckService.js
+++ b/backend/src/services/updateCheckService.js
@@ -94,7 +94,7 @@ async function fetchAvailableVersions() {
   try {
     // Use GitHub Releases API (public, no auth required)
     const response = await axios.get(
-      'https://api.github.com/repos/the-luap/picpeak/releases',
+      'https://api.github.com/repos/PicPeak/picpeak/releases',
       {
         headers: {
           'Accept': 'application/vnd.github+json',

--- a/backend/src/services/updateNotificationService.js
+++ b/backend/src/services/updateNotificationService.js
@@ -129,7 +129,7 @@ async function checkAndNotifyUpdates() {
 
     // Send email to each recipient
     const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:3000';
-    const releaseNotesUrl = `https://github.com/the-luap/picpeak/releases/tag/v${newVersion}`;
+    const releaseNotesUrl = `https://github.com/PicPeak/picpeak/releases/tag/v${newVersion}`;
     const channelLabel = updateInfo.channel === 'beta' ? 'Beta' : 'Stable';
 
     let successCount = 0;

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -45,7 +45,7 @@ services:
   backend:
     # Use pre-built image from GitHub Container Registry
     # PICPEAK_CHANNEL: 'stable' (default), 'beta', or specific version like 'v2.3.0'
-    image: ghcr.io/the-luap/picpeak/backend:${PICPEAK_CHANNEL:-stable}
+    image: ghcr.io/picpeak/picpeak/backend:${PICPEAK_CHANNEL:-stable}
     container_name: picpeak-backend
     env_file: .env
     environment:
@@ -93,7 +93,7 @@ services:
   frontend:
     # Use pre-built image from GitHub Container Registry
     # Uses same channel as backend for consistency
-    image: ghcr.io/the-luap/picpeak/frontend:${PICPEAK_CHANNEL:-stable}
+    image: ghcr.io/picpeak/picpeak/frontend:${PICPEAK_CHANNEL:-stable}
     container_name: picpeak-frontend
     # Note: Pre-built frontend uses Nginx to proxy /api to backend:3001.
     # Prefer keeping API base as '/api' in builds to avoid CORS.

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -8,7 +8,7 @@ ARG VCS_REF
 ARG VERSION
 
 # Add labels for GitHub Container Registry
-LABEL org.opencontainers.image.source="https://github.com/the-luap/picpeak"
+LABEL org.opencontainers.image.source="https://github.com/PicPeak/picpeak"
 LABEL org.opencontainers.image.description="PicPeak Frontend Application"
 LABEL org.opencontainers.image.licenses="MIT"
 

--- a/frontend/src/components/admin/UpdateNotification.tsx
+++ b/frontend/src/components/admin/UpdateNotification.tsx
@@ -90,7 +90,7 @@ export const UpdateNotification: React.FC<UpdateNotificationProps> = ({ onDismis
                 {t('admin.updates.updateNow', 'Update Now')}
               </button>
               <a
-                href="https://github.com/the-luap/picpeak/releases"
+                href="https://github.com/PicPeak/picpeak/releases"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="inline-flex items-center text-xs text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300"

--- a/frontend/src/utils/__tests__/githubReleaseUrl.test.ts
+++ b/frontend/src/utils/__tests__/githubReleaseUrl.test.ts
@@ -12,13 +12,13 @@ import { githubReleaseUrl } from '../githubReleaseUrl';
 describe('githubReleaseUrl', () => {
   it('maps a stable version to its tag page', () => {
     expect(githubReleaseUrl('3.55.0')).toBe(
-      'https://github.com/the-luap/picpeak/releases/tag/v3.55.0',
+      'https://github.com/PicPeak/picpeak/releases/tag/v3.55.0',
     );
   });
 
   it('maps a beta version (with channel suffix) to its tag page', () => {
     expect(githubReleaseUrl('3.55.0-beta.0')).toBe(
-      'https://github.com/the-luap/picpeak/releases/tag/v3.55.0-beta.0',
+      'https://github.com/PicPeak/picpeak/releases/tag/v3.55.0-beta.0',
     );
   });
 

--- a/frontend/src/utils/githubReleaseUrl.ts
+++ b/frontend/src/utils/githubReleaseUrl.ts
@@ -11,4 +11,4 @@
  * indicator to link to the upgrade target's notes.
  */
 export const githubReleaseUrl = (version: string): string =>
-  `https://github.com/the-luap/picpeak/releases/tag/v${version}`;
+  `https://github.com/PicPeak/picpeak/releases/tag/v${version}`;

--- a/scripts/picpeak-setup.sh
+++ b/scripts/picpeak-setup.sh
@@ -13,7 +13,7 @@ IFS=$'\n\t'
 # Script configuration
 readonly SCRIPT_VERSION="2.1.0"
 readonly APP_NAME="PicPeak"
-readonly REPO_URL="https://github.com/the-luap/picpeak.git"
+readonly REPO_URL="https://github.com/PicPeak/picpeak.git"
 readonly NODE_VERSION="20"
 readonly MIN_RAM_DOCKER=2048
 readonly MIN_RAM_NATIVE=1024
@@ -1157,8 +1157,8 @@ print_success_message() {
     echo
     echo "📚 Documentation:"
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-    echo "Setup Guide:  https://github.com/the-luap/picpeak/blob/main/SIMPLE_SETUP.md"
-    echo "Full Docs:    https://github.com/the-luap/picpeak"
+    echo "Setup Guide:  https://github.com/PicPeak/picpeak/blob/main/SIMPLE_SETUP.md"
+    echo "Full Docs:    https://github.com/PicPeak/picpeak"
     echo
     echo -e "${GREEN}✨ Setup complete! Visit the admin panel to start creating galleries.${NC}"
 }


### PR DESCRIPTION
## Summary

Repo transferred from `the-luap/picpeak` → `PicPeak/picpeak`. Docker images are now published to `ghcr.io/picpeak/picpeak/{backend,frontend}` (lowercase, per `docker-build.yml`'s `${GITHUB_REPOSITORY,,}` computation). This PR sweeps every in-repo reference to the old URLs in one mechanical pass.

## What changed (22 files, 48 / 48 line swaps)

- **Docker config** — `docker-compose.production.yml`, `backend/Dockerfile`, `frontend/Dockerfile`: image refs → new GHCR path
- **Operator-facing docs** — `README.md`, `CONTRIBUTING.md`, `SECURITY.md`, `SIMPLE_SETUP.md`, `CODE_OF_CONDUCT.md`, `scripts/picpeak-setup.sh`, `.github/workflows/README-DOCKER.md`, `.github/ISSUE_TEMPLATE/{config.yml,security_vulnerability.md}`
- **Runtime code** — update-check + release-notes services (`updateCheckService.js`, `environmentService.js`, `updateNotificationService.js`, `adminSystem.js`, `UpdateNotification.tsx`, `githubReleaseUrl.ts`) + their tests: GitHub API + tag URLs use the canonical `PicPeak/picpeak` path
- **Comment-only context** in `backend/migrations/core/090_add_customer_accounts.js` + `backend/src/services/customerAccountsService.js` (references to historical discussion #354)

## Intentional exclusions

- **`CHANGELOG.md`** — historical release entries are immutable. GitHub's auto-redirect keeps every old URL working indefinitely.
- **`CLAUDE.md`** — the line `**Reply tone — maintainer voice (the-luap):**` references the maintainer's personal handle (still valid), not a repo URL.
- **Local files** under `.claude/`, untracked PNG screenshots, etc.

## URL form conventions used

| Form | Replacement | Why |
|---|---|---|
| `ghcr.io/the-luap/picpeak/...` | `ghcr.io/picpeak/picpeak/...` | The build workflow lowercases via `${GITHUB_REPOSITORY,,}` — this is the canonical pull path |
| `https://github.com/the-luap/picpeak` | `https://github.com/PicPeak/picpeak` | URLs preserve the org's actual casing |
| `the-luap/picpeak#354` (in comments) | `PicPeak/picpeak#354` | Same as above |

## Test plan

- [ ] CI green (image build pushes successfully under the new path — already verified separately, see runs `28392382436` and onwards)
- [ ] `docker-compose.production.yml` pulls the new image — confirmed via the canonical lowercase path
- [ ] Update-check service hits `api.github.com/repos/PicPeak/picpeak/releases` (GitHub redirects either way, but the canonical path is the right one to log)
- [ ] No residual `the-luap/picpeak` references outside `CHANGELOG.md` (verified — grep returns 0)

## Related

Companion PR in `picpeak-docs` (`chore/migrate-registry-urls-to-picpeak-org`) sweeps the deploy guide + CRM docs + layout. Same conventions.