### PR TITLE
docs: prominent migration banner at the top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # 📸 PicPeak - Open Source Photo Sharing for Events
 
+> [!IMPORTANT]
+> **PicPeak has moved to its own GitHub organization.**
+>
+> - **Docker images** are now published at `ghcr.io/picpeak/picpeak/{backend,frontend}`. The old path (`ghcr.io/the-luap/picpeak/...`) is no longer served — update your `docker-compose.yml`.
+> - **Branches**: active development is now on `main` (was `beta`); the curated stable channel is now `stable` (was `main`). Existing PRs and clones auto-redirect via GitHub.
+>
+> See **[`docs/migration-to-org.md`](docs/migration-to-org.md)** for the one-line `docker-compose.yml` edit and full details.
+
 <div align="center">
   <img src="docs/picpeak-logo.png" alt="PicPeak Logo" width="300" />
   


### PR DESCRIPTION
## Summary

GitHub-flavored `> [!IMPORTANT]` callout right below the title, before the badges/hero block. First thing a visitor sees on the rendered README, so anyone landing on the repo page from a Google result or old bookmark sees the change.

## What it looks like

> [!IMPORTANT]
> **PicPeak has moved to its own GitHub organization.**
>
> - **Docker images** are now published at `ghcr.io/picpeak/picpeak/{backend,frontend}`. The old path (`ghcr.io/the-luap/picpeak/...`) is no longer served — update your `docker-compose.yml`.
> - **Branches**: active development is now on `main` (was `beta`); the curated stable channel is now `stable` (was `main`). Existing PRs and clones auto-redirect via GitHub.
>
> See **[`docs/migration-to-org.md`](docs/migration-to-org.md)** for the one-line `docker-compose.yml` edit and full details.

## Consistency with the in-app banner (#687)

Same message shape: image-path change, branch rename, link to `docs/migration-to-org.md`. An operator gets the same wording whether they're browsing the repo or logged into the admin dashboard.

## Lifecycle

Remove (or downgrade to a regular note) in ~1 quarter after the migration window settles. Same timing as flipping the in-app banner's `MIGRATION_BANNER_ENABLED` constant off.

Refs #669.