### PR TITLE
ci: bypass size gate — cap self-merge PR size for bypass users

### DIFF
--- a/.github/workflows/bypass-size-gate.yml
+++ b/.github/workflows/bypass-size-gate.yml
@@ -1,0 +1,70 @@
+name: Bypass size gate
+
+# Caps how large a PR a "review-bypass" collaborator (e.g. @Luca-Timo) can
+# self-merge without a maintainer review. The branch-protection bypass list
+# alone is binary — once a user is on it they can merge anything without
+# review. This workflow reports a REQUIRED status check that fails when a
+# bypass user's PR exceeds the configured size threshold, which blocks the
+# merge even with bypass enabled. Other contributors are unaffected (the
+# check reports success for them so the required-check gate doesn't trip).
+#
+# To tune: edit LINE_LIMIT or BYPASS_USERS below.
+#
+# Trigger note: uses `pull_request_target` so the workflow has the elevated
+# permissions of the base repo's GITHUB_TOKEN (read PR metadata, write
+# checks). The script never executes code FROM the PR — it only reads
+# metadata via the API — so this is safe against fork-PR attacks.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  pull-requests: read
+  checks: write
+
+jobs:
+  size-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Compute PR size and report check status
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Tune these two constants if the policy shifts.
+            const LINE_LIMIT = 300;
+            const BYPASS_USERS = ['Luca-Timo'];
+
+            const pr = context.payload.pull_request;
+            const author = pr.user.login;
+            const linesChanged = pr.additions + pr.deletions;
+            const filesChanged = pr.changed_files;
+
+            let conclusion, title, summary;
+
+            if (!BYPASS_USERS.includes(author)) {
+              // Not a bypass user — this gate doesn't apply to them. They
+              // go through normal review. Report success so the required
+              // check doesn't block their merge.
+              conclusion = 'success';
+              title = 'Not applicable';
+              summary = `This gate only restricts review-bypass for: ${BYPASS_USERS.join(', ')}. PRs from other authors (${author} here) go through the normal review path and are unaffected.`;
+            } else if (linesChanged <= LINE_LIMIT) {
+              conclusion = 'success';
+              title = `OK — within bypass limit (${linesChanged} lines)`;
+              summary = `Small PR: ${linesChanged} lines changed across ${filesChanged} file(s). Within the ${LINE_LIMIT}-line self-merge limit for @${author}. Can be merged without a maintainer review.`;
+            } else {
+              conclusion = 'failure';
+              title = `Too large for bypass (${linesChanged} lines)`;
+              summary = `Large PR: ${linesChanged} lines changed across ${filesChanged} file(s). Exceeds the ${LINE_LIMIT}-line self-merge limit for @${author} — needs an approving review from a maintainer before merge. Split into smaller PRs or wait for review.`;
+            }
+
+            await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'bypass-size-gate',
+              head_sha: pr.head.sha,
+              status: 'completed',
+              conclusion,
+              output: { title, summary }
+            });


### PR DESCRIPTION
## Summary

Complements the `Luca-Timo` review-bypass on `main` (added earlier) with a size-based gate: small bugfixes can be self-merged without review, large features need a maintainer review.

GitHub branch protection's bypass list is binary — a user can either bypass review for ANY PR or no PR. There's no built-in "small PR" exception. This workflow adds the missing distinction via a required status check.

## How it works

The workflow runs on every PR. For each one, it computes the size (`additions + deletions`) and reports a check status named **`bypass-size-gate`**:

| PR author | Size | Check result | Effect |
|---|---|---|---|
| `@Luca-Timo` (or other bypass user) | ≤ 300 lines | ✅ pass | Bypass works → self-merge allowed |
| `@Luca-Timo` (or other bypass user) | > 300 lines | ❌ fail | Required check blocks merge → needs maintainer review |
| Anyone else | any size | ✅ pass ("not applicable") | Normal review path, unaffected |
| Maintainer | any size | ✅ pass ("not applicable") | Normal admin behavior |

## Tunable

Both knobs at the top of the workflow file:

```javascript
const LINE_LIMIT = 300;          // additions + deletions
const BYPASS_USERS = ['Luca-Timo'];
```

300 lines is a generous "small bugfix" upper bound. Tighten or loosen as the working relationship evolves. Adding/removing bypass users only needs a workflow file edit (and a corresponding repo-level bypass list change).

## Security note

Uses `pull_request_target` (base-repo permissions, not PR-fork permissions) so the workflow can write check statuses. The script never checks out or executes any code from the PR — it only reads metadata via the GitHub API. Safe against fork-PR attacks.

## What this PR does NOT do

- Doesn't add `bypass-size-gate` to the main branch's required-check list yet. That happens via a separate `gh api` call AFTER this PR merges (chicken-and-egg: if I added the check as required before the workflow exists, every PR would block on a never-running check).

## Test plan

- [ ] This PR's own `bypass-size-gate` check fires and reports "not applicable" (since I'm not in `BYPASS_USERS`)
- [ ] After merge + adding the check to required, open a small dummy PR as Luca-Timo → check passes → merge button enabled with bypass
- [ ] Open a large dummy PR as Luca-Timo (> 300 lines) → check fails → merge button disabled

Refs #669 (broader contribution-workflow setup).