### PR TITLE
ci: required-check workflows fire on every PR (drop paths filter + post-rename branch list)

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -16,24 +16,17 @@ name: Fresh-install smoke
 # don't pay the build cost.
 
 on:
+  # No `paths:` filter — branch protection on `main` + `stable` lists
+  # `fresh-install` as a REQUIRED check, and a path-filtered trigger
+  # that skipped on unrelated PRs (e.g. frontend-only) would leave the
+  # required check "missing" forever and block the merge. Better to
+  # pay the boot cost on every PR than maintain a per-path allowlist
+  # that drifts as the install surface evolves. (Branches also updated
+  # post-#669 rename: beta → main, old main → stable.)
   push:
-    branches: [main, beta]
-    paths:
-      - 'backend/Dockerfile'
-      - 'backend/wait-for-db.sh'
-      - 'backend/migrations/**'
-      - 'backend/package*.json'
-      - 'docker-compose.production.yml'
-      - '.github/workflows/install-smoke.yml'
+    branches: [main, stable]
   pull_request:
-    branches: [main, beta]
-    paths:
-      - 'backend/Dockerfile'
-      - 'backend/wait-for-db.sh'
-      - 'backend/migrations/**'
-      - 'backend/package*.json'
-      - 'docker-compose.production.yml'
-      - '.github/workflows/install-smoke.yml'
+    branches: [main, stable]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/schema-drift.yml
+++ b/.github/workflows/schema-drift.yml
@@ -30,20 +30,17 @@ name: Schema drift (#530)
 # the same shape is caught before merge.
 
 on:
+  # No `paths:` filter — branch protection on `main` + `stable` lists
+  # `upgrade-from-bootstrap` as a REQUIRED check. A path-filtered
+  # trigger that skipped on unrelated PRs would leave the required
+  # check "missing" forever, blocking every PR that doesn't touch
+  # migrations. The ~75-second cost on every PR buys an unconditional
+  # safety net. (Branches also updated post-#669 rename: beta → main,
+  # old main → stable.)
   push:
-    branches: [main, beta]
-    paths:
-      - 'backend/migrations/**'
-      - 'backend/src/database/db.js'
-      - 'backend/knexfile.js'
-      - '.github/workflows/schema-drift.yml'
+    branches: [main, stable]
   pull_request:
-    branches: [main, beta]
-    paths:
-      - 'backend/migrations/**'
-      - 'backend/src/database/db.js'
-      - 'backend/knexfile.js'
-      - '.github/workflows/schema-drift.yml'
+    branches: [main, stable]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

Fixes the merge-blocked state on PR #692 (and every future PR that doesn't happen to touch migrations or `package*.json`).

## Problem

Branch protection on `main` + `stable` lists these REQUIRED checks:

| Check name | Producing workflow | Pre-this-PR trigger | Result |
|---|---|---|---|
| `upgrade-from-bootstrap` | `schema-drift.yml` | `paths:` filter on migrations + db.js + knexfile | Skipped on unrelated PRs → required check missing → merge blocked |
| `fresh-install` | `install-smoke.yml` | `paths:` filter on backend Dockerfile + migrations + `backend/package*.json` + docker-compose | Skipped on (e.g.) frontend-only PRs → same problem |

Surfaced on **PR #692** (security bumps): all 12 visible checks green, merge button blocked because both path-filtered workflows correctly skipped, but their required-check names never reported.

## Fix

Drop the `paths:` filter from both `pull_request` and `push` triggers. The workflows now fire on every PR against `main` + `stable`.

Costs we pay per PR:
- `schema-drift` → ~75s (Postgres service boot + `migrate:safe` + schema assertion)
- `install-smoke` → ~2 min (full Docker Compose boot + login smoke)

Combined ~3.5 min of additional CI time per PR. Acceptable for unconditional safety nets on the install + migration paths.

## Also fixed in the same edit

`branches: [main, beta]` → `[main, stable]` in both files — completing the post-#669 rename that PR #686 missed for these two workflows.

## What this does NOT fix

`GitGuardian Security Checks` is the third required check that's currently missing on every post-rename PR. Separate root cause: the GitGuardian GitHub App was installed at the user-account level (`the-luap`) before the org transfer and didn't move with the repo. **Re-installing it on the `PicPeak` org via the GitHub Marketplace is a UI step the maintainer needs to do** — can't be done via API.

After GitGuardian is reinstalled, the three required-check gaps are closed and PR #692 (and all future PRs) merges cleanly.

## Test plan

- [ ] This PR's CI should now produce both `upgrade-from-bootstrap` AND `fresh-install` checks
- [ ] Both should pass on the bumped node:22-alpine builder + new deps
- [ ] After merge, PR #692 (security bumps) should be unblocked (assuming GitGuardian reinstall too)