### PR TITLE
docs(readme): add Pixieset to comparison + customer-accounts/CRM/accounting rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,8 +382,8 @@ See our [Contributing Guide](CONTRIBUTING.md) for details.
 |---------|---------|---------|--------------|----------|
 | Self-Hosted | ✅ | ❌ | ❌ | ❌ |
 | Custom Branding | ✅ Full | Limited | Limited | ✅ (paid) |
-| Monthly Cost | $0 | $29-199 | €19-99 | ~$60 |
-| Storage Limit | Unlimited* | 50-500GB | 100-1000GB | 3GB–Unlimited |
+| Monthly Cost | $0* | $29-199 | €19-99 | ~$60 |
+| Storage Limit | Unlimited** | 50-500GB | 100-1000GB | 3GB–Unlimited*** |
 | Client Uploads | ✅ | ✅ | ✅ | Limited |
 | API Access | ✅ | Paid | ❌ | ❌ |
 | Open Source | ✅ | ❌ | ❌ | ❌ |
@@ -391,8 +391,10 @@ See our [Contributing Guide](CONTRIBUTING.md) for details.
 | Quotes / Contracts / Invoices | 🧪 Beta | ❌ | ❌ | ✅ |
 | Incoming Invoices & Accounting | 🧪 Beta | ❌ | ❌ | ❌ |
 
-*Limited only by your server storage.
-🧪 Beta = built but feature-flagged off by default (see [Beta Features](#-beta-features-use-at-your-own-risk)). picdrop and Scrapbook.de are gallery/delivery tools (no client billing or accounting). Pixieset's client CRM, contracts and invoices live in its paid **Studio Manager**, but it has no inbound supplier-invoice capture or bookkeeping/accountant-export module.
+*You still bring your own server (own hardware or a VPS) and, if you want one, a domain.
+**Limited only by your server storage.
+***Pixieset's "unlimited" is photos only; video is capped by plan (roughly 0–10 h depending on tier).
+🧪 Beta = built but feature-flagged off by default (see [Beta Features](#-beta-features-use-at-your-own-risk)).
 
 ## 🛡️ Security
 

--- a/README.md
+++ b/README.md
@@ -378,17 +378,21 @@ See our [Contributing Guide](CONTRIBUTING.md) for details.
 
 ## 📊 Comparison with Alternatives
 
-| Feature | PicPeak | PicDrop | Scrapbook.de |
-|---------|---------|---------|--------------|
-| Self-Hosted | ✅ | ❌ | ❌ |
-| Custom Branding | ✅ Full | Limited | Limited |
-| Monthly Cost | $0 | $29-199 | €19-99 |
-| Storage Limit | Unlimited* | 50-500GB | 100-1000GB |
-| Client Uploads | ✅ | ✅ | ✅ |
-| API Access | ✅ | Paid | ❌ |
-| Open Source | ✅ | ❌ | ❌ |
+| Feature | PicPeak | PicDrop | Scrapbook.de | Pixieset |
+|---------|---------|---------|--------------|----------|
+| Self-Hosted | ✅ | ❌ | ❌ | ❌ |
+| Custom Branding | ✅ Full | Limited | Limited | ✅ (paid) |
+| Monthly Cost | $0 | $29-199 | €19-99 | ~$60 |
+| Storage Limit | Unlimited* | 50-500GB | 100-1000GB | 3GB–Unlimited |
+| Client Uploads | ✅ | ✅ | ✅ | Limited |
+| API Access | ✅ | Paid | ❌ | ❌ |
+| Open Source | ✅ | ❌ | ❌ | ❌ |
+| Customer Accounts | ✅ | ❌ | ❌ | ✅ |
+| Quotes / Contracts / Invoices | 🧪 Beta | ❌ | ❌ | ✅ |
+| Incoming Invoices & Accounting | 🧪 Beta | ❌ | ❌ | ❌ |
 
-*Limited only by your server storage
+*Limited only by your server storage.
+🧪 Beta = built but feature-flagged off by default (see [Beta Features](#-beta-features-use-at-your-own-risk)). picdrop and Scrapbook.de are gallery/delivery tools (no client billing or accounting). Pixieset's client CRM, contracts and invoices live in its paid **Studio Manager**, but it has no inbound supplier-invoice capture or bookkeeping/accountant-export module.
 
 ## 🛡️ Security
 


### PR DESCRIPTION
Adds **Pixieset** to the comparison table and three business-feature rows.

**Column**
- New `Pixieset` column across all existing rows (self-hosted, branding, cost ~$60, storage, uploads, API, open source).

**New rows**
- **Customer Accounts**, **Quotes / Contracts / Invoices**, **Incoming Invoices & Accounting**.
- PicPeak's CRM + accounting are marked **🧪 Beta** (built but feature-flagged off by default), with a footnote linking to the Beta Features section.

**Competitor cells are researched, not assumed**
- **picdrop** and **Scrapbook.de** are gallery/delivery tools — no client billing or accounting (Scrapbook has a *print shop*, not photographer-client invoicing).
- **Pixieset** has client CRM, contracts and invoices in its paid **Studio Manager**, but no inbound supplier-invoice capture or bookkeeping/accountant export — so ✅ on the first two rows, ❌ on accounting.

**Footnotes**
- `$0` = software/licence/subscription fees only; you still bring your own server (own hardware/VPS) and optional domain.
- Pixieset "unlimited" storage is photos only — video is capped per plan (~0–10 h).