### PR TITLE
fix(ci): whatsnew highlights — set GH_REPO so gh runs without a checkout

### DIFF
--- a/.github/workflows/whatsnew-highlights.yml
+++ b/.github/workflows/whatsnew-highlights.yml
@@ -38,9 +38,22 @@ jobs:
     permissions:
       contents: write   # to edit the release body
       models: read      # GitHub Models (free tier)
+    # GH_REPO at job scope so every `gh` call targets the right repo without
+    # needing an actions/checkout step. Without this, `gh` falls back to
+    # parsing `.git/config` in the runner's empty workspace and dies with
+    # "fatal: not a git repository" — which hard-fails the whole job before
+    # any continue-on-error can save it.
+    env:
+      GH_REPO: ${{ github.repository }}
     steps:
       - name: Extract Features from the published release
         id: feat
+        # Belt-and-braces: the job-level comment says "never let highlights
+        # break a release", but the original wiring only marked the AI +
+        # inject steps as continue-on-error. A hiccup here (rate limit,
+        # transient API error) would still hard-fail the job. Match the
+        # design intent and fail soft.
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ inputs.tag }}


### PR DESCRIPTION
## What broke

Release Please Beta on v3.76.1-beta.0 ([run 28474514207](https://github.com/PicPeak/picpeak/actions/runs/28474514207)) hard-failed at the very first `gh release view` call in the reusable `whatsnew-highlights.yml` workflow:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
##[error]Process completed with exit code 1.
```

## Root cause

The reusable workflow (added in #703) doesn't run `actions/checkout` — and `gh` was trying to infer the target repo from the runner's empty workspace via `.git/config`. With no `.git`, the call errors out before the deterministic-fallback path can save it.

First merge after #703 (the merge of #703 itself) didn't trip this — it was a `ci:` commit, so release-please cut no release and the `highlights` job was skipped. PR #709 produced the first real release tag → first invocation → immediate hard-fail.

The file's comments say *"never let highlights break a release"*, but the original wiring only soft-failed the AI + inject steps. The Extract step had no `continue-on-error`, so a hiccup at extract hard-failed the whole job — defeating the design intent.

## The fix — two single-line changes

1. **`env.GH_REPO: ${{ github.repository }}` at job scope.** `gh` honours this env and won't fall back to parsing `.git/config`. No checkout needed (the workflow only calls the GitHub API, never reads repo files).
2. **`continue-on-error: true` on the "Extract Features" step.** Match the file's stated design intent — even an extract-step blip can't fail a release.

### Why not just add `actions/checkout`?
It would work, but it pulls the whole repo over the wire on every release just so `gh` can find its own remote. `GH_REPO` is the lighter idiom.

## Net impact today

`v3.76.1-beta.0` shipped **without** the `<!-- whatsnew -->` block. The app's `parseWhatsNew()` already falls back to the raw Features list, so the admin "What's New" banner still works — just shows the unpolished commit-bullet text for this one beta. The next beta release picks up the polished version automatically.

## Test plan

- [x] `actionlint` clean (YAML validated)
- [ ] Next release-please beta release runs to verify the highlights block is injected end-to-end