### PR TITLE
feat: admin photos list/grid toggle + upload failure report (#707, #708)

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,36 @@
+name: PR Title Lint
+
+# Release Please derives version bumps and the changelog from Conventional
+# Commit prefixes (feat:, fix:, ...). PRs whose title/commits use other
+# conventions (e.g. gitmoji) are silently ignored, so their changes ship
+# without a version bump or a changelog entry. This check fails a PR whose
+# title is not a valid Conventional Commit so the release stays automated.
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR title is a Conventional Commit
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            perf
+            revert
+            docs
+            style
+            chore
+            refactor
+            test
+            build
+            ci


### PR DESCRIPTION
## Why

PRs #707 and #708 merged with **gitmoji** commit subjects (`✨`, `🐛`, `🎨`) instead of Conventional Commit prefixes (`feat:`, `fix:`). Release Please only parses the latter, so it logged `No commits for path: ., skipping` on both merges — **no beta release, no version bump, no changelog entry** for two user-facing features.

This PR does two things:

### 1. Cut the missing beta (credit #707/#708)

An empty `feat:` commit records the two already-merged features so Release Please cuts the next beta and lists them:
- **#707** — grid/list layout toggle on the admin Photos tab
- **#708** — per-file upload failure report in the upload modal

No code change — the features are already on `main`.

### 2. Prevent recurrence — `ci: validate PR titles against Conventional Commits`

Adds `.github/workflows/pr-title-lint.yml` (`amannn/action-semantic-pull-request`) which fails any PR whose title isn't a valid Conventional Commit. Allowed types mirror the `changelog-sections` in `release-please-config-beta.json`.

## ⚠️ Follow-up needed to make the guard fully effective

The title check only governs the release commit **if the PR title becomes the merge commit subject**. Right now the repo allows merge-commit + rebase, and `squash_merge_commit_title = COMMIT_OR_PR_TITLE` (a single-commit squash uses the *commit* subject, not the PR title). To close the loop:

- Set merge policy to **squash-only** (`allow_merge_commit=false`, `allow_rebase_merge=false`)
- Set **`squash_merge_commit_title=PR_TITLE`** so the enforced title is always what lands
- Mark **`lint-pr-title`** a required status check on `main`

These are repo-admin settings, left out of this PR intentionally.
