### PR TITLE
docs: require screenshots for UI changes in PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,10 @@ Unsure where to begin? You can start by looking through these issues:
    - Linting passes: `npm run lint`
 4. **Write tests** if you've added code
 5. **Update documentation** if needed
-6. **Create a Pull Request**
+6. **Attach a screenshot for any UI change** (see below)
+7. **Create a Pull Request**
+
+> **📸 Screenshots are required for UI changes.** Any PR that changes a user-facing surface — a component, page, layout, style, or in-app copy — must include at least one screenshot of the result in the PR description, showing before/after where it helps reviewers see the difference. PRs that touch the UI without a screenshot will be asked to add one before review. Backend-only or otherwise non-visual changes don't need one.
 
 ## 💻 Development Setup
 


### PR DESCRIPTION
## What

Adds a **screenshot requirement for UI changes** to the PR checklist in `CONTRIBUTING.md`.

Any PR that changes a user-facing surface (component, page, layout, style, or in-app copy) must include at least one screenshot of the result in the PR description — before/after where it helps reviewers. Backend-only / non-visual changes are exempt.

## Why

UI changes are hard to review from a diff alone. A screenshot lets reviewers verify the visual result without checking out and running the branch, and gives a durable record of what changed. This codifies what we've been asking for ad hoc (e.g. on the `/setup` wizard in #714) into the contribution guidelines so it's a consistent, up-front expectation.

## Scope

Docs-only — one paragraph + one checklist item in `CONTRIBUTING.md`. No code changes.
