### PR TITLE
fix: auto-publish release-please PRs without manual approval

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -38,6 +38,16 @@ on:
           - 'true'
           - 'false'
 
+# Once release-please authors releases with a PAT (#719), a new version fires
+# BOTH the tag-push and the release-published triggers (GITHUB_TOKEN used to
+# suppress them). They build the same immutable version, so collapse them into a
+# single run by grouping on the ref. Branch and PR builds use different refs and
+# still run independently; a superseding push cancels an in-flight run for the
+# same ref (only the newest build per ref is kept).
+concurrency:
+  group: docker-build-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   REGISTRY: ghcr.io
   # BACKEND_IMAGE_NAME and FRONTEND_IMAGE_NAME are computed per job in the

--- a/.github/workflows/release-please-beta.yml
+++ b/.github/workflows/release-please-beta.yml
@@ -20,10 +20,39 @@ jobs:
         uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # A dedicated token (fine-grained PAT) makes the release PR run CI
+          # automatically (no "workflows awaiting approval") and lets it be
+          # merged without a manual review. Falls back to GITHUB_TOKEN so the
+          # workflow still works before the secret is added (#719).
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: release-please-config-beta.json
           manifest-file: .release-please-manifest-beta.json
           target-branch: main
+
+      # Auto-approve + enable auto-merge on the open release PR so betas publish
+      # with no manual clicks. Approval uses GITHUB_TOKEN (github-actions[bot]) —
+      # a different identity than the PR author (RELEASE_PLEASE_TOKEN) — so it is
+      # a valid review (requires the org's "Allow GitHub Actions to approve pull
+      # requests" + the repo's "Allow auto-merge"). Only meaningful when a PAT is
+      # set: without it the PR is bot-authored and can't be self-approved, so we
+      # skip and leave today's manual flow. Best-effort — never blocks the run.
+      - name: Auto-approve and enable auto-merge on the release PR
+        if: ${{ steps.release.outputs.release_created != 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_PAT: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: |
+          if [ -z "$RELEASE_PAT" ]; then
+            echo "RELEASE_PLEASE_TOKEN not set — skipping auto-merge (manual review still required)."
+            exit 0
+          fi
+          pr=$(gh pr list --head release-please--branches--main --state open --json number --jq '.[0].number // empty')
+          if [ -n "$pr" ]; then
+            gh pr review "$pr" --approve --body "Automated approval — release-please version bump + changelog (#719)." || true
+            gh pr merge "$pr" --squash --auto || true
+          else
+            echo "No open release PR to auto-merge."
+          fi
 
       - name: Output Release Info
         if: ${{ steps.release.outputs.release_created }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,9 +20,32 @@ jobs:
         uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Dedicated token so the release PR runs CI + can auto-merge without a
+          # manual review. Falls back to GITHUB_TOKEN before the secret is set (#719).
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      # Auto-approve + auto-merge the open stable release PR. See the beta
+      # workflow for the full rationale. Skipped on the release-cutting run and
+      # whenever no PAT is configured.
+      - name: Auto-approve and enable auto-merge on the release PR
+        if: ${{ steps.release.outputs.release_created != 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_PAT: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: |
+          if [ -z "$RELEASE_PAT" ]; then
+            echo "RELEASE_PLEASE_TOKEN not set — skipping auto-merge (manual review still required)."
+            exit 0
+          fi
+          pr=$(gh pr list --head release-please--branches--stable --state open --json number --jq '.[0].number // empty')
+          if [ -n "$pr" ]; then
+            gh pr review "$pr" --approve --body "Automated approval — release-please version bump + changelog (#719)." || true
+            gh pr merge "$pr" --squash --auto || true
+          else
+            echo "No open release PR to auto-merge."
+          fi
 
       - name: Output Release Info
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
Fixes #719.

## Root cause
The release PR (e.g. #717) is authored by `github-actions[bot]` using the default `GITHUB_TOKEN`. That triggers two dead-ends:
1. **Workflows "awaiting approval"** — bot/external PRs are held pending a maintainer click, so the required checks never report and the merge gate never goes green.
2. **Review required** — `main`'s branch protection needs an approving review, and the bot can't approve its own PR.

Both defeat automated releases. (This most likely regressed with the move into the `PicPeak` org, which enforces the Actions approval gate.)

## Fix
Both release-please workflows (`release-please-beta.yml`, `release-please.yml`):
- **Use a dedicated `RELEASE_PLEASE_TOKEN`** (fine-grained PAT) with a `GITHUB_TOKEN` fallback. A PAT-authored PR isn't held behind "awaiting approval" → CI runs automatically.
- **Auto-approve + enable auto-merge** on the open release PR. The approval uses `GITHUB_TOKEN` (`github-actions[bot]`) — a *different* identity than the PR author — so it's a valid review. The step self-skips when no PAT is set (falls back to today's manual flow — nothing breaks before the secret exists).

`docker-build.yml`: a PAT un-suppresses the `tag`-push and `release: published` triggers that `GITHUB_TOKEN` used to swallow (this is actually the *intended* behavior per that file's header comment — versioned images finally get built). Both fire for the same version, so a **concurrency group** collapses them into one run.

## ⚠️ One-time setup required before this takes effect
1. **Create the PAT** — a fine-grained PAT (`contents: write`, `pull-requests: write`) on a maintainer/machine account, added as repo secret **`RELEASE_PLEASE_TOKEN`**. (Fine-grained PATs must be allowlisted by the org.)
2. **Enable "Allow auto-merge"** on the repo — currently `false`:
   ```bash
   gh api -X PATCH repos/PicPeak/picpeak -f allow_auto_merge=true
   ```
3. "Allow GitHub Actions to create and approve pull requests" — **already enabled** (verified `can_approve_pull_request_reviews: true`), no action.

Until the secret is added, the workflows behave exactly as today (fallback to `GITHUB_TOKEN`, auto-merge step skipped).

## Note
Verify `main` branch protection doesn't *require review from Code Owners* specifically — if it does, the `github-actions[bot]` approval won't satisfy it and the bot identity would need a bypass entry instead. A plain "1 approving review" requirement is satisfied by the bot approval.
