### PR TITLE
fix: set GH_REPO in release-please auto-merge step

### DIFF
--- a/.github/workflows/release-please-beta.yml
+++ b/.github/workflows/release-please-beta.yml
@@ -41,6 +41,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_PAT: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          # This job has no checkout, so gh can't infer the repo from a git
+          # remote — set it explicitly (same pattern as whatsnew, 2a5f0a8).
+          GH_REPO: ${{ github.repository }}
         run: |
           if [ -z "$RELEASE_PAT" ]; then
             echo "RELEASE_PLEASE_TOKEN not set — skipping auto-merge (manual review still required)."

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,6 +34,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_PAT: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          # No checkout in this job — set the repo explicitly so gh works
+          # without a git remote (same pattern as whatsnew, 2a5f0a8).
+          GH_REPO: ${{ github.repository }}
         run: |
           if [ -z "$RELEASE_PAT" ]; then
             echo "RELEASE_PLEASE_TOKEN not set — skipping auto-merge (manual review still required)."


### PR DESCRIPTION
Follow-up to #720 (fixes #719).

## What happened
After #720 merged, the core fix **worked**: with `RELEASE_PLEASE_TOKEN` set, release PR **#721** is now authored by the PAT identity (not `github-actions[bot]`) and **all required checks run + pass automatically** — the "awaiting approval" dead-end is gone.

But the new **auto-approve/merge step** failed:
```
failed to run git: fatal: not a git repository
```
The release-please job has no `actions/checkout`, so `gh pr list/review/merge` couldn't infer the repo from a git remote.

## Fix
Set `GH_REPO: ${{ github.repository }}` on that step in both workflows — the same pattern the whatsnew workflow already uses (`2a5f0a8`). `gh` then targets the repo explicitly, no checkout needed.

## After this merges
Merging this PR pushes to `main` → release-please runs again → updates #721's changelog, then auto-approves (as `github-actions[bot]`) and enables auto-merge → #721 publishes once checks pass. That run is itself the end-to-end proof.

All three prerequisites are already in place: `RELEASE_PLEASE_TOKEN` secret set, `allow_auto_merge: true`, Actions-approve enabled.
