### PR TITLE
fix: enable release-PR auto-merge with the PAT so releases actually publish

### DIFF
--- a/.github/workflows/release-please-beta.yml
+++ b/.github/workflows/release-please-beta.yml
@@ -51,8 +51,14 @@ jobs:
           fi
           pr=$(gh pr list --head release-please--branches--main --state open --json number --jq '.[0].number // empty')
           if [ -n "$pr" ]; then
+            # Approve as github-actions[bot] (GITHUB_TOKEN) — a different identity
+            # than the PR author (the PAT) — so it counts as a valid review.
             gh pr review "$pr" --approve --body "Automated approval — release-please version bump + changelog (#719)." || true
-            gh pr merge "$pr" --squash --auto || true
+            # Enable auto-merge as the PAT so the eventual merge commit is
+            # attributed to a real identity. If enabled via GITHUB_TOKEN the merge
+            # push is suppressed by recursion prevention and the follow-up run that
+            # cuts the tag/release never fires (#719).
+            GH_TOKEN="$RELEASE_PAT" gh pr merge "$pr" --squash --auto || true
           else
             echo "No open release PR to auto-merge."
           fi

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -44,8 +44,11 @@ jobs:
           fi
           pr=$(gh pr list --head release-please--branches--stable --state open --json number --jq '.[0].number // empty')
           if [ -n "$pr" ]; then
+            # Approve as github-actions[bot] (GITHUB_TOKEN, ≠ the PAT author) so it
+            # is a valid review; enable auto-merge as the PAT so the merge commit is
+            # attributed to a real identity and triggers the tag-cutting run (#719).
             gh pr review "$pr" --approve --body "Automated approval — release-please version bump + changelog (#719)." || true
-            gh pr merge "$pr" --squash --auto || true
+            GH_TOKEN="$RELEASE_PAT" gh pr merge "$pr" --squash --auto || true
           else
             echo "No open release PR to auto-merge."
           fi


### PR DESCRIPTION
Follow-up to #720/#722 (fixes #719). **This is the piece that makes releases actually publish.**

## What we observed
After #722, the release PR **#723 auto-approved and auto-merged on its own** — great. But **no release-please run fired afterward, and `v3.77.3-beta.0` was never tagged/released** (latest tag is still `3.77.2-beta.0`).

## Root cause
The auto-merge was **enabled with `GITHUB_TOKEN`**. When GitHub completes an auto-merge, the merge commit is attributed to whoever enabled it — `github-actions[bot]`. Recursion prevention then suppresses the resulting push to `main`, so the follow-up release-please run that *cuts the tag/release* never runs. Net result is worse than the original bug: the version PR merges, but **no release, tag, or images are ever produced**.

## Fix
Enable auto-merge with **`RELEASE_PLEASE_TOKEN`** (a real identity) so the merge commit triggers the tag-cutting run. The **approval stays on `GITHUB_TOKEN`**, because it must be a *different* identity than the PR author (the PAT) to count as a valid review.

```diff
  gh pr review "$pr" --approve ...            # bot — valid review (≠ author)
- gh pr merge "$pr" --squash --auto
+ GH_TOKEN="$RELEASE_PAT" gh pr merge "$pr" --squash --auto   # PAT — merge triggers the release run
```

## Self-heal
Merging this triggers a release-please run that should **catch up and cut the missing `3.77.3-beta.0`** (release-please releases a merged-but-unreleased release PR on its next run), then exercise the corrected PAT-merge path on the next version. I'll verify the tag appears after merge.
