### PR TITLE
fix(settings): remove duplicate Mail import that crashes the dev server

### DIFF
--- a/frontend/src/pages/admin/SettingsPage.tsx
+++ b/frontend/src/pages/admin/SettingsPage.tsx
@@ -55,7 +55,7 @@ import { CrmSettingsPage } from './settings/CrmSettingsPage';
 import { ReminderTemplatesPage } from './settings/ReminderTemplatesPage';
 import { BlockLibraryPage } from './contracts/BlockLibraryPage';
 import { useFeatureFlags } from '../../contexts/FeatureFlagsContext';
-import { Briefcase, Receipt, ScrollText, Mail, Landmark, Smartphone, MonitorPlay } from 'lucide-react';
+import { Briefcase, Receipt, ScrollText, Landmark, Smartphone, MonitorPlay } from 'lucide-react';
 
 // Tab keys driving the inner-nav. Must include every key used in
 // `navGroups` below and in the switch at the bottom of the component.


### PR DESCRIPTION
## Summary

`frontend/src/pages/admin/SettingsPage.tsx` imports `Mail` from `lucide-react` **twice** — once in the main icon block (line 20) and again in a later import (line 58). Duplicate declarations from the same specifier are rejected by the `@vitejs/plugin-react` babel transform, so **`npm run dev` crashes** the moment the Settings module loads:

> `[plugin:vite:react-babel] Identifier 'Mail' has already been declared. (58:41)`

The production `vite build` (esbuild) silently dedupes the duplicate, so `npm run build`, CI, and Docker images all pass — which is why this slipped through and only breaks the local dev server.

## Fix

The two imports overlap on **exactly one** name, `Mail`. Removed it from line 58, keeping that line's six unique, still-used icons (`Briefcase, Receipt, ScrollText, Landmark, Smartphone, MonitorPlay`). `Mail` remains imported once (line 20) and continues to be used (Email Settings + Reminder emails tabs).

```diff
-import { Briefcase, Receipt, ScrollText, Mail, Landmark, Smartphone, MonitorPlay } from 'lucide-react';
+import { Briefcase, Receipt, ScrollText, Landmark, Smartphone, MonitorPlay } from 'lucide-react';
Verification
Mail now imported exactly once; all seven icons still resolve.
npm run build (esbuild) passes.
npm run dev: forced Vite to transform SettingsPage.tsx — now returns HTTP 200 with zero "already been declared" errors and a clean dev log (previously the dev server errored on load).
Built and ran the frontend Docker image locally: container healthy, app shell + main bundle serve.
One-line, no behavior change — purely unblocks npm run dev.

Want me to also draft a short note you can drop on PR #350 explaining it's superseded/retargeted, or leave that to you?