### PR TITLE
fix(invoices): correct payment-check email template key so dunning email sends

### DIFF
--- a/backend/src/services/invoice/payments.js
+++ b/backend/src/services/invoice/payments.js
@@ -278,7 +278,7 @@ async function queuePaymentCheckEmail(invoiceId, { skipThrottle = false } = {}) 
     : null;
 
   await emailProcessor.queueEmail(invoice.event_id || null, adminContact.email,
-    'invoice_payment_check_admin', {
+    'invoice_payment_check', {
       invoice_number: invoice.invoice_number,
       customer_name: customer?.company_name
         || customer?.display_name


### PR DESCRIPTION
Fixes #751.

`queuePaymentCheckEmail` queued the admin payment-check email with template key **`invoice_payment_check_admin`** (`invoiceService.js:3059`), but no such template exists — the only one is **`invoice_payment_check`** (`crmEmailTemplates.js:217`, seeded by migration 116), which IS the admin "Paid / Partial / Not paid" email. The processor does an exact `template_key` lookup (`emailProcessor.js:715`) and throws `Email template '…' not found`, so **every** dunning admin payment-check email fails, retries to the cap, and gets stuck `pending`.

**One-word fix:** queue `invoice_payment_check`. Unbreaks the built-in invoice-dunning flow's email step. Verified in the field: the queued row's `error_message` was exactly `Email template 'invoice_payment_check_admin' not found`.

Left as a follow-up (cosmetic, not a break): the dev-tools test-send list still references `invoice_payment_check_admin` — that surface already greys out absent templates.