### PR TITLE
fix(email,ui): billing emails follow customer language + readable payment-check confirmation

### DIFF
--- a/backend/src/services/emailProcessor.js
+++ b/backend/src/services/emailProcessor.js
@@ -726,9 +726,12 @@ async function sendTemplateEmail(to, templateKey, variables) {
       throw new Error('Email configuration not found');
     }
 
-    // Determine recipient language (pass eventId if available in variables)
-    const language = await getRecipientLanguage(to, variables.eventId || null);
-    
+    // Determine recipient language. An explicit `__language` in the email data
+    // wins (CRM/billing emails set it to the customer/invoice language so a
+    // gallery event's language can't override a dunning notice — see #760);
+    // otherwise fall back to the event-first recipient resolution.
+    const language = variables.__language || await getRecipientLanguage(to, variables.eventId || null);
+
     // Process template with variables
     const { subject, htmlBody, textBody } = await processTemplate(template, variables, language);
 
@@ -783,7 +786,7 @@ async function sendTemplateEmail(to, templateKey, variables) {
 async function renderQueuedEmail(templateKey, variables = {}, to = '') {
   const template = await db('email_templates').where('template_key', templateKey).first();
   if (!template) return null;
-  const language = await getRecipientLanguage(to, variables.eventId || null);
+  const language = variables.__language || await getRecipientLanguage(to, variables.eventId || null);
   const { subject, htmlBody } = await processTemplate(template, variables, language);
   return { subject, html: htmlBody };
 }

--- a/backend/src/services/invoice/payments.js
+++ b/backend/src/services/invoice/payments.js
@@ -185,6 +185,8 @@ async function queueInvoicePaidAdminNotification({
         || [customer?.first_name, customer?.last_name].filter(Boolean).join(' ')
         || customer?.email || '',
       event_name: invoice.event_name || '',
+      // Keep the body language consistent with the locale-formatted amounts.
+      __language: locale,
       total_amount: formatMajor(invoice.total_amount_minor, invoice.currency, locale),
       paid_amount: formatMajor(paidTotalMinor, invoice.currency, locale),
       payment_method: paymentMethod || '',
@@ -285,6 +287,9 @@ async function queuePaymentCheckEmail(invoiceId, { skipThrottle = false } = {}) 
         || [customer?.first_name, customer?.last_name].filter(Boolean).join(' ')
         || customer?.email || '',
       event_name: invoice.event_name || '',
+      // Keep the body language consistent with the locale the amounts are
+      // formatted in, instead of event-first resolution (admin-facing gate).
+      __language: locale,
       due_date: formatShortDate(invoice.due_date),
       total_amount: formatMajor(invoice.total_amount_minor, invoice.currency, locale),
       paid_amount: formatMajor(paidMinor, invoice.currency, locale),

--- a/backend/src/services/invoice/reminders.js
+++ b/backend/src/services/invoice/reminders.js
@@ -141,7 +141,7 @@ async function applyReminder(invoice, lineItems, level, adminId) {
   const rawDaysOverdue = Math.floor((Date.now() - new Date(invoice.due_date).getTime()) / 86400000);
   const daysOverdue = Math.max(1, rawDaysOverdue);
   const templateKey = level === 1 ? 'invoice_reminder_first' : 'invoice_reminder_second';
-  const locale = ctx.locale || invoice.language || 'de';
+  const locale = ctx.locale || customer.preferred_language || invoice.language || 'de';
   const outstandingMinor = Math.max(0, newTotal - Number(invoice.paid_amount_minor || 0));
 
   // Attach the (unchanged) original invoice PDF + the new Mahnung.
@@ -154,6 +154,8 @@ async function applyReminder(invoice, lineItems, level, adminId) {
   const { to: reminderTo, cc: reminderCc } = resolveBillingRecipients(customer, invoice.cc_pdf_email);
   try {
     await emailProcessor.queueEmail(invoice.event_id || null, reminderTo, templateKey, {
+      // Render in the customer/invoice language, not the gallery event's (#760).
+      __language: locale,
       invoice_number: invoice.invoice_number,
       customer_name: customer.display_name || customer.first_name || customer.email.split('@')[0],
       total_amount: formatMajor(invoice.total_amount_minor, invoice.currency, locale),

--- a/backend/src/services/invoice/sending.js
+++ b/backend/src/services/invoice/sending.js
@@ -127,6 +127,9 @@ async function sendInvoice(id, adminId) {
     installment_label: invoice.installment_label || '',
     installment_index: invoice.installment_index + 1,
     installment_total: invoice.installment_total,
+    // Send in the customer's language (matches the ctx.locale-formatted amounts
+    // above) rather than the event-first default resolution.
+    __language: ctx.locale,
     cc: invoiceCc,
     attachments: [{
       filename: `${invoice.invoice_number}.pdf`,
@@ -368,6 +371,8 @@ async function sendStorno(stornoId, adminId) {
     original_issue_date: originalRow?.issue_date ? formatShortDate(originalRow.issue_date) : '',
     customer_name: customer.display_name || customer.first_name || customer.email.split('@')[0],
     total_amount: formatMajor(Math.abs(storno.total_amount_minor), storno.currency, ctx.locale),
+    // Match the customer's language (as with the ctx.locale-formatted amount).
+    __language: ctx.locale,
     cc: stornoCc,
     attachments: [{
       filename: `${storno.invoice_number}.pdf`,

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -4074,7 +4074,7 @@
       "noEvents": "Noch keinem Event zugewiesen. Fügen Sie diesen Kunden über das Event-Formular hinzu.",
       "email": "E-Mail",
       "preferredLanguage": "Bevorzugte Sprache",
-      "preferredLanguageHint": "Steuert die Portal-Sprache sowie die Sprache von Angebots- und Rechnungs-PDFs. Neue Kunden erben standardmässig die Sprache aus dem Geschäftsprofil ({{lang}}); hier kann pro Kunde überschrieben werden.",
+      "preferredLanguageHint": "Steuert die Portal-Sprache, Angebots-/Rechnungs-PDFs sowie Rechnungs-E-Mails (Erinnerungen/Mahnungen). Neue Kunden erben standardmässig die Sprache aus dem Geschäftsprofil ({{lang}}); hier kann pro Kunde überschrieben werden.",
       "salutation": "Anrede",
       "salutationNone": "—",
       "firstName": "Vorname",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -4074,7 +4074,7 @@
       "noEvents": "Not assigned to any events yet. Add this customer to an event from the event form.",
       "email": "Email",
       "preferredLanguage": "Preferred language",
-      "preferredLanguageHint": "Drives portal UI and quote/invoice PDF locale. New customers default to the business-profile language ({{lang}}); override here per customer.",
+      "preferredLanguageHint": "Drives portal UI, quote/invoice PDFs, and billing emails (reminders/dunning). New customers default to the business-profile language ({{lang}}); override here per customer.",
       "salutation": "Salutation",
       "salutationNone": "—",
       "firstName": "First name",

--- a/frontend/src/pages/admin/CustomerDetailPage.tsx
+++ b/frontend/src/pages/admin/CustomerDetailPage.tsx
@@ -360,7 +360,7 @@ export const CustomerDetailPage: React.FC = () => {
             </select>
             <p className="text-xs text-neutral-500 mt-1">
               {t('customers.detail.preferredLanguageHint',
-                'Drives portal UI and quote/invoice PDF locale. New customers default to the business-profile language ({{lang}}); override here per customer.',
+                'Drives portal UI, quote/invoice PDFs, and billing emails (reminders/dunning). New customers default to the business-profile language ({{lang}}); override here per customer.',
                 { lang: LOCALE_LABELS[profileDefaultLocale] || profileDefaultLocale.toUpperCase() })}
             </p>
           </div>

--- a/frontend/src/pages/public/PaymentCheckPage.tsx
+++ b/frontend/src/pages/public/PaymentCheckPage.tsx
@@ -373,15 +373,18 @@ const ResultBox: React.FC<{
         <div
           className="rounded-lg border p-6"
           style={{
-            borderColor: '#bbf7d0',
-            backgroundColor: 'color-mix(in srgb, #dcfce7 50%, var(--color-surface))',
+            // Theme-adaptive success card — a light-green tint on light surfaces,
+            // a dark-green tint on dark ones (was a hardcoded light-green mix +
+            // dark-green title that went unreadable in dark mode, #759).
+            borderColor: 'color-mix(in srgb, #16a34a 35%, var(--color-surface))',
+            backgroundColor: 'color-mix(in srgb, #16a34a 12%, var(--color-surface))',
           }}
         >
           <CheckCircle2 className="w-10 h-10 mb-3" style={{ color: '#16a34a' }} />
-          <h1 className="text-lg font-bold mb-1" style={{ color: '#166534' }}>
+          <h1 className="text-lg font-bold mb-1" style={{ color: 'var(--color-text)' }}>
             {t('paymentCheck.result.title', 'Action recorded')}
           </h1>
-          <p className="text-sm">
+          <p className="text-sm" style={{ color: 'var(--color-text)' }}>
             {result.applied === 'paid_full' && t('paymentCheck.result.paid',
               'Invoice {{n}} marked as paid in full.', { n: inv.invoiceNumber })}
             {result.applied === 'paid_with_skonto' && t('paymentCheck.result.paidSkonto',


### PR DESCRIPTION
Fixes three issues found while testing the invoice-dunning flow. Tested on the dev instance.

## #760 — billing/dunning emails used the event's gallery language
`emailProcessor.getRecipientLanguage()` resolves language **event-first**, so an invoice tied to an English-gallery event sent the customer an **English** dunning email even for a German customer/invoice.
- `emailProcessor` now honors an explicit **`__language`** in the email data (both the queue-processor and preview paths); otherwise it falls back to the existing event-first resolution — no change for gallery emails.
- The invoice reminder (`invoice/reminders.js`) resolves the locale as `customer.preferred_language || invoice.language || 'de'` and passes it as `__language`.

## #759 — payment-check confirmation card unreadable in dark mode
The "Action recorded" card hardcoded a dark-green title over a light-green `color-mix` background — muddy + illegible on dark surfaces. Now theme-adaptive: a green tint over `--color-surface` with `--color-text` title/body, readable on both light and dark.
<img width="593" height="438" alt="Screenshot 2026-07-06 at 19 59 27" src="https://github.com/user-attachments/assets/42810350-08a3-438b-bc31-5a4b2e32cf33" />


## #761 — per-customer language
The per-customer **"Preferred language"** dropdown already exists (`CustomerDetailPage`), as does the global business-profile default. The gap was that emails ignored it (#760). Updated the field's helper text (en + de) to note billing emails now honor it.

Fixes #759, #760, #761.