### PR TITLE
fix(admin): stop the event-date field crashing the page on backspace

### DIFF
--- a/frontend/src/components/common/LocalizedDateInput.tsx
+++ b/frontend/src/components/common/LocalizedDateInput.tsx
@@ -90,6 +90,13 @@ export const LocalizedDateInput: React.FC<LocalizedDateInputProps> = ({
       [d, mo, y] = [a, b, c];
     }
     if (!/^\d{1,2}$/.test(d) || !/^\d{1,2}$/.test(mo) || !/^\d{4}$/.test(y)) return '';
+    // Reject impossible calendar dates (day 00, month 13, 31 Feb…) — a partial
+    // value mid-backspace like "0/07/2026" is otherwise coerced to "2026-07-00",
+    // which is a valid string but an Invalid Date that crashes date-fns format()
+    // downstream. Round-trip through Date to confirm the components survive.
+    const yy = Number(y), mm = Number(mo), dd = Number(d);
+    const probe = new Date(yy, mm - 1, dd);
+    if (probe.getFullYear() !== yy || probe.getMonth() !== mm - 1 || probe.getDate() !== dd) return '';
     return `${y}-${mo.padStart(2, '0')}-${d.padStart(2, '0')}`;
   };
 

--- a/frontend/src/components/common/__tests__/LocalizedDateInput.test.tsx
+++ b/frontend/src/components/common/__tests__/LocalizedDateInput.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi } from 'vitest';
+import { LocalizedDateInput } from '../LocalizedDateInput';
+
+// Stub the settings hook so the component doesn't need a QueryClient; falls
+// back to the default DD.MM.YYYY display format. The parse/validation under
+// test is separator-independent.
+vi.mock('../../../hooks/usePublicSettings', () => ({
+  usePublicSettings: () => ({ settings: {} }),
+}));
+
+describe('LocalizedDateInput', () => {
+  const renderInput = (value = '2026-07-07') => {
+    const onChange = vi.fn();
+    render(<LocalizedDateInput value={value} onChange={onChange} />);
+    const input = screen.getByDisplayValue('07.07.2026') as HTMLInputElement;
+    return { input, onChange };
+  };
+
+  it('does not commit an impossible date mid-edit (regression: backspacing the day → "2026-07-00" crashed the page)', () => {
+    const { input, onChange } = renderInput();
+    // Backspacing a day digit leaves "0.07.2026" — a syntactically complete but
+    // invalid date. It must NOT propagate (used to coerce to "2026-07-00",
+    // which crashed date-fns format() downstream).
+    fireEvent.change(input, { target: { value: '0.07.2026' } });
+    expect(onChange).not.toHaveBeenCalled();
+
+    // Nor may an out-of-range calendar date (31 Feb).
+    fireEvent.change(input, { target: { value: '31.02.2026' } });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('commits a complete, valid date as ISO', () => {
+    const { input, onChange } = renderInput();
+    fireEvent.change(input, { target: { value: '15.08.2026' } });
+    expect(onChange).toHaveBeenCalledWith('2026-08-15');
+  });
+});

--- a/frontend/src/hooks/useLocalizedDate.ts
+++ b/frontend/src/hooks/useLocalizedDate.ts
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { format as dateFnsFormat, formatDistanceToNow as dateFnsFormatDistanceToNow } from 'date-fns';
+import { format as dateFnsFormat, formatDistanceToNow as dateFnsFormatDistanceToNow, isValid } from 'date-fns';
 import { de, enUS, ptBR, fr } from 'date-fns/locale';
 import { usePublicSettings } from './usePublicSettings';
 
@@ -32,6 +32,11 @@ export const useLocalizedDate = () => {
   
   const format = (date: Date | string, formatStr?: string) => {
     const dateObj = typeof date === 'string' ? new Date(date) : date;
+    // date-fns `format` throws RangeError on an Invalid Date, which crashes the
+    // whole page when a call site renders a transient/partial date (e.g. the
+    // event-date field mid-edit). Return '' instead so a bad value degrades to
+    // blank rather than tearing down the tree.
+    if (!isValid(dateObj)) return '';
     // Use admin-configured date format if available and no format string provided
     let dateFormat = formatStr;
     if (!dateFormat && settings?.general_date_format) {
@@ -50,6 +55,7 @@ export const useLocalizedDate = () => {
   
   const formatDistanceToNow = (date: Date | string, options?: { addSuffix?: boolean }) => {
     const dateObj = typeof date === 'string' ? new Date(date) : date;
+    if (!isValid(dateObj)) return '';
     return dateFnsFormatDistanceToNow(dateObj, { ...options, locale: getLocale() });
   };
 


### PR DESCRIPTION
## The bug

Create an event → click into the **Event date** field → backspace a day digit → the whole page white-screens and needs a reload.

## Root cause

Two layers combine:

1. `LocalizedDateInput.toIso()` only checked that day/month were 1–2 digits, **not that they formed a real date**. So a mid-backspace value like `0/07/2026` was coerced to the string `"2026-07-00"` and committed to `event_date`.
2. `CreateEventPage` renders the expiry preview as `format(addDays(new Date(event_date), days))`, and date-fns `format` **throws `RangeError: Invalid time value`** on an Invalid Date. Thrown *during render* → React unwinds to the error boundary → blank screen.

Confirmed live — the exact stack:
```
RangeError: Invalid time value
  at format (date-fns)
  at format (useLocalizedDate.ts:32)
  at CreateEventPage  (the "Expires on" preview)
```

## Fix (two complementary layers)

- **`toIso` rejects impossible dates** — round-trips the parsed `y/m/d` through `Date` and bails if the components don't survive (day `00`, month `13`, `31 Feb`…). The field never commits a value that isn't a real calendar date.
- **`useLocalizedDate.format` / `formatDistanceToNow` guard with `isValid`** and return `''` instead of throwing. Defence in depth for the ~57 call sites that could otherwise white-screen on a bad date.

## Verification

- Reproduced the crash, then confirmed the same backspace keeps the form rendered (no error boundary), and a valid date still commits + the expiry preview renders (`15.08.2026` → `Expires on: 14/09/2026`).
- New `LocalizedDateInput` regression test (invalid mid-edit value not committed; valid value commits as ISO). `tsc` + build green.

![event date field working after fix](https://raw.githubusercontent.com/PicPeak/picpeak/screenshots/date-fix/event-date-fix.png)
