### PR TITLE
ci: run the Tests workflow on stable-targeted PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,9 +17,9 @@ name: Tests
 
 on:
   push:
-    branches: [main, beta]
+    branches: [main, beta, stable]
   pull_request:
-    branches: [main, beta]
+    branches: [main, beta, stable]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
`tests.yml` (the `backend`/`frontend` Jest+Vitest jobs) only triggered on `main`/`beta`, but both jobs are **required status checks** on the `stable` branch. So a beta→stable promote PR (e.g. #771) hangs forever on *"Expected — Waiting for status to be reported"* for `backend`/`frontend`, while `docker-build` / `install-smoke` / `schema-drift` (which already list `stable`) run fine.

Fix: add `stable` to the `push` + `pull_request` branch filters so the Tests suite runs on promote PRs too. One-liner, no test changes.

Unblocks #771.