### PR TITLE
ci(release): cut the real v3.45.0 stable (target-branch: stable)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -25,6 +25,7 @@ jobs:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          target-branch: stable
 
       # Auto-approve + auto-merge the open stable release PR. See the beta
       # workflow for the full rationale. Skipped on the release-cutting run and


### PR DESCRIPTION
Follow-up to the mis-fired promote. Adds `target-branch: stable` to `release-please.yml` on the **stable** branch so that merging this re-runs release-please correctly against `stable` (manifest `3.44.0` → **`v3.45.0`**), instead of the earlier default-to-main behaviour that produced the bogus `v2.7.0`.

Merging this PR is the trigger: release-please will open + auto-merge a `chore: release 3.45.0` PR and publish the real stable. #774 applies the same fix on `main` for all future promotes; `v2.7.0` has been deleted.