### PR TITLE
fix(ci): publish v-prefixed image tags so :vX.Y.Z resolves (#668)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -282,6 +282,9 @@ jobs:
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}},enable=${{ steps.context.outputs.is_prerelease == 'false' }}
           type=semver,pattern={{major}},enable=${{ steps.context.outputs.is_prerelease == 'false' }}
+          type=semver,pattern=v{{version}}
+          type=semver,pattern=v{{major}}.{{minor}},enable=${{ steps.context.outputs.is_prerelease == 'false' }}
+          type=semver,pattern=v{{major}},enable=${{ steps.context.outputs.is_prerelease == 'false' }}
           type=sha,format=short
           # `:latest` + `:stable` follow the stable channel (the `stable` branch +
           # stable release tags). The default branch is now `main` (active dev),
@@ -499,6 +502,9 @@ jobs:
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}},enable=${{ steps.context.outputs.is_prerelease == 'false' }}
           type=semver,pattern={{major}},enable=${{ steps.context.outputs.is_prerelease == 'false' }}
+          type=semver,pattern=v{{version}}
+          type=semver,pattern=v{{major}}.{{minor}},enable=${{ steps.context.outputs.is_prerelease == 'false' }}
+          type=semver,pattern=v{{major}},enable=${{ steps.context.outputs.is_prerelease == 'false' }}
           type=sha,format=short
           # `:latest` + `:stable` follow the stable channel (the `stable` branch +
           # stable release tags). The default branch is now `main` (active dev),


### PR DESCRIPTION
Closes #668 (and the root of #664).

## Problem
Versioned image tags **are** published now (post-#719 PAT), but `docker/metadata-action`'s `type=semver` **strips the leading `v`** — so releases only publish `:3.45.0`, `:3.83.1-beta.0`, etc. Since git tags + GitHub releases are named `v3.45.0`, anyone pinning `ghcr.io/picpeak/picpeak/backend:v3.45.0` (the natural choice) gets `manifest unknown` — exactly @alexvaltchev's #664 report.

Verified against GHCR: `backend:3.45.0` → 200, `backend:v3.45.0` → 404.

## Fix
Add `v`-prefixed semver patterns (`v{{version}}`, `v{{major}}.{{minor}}`, `v{{major}}`) alongside the existing bare ones, for **both** backend and frontend metadata steps. Now **both** `:v3.45.0` and `:3.45.0` resolve — users can pin either the git-tag form or the bare semver.

## Notes
- Applies to future releases. The already-published `v3.45.0` only carries the bare `:3.45.0` tag; retagging past releases is out of scope.
- Reaches stable on the next promote (docker-build.yml is shared).