### PR TITLE
ci(docker): also publish images to Docker Hub (picpeak/backend, picpeak/frontend)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -95,6 +95,15 @@ jobs:
         repo_lc="${GITHUB_REPOSITORY,,}"
         echo "BACKEND_IMAGE_NAME=${repo_lc}/backend" >> "$GITHUB_ENV"
         echo "FRONTEND_IMAGE_NAME=${repo_lc}/frontend" >> "$GITHUB_ENV"
+        # Mirror manifests to Docker Hub (picpeak/{backend,frontend}) only on the
+        # canonical org repo, where the DOCKERHUB_* secrets live. Forks (and any
+        # other owner) fall back to GHCR-only — the Docker Hub image line and login
+        # are gated on this flag so their builds keep working unchanged.
+        if [[ "$GITHUB_REPOSITORY" == "PicPeak/picpeak" ]]; then
+          echo "DOCKERHUB_ENABLED=true" >> "$GITHUB_ENV"
+        else
+          echo "DOCKERHUB_ENABLED=false" >> "$GITHUB_ENV"
+        fi
 
     - name: Prepare platform pair
       run: |
@@ -233,6 +242,15 @@ jobs:
         repo_lc="${GITHUB_REPOSITORY,,}"
         echo "BACKEND_IMAGE_NAME=${repo_lc}/backend" >> "$GITHUB_ENV"
         echo "FRONTEND_IMAGE_NAME=${repo_lc}/frontend" >> "$GITHUB_ENV"
+        # Mirror manifests to Docker Hub (picpeak/{backend,frontend}) only on the
+        # canonical org repo, where the DOCKERHUB_* secrets live. Forks (and any
+        # other owner) fall back to GHCR-only — the Docker Hub image line and login
+        # are gated on this flag so their builds keep working unchanged.
+        if [[ "$GITHUB_REPOSITORY" == "PicPeak/picpeak" ]]; then
+          echo "DOCKERHUB_ENABLED=true" >> "$GITHUB_ENV"
+        else
+          echo "DOCKERHUB_ENABLED=false" >> "$GITHUB_ENV"
+        fi
 
     - name: Download digest artifacts
       uses: actions/download-artifact@v4
@@ -266,11 +284,24 @@ jobs:
           echo "is_prerelease=false" >> $GITHUB_OUTPUT
         fi
 
+    - name: Log in to Docker Hub
+      if: env.DOCKERHUB_ENABLED == 'true'
+      uses: docker/login-action@v3
+      with:
+        registry: docker.io
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
     - name: Extract metadata for Backend
       id: meta-backend
       uses: docker/metadata-action@v5
       with:
-        images: ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE_NAME }}
+        # GHCR always; Docker Hub (picpeak/backend) added on the canonical repo so
+        # the same tag scheme is mirrored to both registries. metadata-action drops
+        # the blank second line on forks → GHCR-only there.
+        images: |
+          ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE_NAME }}
+          ${{ env.DOCKERHUB_ENABLED == 'true' && 'docker.io/picpeak/backend' || '' }}
         labels: |
           org.opencontainers.image.title=PicPeak Backend
           org.opencontainers.image.description=PicPeak photo sharing platform backend service
@@ -301,9 +332,14 @@ jobs:
         docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
           $(printf "${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE_NAME }}@sha256:%s " *)
 
-    - name: Inspect manifest
+    - name: Inspect manifest (GHCR)
       run: |
         docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE_NAME }}:${{ steps.meta-backend.outputs.version }}
+
+    - name: Inspect manifest (Docker Hub)
+      if: env.DOCKERHUB_ENABLED == 'true'
+      run: |
+        docker buildx imagetools inspect docker.io/picpeak/backend:${{ steps.meta-backend.outputs.version }}
 
   # -----------------------------------------------------------------------------
   # Frontend: per-arch build, then merge into a multi-arch manifest
@@ -334,6 +370,15 @@ jobs:
         repo_lc="${GITHUB_REPOSITORY,,}"
         echo "BACKEND_IMAGE_NAME=${repo_lc}/backend" >> "$GITHUB_ENV"
         echo "FRONTEND_IMAGE_NAME=${repo_lc}/frontend" >> "$GITHUB_ENV"
+        # Mirror manifests to Docker Hub (picpeak/{backend,frontend}) only on the
+        # canonical org repo, where the DOCKERHUB_* secrets live. Forks (and any
+        # other owner) fall back to GHCR-only — the Docker Hub image line and login
+        # are gated on this flag so their builds keep working unchanged.
+        if [[ "$GITHUB_REPOSITORY" == "PicPeak/picpeak" ]]; then
+          echo "DOCKERHUB_ENABLED=true" >> "$GITHUB_ENV"
+        else
+          echo "DOCKERHUB_ENABLED=false" >> "$GITHUB_ENV"
+        fi
 
     - name: Prepare platform pair
       run: |
@@ -453,6 +498,15 @@ jobs:
         repo_lc="${GITHUB_REPOSITORY,,}"
         echo "BACKEND_IMAGE_NAME=${repo_lc}/backend" >> "$GITHUB_ENV"
         echo "FRONTEND_IMAGE_NAME=${repo_lc}/frontend" >> "$GITHUB_ENV"
+        # Mirror manifests to Docker Hub (picpeak/{backend,frontend}) only on the
+        # canonical org repo, where the DOCKERHUB_* secrets live. Forks (and any
+        # other owner) fall back to GHCR-only — the Docker Hub image line and login
+        # are gated on this flag so their builds keep working unchanged.
+        if [[ "$GITHUB_REPOSITORY" == "PicPeak/picpeak" ]]; then
+          echo "DOCKERHUB_ENABLED=true" >> "$GITHUB_ENV"
+        else
+          echo "DOCKERHUB_ENABLED=false" >> "$GITHUB_ENV"
+        fi
 
     - name: Download digest artifacts
       uses: actions/download-artifact@v4
@@ -486,11 +540,24 @@ jobs:
           echo "is_prerelease=false" >> $GITHUB_OUTPUT
         fi
 
+    - name: Log in to Docker Hub
+      if: env.DOCKERHUB_ENABLED == 'true'
+      uses: docker/login-action@v3
+      with:
+        registry: docker.io
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
     - name: Extract metadata for Frontend
       id: meta-frontend
       uses: docker/metadata-action@v5
       with:
-        images: ${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE_NAME }}
+        # GHCR always; Docker Hub (picpeak/frontend) added on the canonical repo so
+        # the same tag scheme is mirrored to both registries. metadata-action drops
+        # the blank second line on forks → GHCR-only there.
+        images: |
+          ${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE_NAME }}
+          ${{ env.DOCKERHUB_ENABLED == 'true' && 'docker.io/picpeak/frontend' || '' }}
         labels: |
           org.opencontainers.image.title=PicPeak Frontend
           org.opencontainers.image.description=PicPeak photo sharing platform frontend application
@@ -521,9 +588,14 @@ jobs:
         docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
           $(printf "${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE_NAME }}@sha256:%s " *)
 
-    - name: Inspect manifest
+    - name: Inspect manifest (GHCR)
       run: |
         docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE_NAME }}:${{ steps.meta-frontend.outputs.version }}
+
+    - name: Inspect manifest (Docker Hub)
+      if: env.DOCKERHUB_ENABLED == 'true'
+      run: |
+        docker buildx imagetools inspect docker.io/picpeak/frontend:${{ steps.meta-frontend.outputs.version }}
 
   summary:
     needs: [build-backend, merge-backend, build-frontend, merge-frontend]
@@ -538,6 +610,15 @@ jobs:
         repo_lc="${GITHUB_REPOSITORY,,}"
         echo "BACKEND_IMAGE_NAME=${repo_lc}/backend" >> "$GITHUB_ENV"
         echo "FRONTEND_IMAGE_NAME=${repo_lc}/frontend" >> "$GITHUB_ENV"
+        # Mirror manifests to Docker Hub (picpeak/{backend,frontend}) only on the
+        # canonical org repo, where the DOCKERHUB_* secrets live. Forks (and any
+        # other owner) fall back to GHCR-only — the Docker Hub image line and login
+        # are gated on this flag so their builds keep working unchanged.
+        if [[ "$GITHUB_REPOSITORY" == "PicPeak/picpeak" ]]; then
+          echo "DOCKERHUB_ENABLED=true" >> "$GITHUB_ENV"
+        else
+          echo "DOCKERHUB_ENABLED=false" >> "$GITHUB_ENV"
+        fi
 
     - name: Build Summary
       run: |
@@ -576,6 +657,10 @@ jobs:
         echo "### 📦 Images" >> $GITHUB_STEP_SUMMARY
         echo "- Backend: \`${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE_NAME }}\`" >> $GITHUB_STEP_SUMMARY
         echo "- Frontend: \`${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE_NAME }}\`" >> $GITHUB_STEP_SUMMARY
+        if [[ "$DOCKERHUB_ENABLED" == "true" ]]; then
+          echo "- Backend (Docker Hub): \`docker.io/picpeak/backend\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Frontend (Docker Hub): \`docker.io/picpeak/frontend\`" >> $GITHUB_STEP_SUMMARY
+        fi
 
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "### 🏗️ Architectures" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## What

Publish the backend + frontend images to **Docker Hub** (`picpeak/backend`, `picpeak/frontend`) in addition to GHCR, on every push that already publishes today — `main`, `stable`, `latest`, semver release tags, and `:sha-…`. Full parity with GHCR.

## How

The pipeline builds each arch **by digest to GHCR** and then the `merge-*` jobs assemble the multi-arch manifest with `docker buildx imagetools create`. That command already applies every tag from `metadata-action`'s output and can target multiple registries in one shot. So the change is minimal and lives entirely in the two merge jobs:

- Add `docker.io/picpeak/{backend,frontend}` to each `metadata-action` `images:` list → the same tag scheme is generated for both registries.
- Add a **Docker Hub login** step in each merge job. `imagetools create` then copies the GHCR digest blobs into Docker Hub and pushes the manifest there too.
- Add a Docker Hub `imagetools inspect` + summary lines for confirmation.

**No change to the build-by-digest jobs** — single source-of-truth digests in GHCR, mirrored at manifest time. No second push, no QEMU.

## Fork-safe

Everything is gated on `DOCKERHUB_ENABLED` (`github.repository == 'PicPeak/picpeak'`). On forks the Docker Hub image line collapses to blank (metadata-action drops it) and the login/inspect steps skip — fork builds stay GHCR-only and unchanged.

## Required secrets (already set on this repo)

- `DOCKERHUB_USERNAME`
- `DOCKERHUB_TOKEN` (Docker Hub access token with write to the `picpeak` org repos)

## Test plan

- [ ] Merge, then confirm the next `main` build pushes `picpeak/backend:main` + `picpeak/frontend:main` to Docker Hub (both arches in the manifest).
- [ ] Confirm a `stable`/release run mirrors `:stable`, `:latest`, and the semver tags.

Follow-up (separate PR): document `picpeak/{backend,frontend}` as the primary pull path in README / compose.
