### PR TITLE
fix(ci): publish v-prefixed image tags via type=ref,event=tag (#668)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -282,9 +282,10 @@ jobs:
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}},enable=${{ steps.context.outputs.is_prerelease == 'false' }}
           type=semver,pattern={{major}},enable=${{ steps.context.outputs.is_prerelease == 'false' }}
-          type=semver,pattern=v{{version}}
-          type=semver,pattern=v{{major}}.{{minor}},enable=${{ steps.context.outputs.is_prerelease == 'false' }}
-          type=semver,pattern=v{{major}},enable=${{ steps.context.outputs.is_prerelease == 'false' }}
+          # #668/#783: publish the git-tag name verbatim (v3.45.0 / v3.84.0-beta.0)
+          # so users can pin the same string as the GitHub release. metadata-action's
+          # `pattern=v{{version}}` silently dropped it on prereleases, so use type=ref.
+          type=ref,event=tag
           type=sha,format=short
           # `:latest` + `:stable` follow the stable channel (the `stable` branch +
           # stable release tags). The default branch is now `main` (active dev),
@@ -502,9 +503,10 @@ jobs:
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}},enable=${{ steps.context.outputs.is_prerelease == 'false' }}
           type=semver,pattern={{major}},enable=${{ steps.context.outputs.is_prerelease == 'false' }}
-          type=semver,pattern=v{{version}}
-          type=semver,pattern=v{{major}}.{{minor}},enable=${{ steps.context.outputs.is_prerelease == 'false' }}
-          type=semver,pattern=v{{major}},enable=${{ steps.context.outputs.is_prerelease == 'false' }}
+          # #668/#783: publish the git-tag name verbatim (v3.45.0 / v3.84.0-beta.0)
+          # so users can pin the same string as the GitHub release. metadata-action's
+          # `pattern=v{{version}}` silently dropped it on prereleases, so use type=ref.
+          type=ref,event=tag
           type=sha,format=short
           # `:latest` + `:stable` follow the stable channel (the `stable` branch +
           # stable release tags). The default branch is now `main` (active dev),


### PR DESCRIPTION
Follow-up to #783 — the v-prefixed image tag still wasn't published.

## What was wrong
#783 added `type=semver,pattern=v{{version}}` to the **merge-job** metadata, but `docker/metadata-action` silently dropped it on **prereleases**. Verified on the `3.84.0-beta.0` build: the merge-backend push log lists only `:3.84.0-beta.0` + `:sha-…`, and GHCR confirms `backend:v3.84.0-beta.0` → **404** while `:3.84.0-beta.0` → 200.

## Fix
Replace the `v{{version}}` / `v{{major}}.{{minor}}` / `v{{major}}` semver patterns with **`type=ref,event=tag`** in both the backend and frontend merge metadata steps. That emits the **git-tag name verbatim** — `v3.45.0` for stable, `v3.84.0-beta.0` for beta — i.e. exactly the string users pin (it matches the GitHub release tag), and it works the same for prereleases.

The bare `:3.84.0-beta.0` / `:3.45.0` tags are unchanged (the `{{version}}` patterns stay), so **both** forms resolve.

Takes effect on the next release build; I'll verify `:v…` publishes then.