### PR TITLE
fix(gallery): show feedback filter chips on desktop for galleries without categories

### DIFF
--- a/frontend/src/components/gallery/PhotoFilterBar.tsx
+++ b/frontend/src/components/gallery/PhotoFilterBar.tsx
@@ -154,39 +154,45 @@ export const PhotoFilterBar: React.FC<PhotoFilterBarProps> = ({
 
       {/* Category and Feedback Filters */}
       <div className="space-y-3">
-        {/* Categories Row */}
-        {categories && categories.length > 0 && (
+        {/* Categories + desktop feedback row. Rendered whenever EITHER part
+            has content: the desktop feedback chips must not depend on the
+            (optional) categories existing, or category-less galleries show
+            no feedback filter at all on desktop (#802 — the lg:hidden
+            fallback block below only covers mobile/tablet). */}
+        {((categories && categories.length > 0) || (feedbackEnabled && !!onFilterChange)) && (
           <div className="flex items-start lg:items-center justify-between flex-col lg:flex-row gap-3">
             {/* Categories: keep in a horizontal scroll container */}
-            <div className="w-full overflow-x-auto pb-2 lg:pb-0">
-              <div className="flex items-center gap-2 min-w-max">
-                <Button
-                  variant={selectedCategoryId === null ? 'primary' : 'outline'}
-                  size="sm"
-                  onClick={() => onCategoryChange(null)}
-                  leftIcon={<Grid className="w-3 h-3 md:w-4 md:h-4" />}
-                  className="text-xs md:text-sm whitespace-nowrap flex-shrink-0"
-                >
-                  {showMediaFilter ? t('gallery.allMedia', 'All media') : t('gallery.allPhotos')} ({photos.length})
-                </Button>
-                {categories.map((category) => {
-                  const categoryPhotoCount = photos.filter(p => p.category_id === category.id).length;
-                  if (categoryPhotoCount === 0) return null;
-                  
-                  return (
-                    <Button
-                      key={category.id}
-                      variant={selectedCategoryId === category.id ? 'primary' : 'outline'}
-                      size="sm"
-                      onClick={() => onCategoryChange(category.id)}
-                      className="text-xs md:text-sm whitespace-nowrap flex-shrink-0"
-                    >
-                      {category.name} ({categoryPhotoCount})
-                    </Button>
-                  );
-                })}
+            {categories && categories.length > 0 && (
+              <div className="w-full overflow-x-auto pb-2 lg:pb-0">
+                <div className="flex items-center gap-2 min-w-max">
+                  <Button
+                    variant={selectedCategoryId === null ? 'primary' : 'outline'}
+                    size="sm"
+                    onClick={() => onCategoryChange(null)}
+                    leftIcon={<Grid className="w-3 h-3 md:w-4 md:h-4" />}
+                    className="text-xs md:text-sm whitespace-nowrap flex-shrink-0"
+                  >
+                    {showMediaFilter ? t('gallery.allMedia', 'All media') : t('gallery.allPhotos')} ({photos.length})
+                  </Button>
+                  {categories.map((category) => {
+                    const categoryPhotoCount = photos.filter(p => p.category_id === category.id).length;
+                    if (categoryPhotoCount === 0) return null;
+
+                    return (
+                      <Button
+                        key={category.id}
+                        variant={selectedCategoryId === category.id ? 'primary' : 'outline'}
+                        size="sm"
+                        onClick={() => onCategoryChange(category.id)}
+                        className="text-xs md:text-sm whitespace-nowrap flex-shrink-0"
+                      >
+                        {category.name} ({categoryPhotoCount})
+                      </Button>
+                    );
+                  })}
+                </div>
               </div>
-            </div>
+            )}
 
             {/* Desktop: compact horizontal feedback filter with headline (icons only) */}
             {feedbackEnabled && onFilterChange && (
@@ -244,7 +250,10 @@ export const PhotoFilterBar: React.FC<PhotoFilterBarProps> = ({
               </div>
             )}
 
-            <p className="text-xs md:text-sm text-muted-theme flex-shrink-0 ml-auto">
+            {/* Without categories this row only carries desktop content (the
+                chips are lg-only; mobile has its own block below), so hide
+                the count below lg to keep the mobile layout unchanged. */}
+            <p className={`text-xs md:text-sm text-muted-theme flex-shrink-0 ml-auto ${categories && categories.length > 0 ? '' : 'hidden lg:block'}`}>
               {photoCount} {t('common.media', 'media')}
             </p>
           </div>

--- a/frontend/src/components/gallery/__tests__/PhotoFilterBar.feedbackChips.test.tsx
+++ b/frontend/src/components/gallery/__tests__/PhotoFilterBar.feedbackChips.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * Regression coverage for #802: the desktop feedback-filter chips
+ * (All / Likes / Saved / Rated / Commented) were nested inside the
+ * categories row, so a gallery WITHOUT photo categories (the default)
+ * rendered no feedback filter at all on desktop — the standalone
+ * fallback block is lg:hidden (mobile/tablet only). These tests pin
+ * that both chip groups exist in the DOM regardless of categories.
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { PhotoFilterBar } from '../PhotoFilterBar';
+
+vi.mock('react-i18next', async () => {
+  const actual = await vi.importActual<typeof import('react-i18next')>('react-i18next');
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (_key: string, fallback?: unknown) =>
+        typeof fallback === 'string' ? fallback : _key,
+      i18n: { language: 'en' }
+    })
+  };
+});
+
+const baseProps = {
+  categories: [] as Array<{ id: number; name: string; slug: string }>,
+  photos: [] as never[],
+  selectedCategoryId: null,
+  onCategoryChange: vi.fn(),
+  searchTerm: '',
+  onSearchChange: vi.fn(),
+  sortBy: 'date' as const,
+  onSortChange: vi.fn(),
+  photoCount: 0,
+};
+
+describe('PhotoFilterBar feedback chips (#802)', () => {
+  it('renders both chip groups (desktop lg:flex + mobile lg:hidden) with NO categories', () => {
+    render(
+      <PhotoFilterBar
+        {...baseProps}
+        feedbackEnabled
+        currentFilter="all"
+        onFilterChange={vi.fn()}
+      />
+    );
+    // Two groups: the desktop row variant and the mobile fallback. Before
+    // the fix, only the mobile one rendered when categories were empty,
+    // leaving desktop with no feedback filter at all.
+    expect(screen.getAllByText('Feedback Filter')).toHaveLength(2);
+  });
+
+  it('still renders both chip groups when categories exist', () => {
+    render(
+      <PhotoFilterBar
+        {...baseProps}
+        categories={[{ id: 1, name: 'Ceremony', slug: 'ceremony' }]}
+        photos={[{ id: 1, category_id: 1 } as never]}
+        feedbackEnabled
+        currentFilter="all"
+        onFilterChange={vi.fn()}
+      />
+    );
+    expect(screen.getAllByText('Feedback Filter')).toHaveLength(2);
+  });
+
+  it('renders no chips when feedback is disabled', () => {
+    render(<PhotoFilterBar {...baseProps} />);
+    expect(screen.queryByText('Feedback Filter')).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #802.

> **Classification: bugfix only — no new feature, no backend changes.** One component + one test file. Safe to promote to stable immediately.

## Root cause

The feedback-filter chips (All / Likes / Saved / Rated / Commented) and their filtering logic have existed all along — the reporter's docs weren't ahead of the implementation. The bug was pure layout gating in `PhotoFilterBar.tsx`:

- The **desktop** chip group was nested inside the categories-row conditional (`categories.length > 0 && …`). Photo categories are optional, so a category-less gallery — the default — skipped the entire row including the chips.
- The standalone fallback chip block is `lg:hidden`, i.e. mobile/tablet only.

Result: on a desktop viewport with no categories, no chip group was visible anywhere — exactly the reported "only Search + Sort". (On a phone the chips did appear; sidebar-style themes render the chips through `GallerySidebar` and were unaffected.)

## Fix

Render the row whenever **either** part has content, and gate only the category scroller on categories existing. The media-count label hides below `lg` when no categories exist, so the mobile layout is byte-identical to before (mobile keeps its own chip block). Galleries **with** categories render exactly as before.

## Verification

- New regression test `PhotoFilterBar.feedbackChips.test.tsx`: both chip groups present in the DOM with and without categories, none when feedback is disabled — **fails on the pre-fix component** (verified by stashing the fix).
- Reproduced live against the reported setup (fresh event, feedback fully enabled, zero categories, three photos, desktop 1440px): before → chip element in DOM but `lg:hidden`-invisible, only Search + Sort visible; after → desktop chip row visible, and clicking *Favorisiert* filters 3 → 0 photos with the empty state, *Alle* restores them. Mobile (390px) verified unchanged: one visible chip group, no stray media-count line.
- Full frontend suite 103/103, `tsc --noEmit` clean, no new lint findings.

Before/after screenshots in the PR conversation.
