### PR TITLE
chore(security): close 21 frontend image CVEs — nginx 1.30 base + apk cache-bust

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -27,8 +27,15 @@ FROM node:22-alpine
 
 WORKDIR /app
 
+# Redeclare CACHEBUST — ARGs don't cross stage boundaries, so the builder
+# stage's declaration never reached this stage. Consuming it in the RUN below
+# busts that layer's cache every CI run (CACHEBUST=github.run_number), so the
+# image always picks up current Alpine security updates instead of reusing a
+# stale cached upgrade layer.
+ARG CACHEBUST=1
+
 # Upgrade all packages to fix security vulnerabilities (OpenSSL, libexpat, BusyBox CVEs)
-RUN apk upgrade --no-cache
+RUN echo "cachebust=${CACHEBUST}" && apk upgrade --no-cache
 
 # Upgrade the npm CLI in the final image so its bundled deps are patched
 # (sigstore 4.x, tar) — closes CVE-2026-48815 and the older @sigstore/core / tar

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -29,14 +29,24 @@ COPY . .
 # Build the application
 RUN npm run build
 
-# Production stage (Alpine 3.23 with OpenSSL 3.5.5, patched libexpat)
-FROM nginx:1.28-alpine
+# Production stage (nginx stable 1.30 on Alpine 3.24). The 1.28 base is a
+# dead end for the nginx HTTP/2 + rewrite/charset CVEs (CVE-2026-42055 /
+# -49975 / -9256 / -48142): nginx.org's nginx-module-* packages pin the exact
+# nginx version, so `apk upgrade` can never pull Alpine's patched 1.28.3-r4 —
+# nginx fixes have to come via the base image tag, not apk.
+FROM nginx:1.30-alpine
 
-# Upgrade all Alpine packages for security fixes. The explicit nginx upgrade
-# closes the HTTP/2 + rewrite/charset CVEs (CVE-2026-42055 / -49975 / -9256 /
-# -48142, fixed in nginx 1.28.3-r4) and busts any cached layer still carrying
-# the vulnerable r1 build.
-RUN apk upgrade --no-cache && apk add --no-cache --upgrade nginx
+# Redeclare CACHEBUST — ARGs don't cross stage boundaries, so the builder
+# stage's declaration never reached this stage. Consuming it in the RUN below
+# busts that layer's cache every CI run (CACHEBUST=github.run_number), so the
+# image always picks up current Alpine security updates. Without this, the
+# upgrade layer was cached indefinitely and builds kept shipping curl 8.19.0 /
+# c-ares 1.34.6 for weeks after fixed packages landed in the Alpine repo.
+ARG CACHEBUST=1
+
+# Upgrade all Alpine packages for security fixes (nginx itself is version-
+# pinned by its module packages — see the FROM comment above).
+RUN echo "cachebust=${CACHEBUST}" && apk upgrade --no-cache
 
 # Install runtime dependencies. `gettext` provides envsubst, used by
 # docker-entrypoint.sh for the BRAND_TITLE / BRAND_DESCRIPTION runtime


### PR DESCRIPTION
Closes all 21 open [code-scanning alerts](https://github.com/PicPeak/picpeak/security/code-scanning) — all of them OS-package CVEs in the frontend image (nginx ×4, curl/libcurl ×16, c-ares ×1).

## Why the previous fix didn't stick

The `apk upgrade` line has been in the Dockerfile since the last CVE round, yet the July 15 build still scanned with all 21 findings. Two independent root causes:

**1. The runtime stage's `apk upgrade` layer was cached indefinitely.** CI passes `CACHEBUST=${{ github.run_number }}` as a build-arg, but the ARG was only declared in the *builder* stage — ARGs don't cross stage boundaries, so the runtime stage never saw it and the upgrade layer's cache key never changed. Builds kept reusing a stale layer with curl 8.19.0 / c-ares 1.34.6 for weeks after the fixed packages (8.20.0-r0 / 1.34.8-r0) landed in the Alpine v3.23 repo. Both Dockerfiles now redeclare `ARG CACHEBUST` in the runtime stage and consume it in the apk `RUN`, so the upgrade re-runs on every CI build.

**2. nginx can never upgrade via apk on this base image.** The official `nginx:alpine` images install nginx from nginx.org's packaging together with `nginx-module-*` packages that pin the *exact* nginx version — so `apk add --no-cache --upgrade nginx` was a silent no-op (verified empirically: after it runs, nginx stays at 1.28.3-r1 while Alpine's patched 1.28.3-r4 sits unreachable in the repo). nginx fixes have to come via the base image tag. Bumped `nginx:1.28-alpine` → `nginx:1.30-alpine` (current stable branch: nginx 1.30.4 on Alpine 3.24.1, same nginx.org `conf.d/` layout — drop-in, no config changes needed). The ineffective explicit nginx upgrade is removed; the comment now documents the pinning constraint so this doesn't regress.

## Verification (local build of this branch)

Trivy scan of the built frontend image — **0 OS findings** (was 21):

```
┌─────────────────────────────────────────┬────────┬─────────────────┐
│                 Target                  │  Type  │ Vulnerabilities │
├─────────────────────────────────────────┼────────┼─────────────────┤
│ picpeak-frontend-secfix (alpine 3.24.1) │ alpine │        0        │
└─────────────────────────────────────────┴────────┴─────────────────┘
```

Resulting package versions: nginx 1.30.4-r1, curl/libcurl 8.21.0-r0, c-ares 1.34.8-r0 — all at or past the fixed versions from the alerts.

Runtime smoke test of the built image:
- `/health` → `healthy`
- SPA fallback route (`/admin`) → 200 with `BRAND_TITLE` envsubst applied (`<title>SmokeTest</title>`)
- runs as non-root `nginx` user; `location = /` 502s only because no backend exists in the standalone test (expected — it's a proxy location)
- backend image also builds clean with the same cache-bust change (backend currently scans at 0 findings; the change prevents the same staleness there)

## Rollout

Needs to land on `main` and `stable` so both image lines rebuild with the fix — stable's Dockerfiles are identical to main's, so the cherry-pick to stable is conflict-free (companion PR follows).
