### PR TITLE
fix(events): accept hero_logo_visible: null on create/update (#822)

### DIFF
--- a/backend/__tests__/routes/adminEvents.smoke.test.js
+++ b/backend/__tests__/routes/adminEvents.smoke.test.js
@@ -180,6 +180,27 @@ describe('admin events CRUD endpoints (smoke)', () => {
       });
       expect(res.status).toBe(404);
     });
+
+    // #822 — hero_logo_visible/position are nullable (null = "inherit the global
+    // branding toggle"), but the validator used .optional() without
+    // { nullable: true }, so an explicit null was rejected with 400.
+    it('accepts hero_logo_visible: null and stores NULL (inherit)', async () => {
+      const id = await insertEvent(db, adminId, { hero_logo_visible: 1 });
+      const res = await auth(request(app).put(`/api/admin/events/${id}`)).send({
+        hero_logo_visible: null,
+      });
+      expect(res.status).toBe(200);
+      const row = await db('events').where({ id }).first();
+      expect(row.hero_logo_visible).toBeNull();
+    });
+
+    it('still rejects a non-boolean hero_logo_visible', async () => {
+      const id = await insertEvent(db, adminId);
+      const res = await auth(request(app).put(`/api/admin/events/${id}`)).send({
+        hero_logo_visible: 'maybe',
+      });
+      expect(res.status).toBe(400);
+    });
   });
 
   describe('DELETE /:id', () => {

--- a/backend/src/routes/adminEvents/crud.js
+++ b/backend/src/routes/adminEvents/crud.js
@@ -94,7 +94,7 @@ module.exports = (router) => {
     body('allow_presigned_download').optional().isBoolean(),
     body('css_template_id').optional({ nullable: true, checkFalsy: true }).isInt(),
     // Hero logo settings
-    body('hero_logo_visible').optional().isBoolean(),
+    body('hero_logo_visible').optional({ nullable: true }).isBoolean(),
     body('hero_logo_size').optional({ nullable: true }).isIn(['small', 'medium', 'large', 'xlarge']),
     body('hero_logo_position').optional().isIn(['top', 'center', 'bottom']),
     // Header style settings (decoupled from layout)
@@ -342,8 +342,10 @@ module.exports = (router) => {
       // hero_logo_visible: store NULL ("inherit") unless the admin explicitly
       // set it, so the global branding_logo_display_hero toggle keeps
       // controlling this gallery afterwards (#756). Only an explicit per-event
-      // choice overrides the global.
-      const effectiveHeroLogoVisible = req.body.hero_logo_visible !== undefined
+      // choice overrides the global. `!= null` treats an explicit null the same
+      // as omitted (both → inherit); otherwise formatBoolean(null) would coerce
+      // to 0/false on SQLite instead of NULL (the PUT handler already does this).
+      const effectiveHeroLogoVisible = req.body.hero_logo_visible != null
         ? formatBoolean(hero_logo_visible)
         : null;
       // NULL = inherit the global branding_logo_size (#756), resolved at read
@@ -1224,7 +1226,7 @@ module.exports = (router) => {
     }),
     body('css_template_id').optional({ nullable: true, checkFalsy: true }).isInt(),
     // Hero logo settings
-    body('hero_logo_visible').optional().isBoolean(),
+    body('hero_logo_visible').optional({ nullable: true }).isBoolean(),
     body('hero_logo_size').optional({ nullable: true }).isIn(['small', 'medium', 'large', 'xlarge']),
     body('hero_logo_position').optional().isIn(['top', 'center', 'bottom']),
     // Header style settings (decoupled from layout)


### PR DESCRIPTION
Fixes #822 — on v3.45.2, `PUT /api/admin/events/:id` with `hero_logo_visible: null` returns HTTP 400 `"Invalid value"` even though the column is nullable.

## Root cause
`hero_logo_visible` is nullable — `null` means "inherit the global `branding_logo_display_hero` toggle" (#756, migration `152_hero_logo_visible_inherit`). But the validator (`adminEvents/crud.js`) used:
```js
body('hero_logo_visible').optional().isBoolean()
```
`.optional()` **without `{ nullable: true }`** only skips `undefined`. An explicit `null` still runs `.isBoolean()` → `null` isn't a boolean → 400. The sibling `hero_logo_size` rule right below it is already correct (`.optional({ nullable: true })`), and the handler explicitly stores `null` as "inherit" — so `null` is a valid, intended value the validator wrongly rejected. Present in **both** the create (`POST /`) and update (`PUT /:id`) routes.

## Fix
- Both routes: `hero_logo_visible` → `.optional({ nullable: true }).isBoolean()`.
- Create handler: guard on `!= null` instead of `!== undefined`, so an explicit `null` stores `NULL` (inherit) rather than being coerced to `0/false` by `formatBoolean` on SQLite. (The update handler already did `=== null ? null`, so Postgres — the reporter's engine — was already correct once the validator passes; this makes SQLite correct too.)

## Deliberately scoped out: `hero_logo_position`
It looks like the same pattern (`.optional().isIn(...)`), but its column is **`NOT NULL`** (no inherit migration — its handler always resolves to a concrete value via `|| brandingDefaults`). My first pass made it nullable too and a test immediately caught it turning the 400 into a **500** DB constraint error. Left it on plain `.optional()` — `null` is genuinely invalid there.

## Tests
Adds smoke tests (real-SQLite harness): `PUT` accepts `hero_logo_visible: null` and stores `NULL`; a non-boolean value is still rejected. Full `adminEvents.smoke` suite green (12/12); lint clean.

Reported against stable v3.45.2 and present on both lines → **main**; stable backport (companion PR) follows.
