### PR TITLE
chore(backend): ignore runtime storage in git/docker, remove dead getSafeFilename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,5 +130,6 @@ docker-compose.dev.yml
 # New layout development files
 new-layouts/
 
-# Generated CRM/accounting documents (runtime) — never commit
-backend/storage/business-docs/
+# Backend runtime storage (generated media, previews, thumbnails,
+# CRM/accounting documents) — never commit
+backend/storage/

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,9 +1,7 @@
 node_modules
 npm-debug.log
 .env
-storage/events/active/*
-storage/events/archived/*
-storage/thumbnails/*
+storage
 data/*.db
 logs/*
 coverage

--- a/backend/src/utils/fileSecurityUtils.js
+++ b/backend/src/utils/fileSecurityUtils.js
@@ -214,25 +214,6 @@ async function validateFileContent(filePath, expectedMimeType) {
 }
 
 /**
- * Get safe filename for storage
- * @param {string} originalFilename - Original filename
- * @returns {string} - Safe filename
- */
-function getSafeFilename(originalFilename) {
-  const timestamp = Date.now();
-  const randomString = Math.random().toString(36).substring(2, 15);
-  const ext = path.extname(originalFilename).toLowerCase();
-
-  // Validate extension - including both image and video extensions
-  const validExtensions = ['.jpg', '.jpeg', '.png', '.webp', '.gif', '.svg', '.ico', '.mp4', '.m4v', '.webm', '.mov', '.avi'];
-  if (!validExtensions.includes(ext)) {
-    throw new Error('Invalid file extension');
-  }
-
-  return `upload_${timestamp}_${randomString}${ext}`;
-}
-
-/**
  * Create a file upload validator middleware
  * @param {Object} options - Validation options
  * @returns {Function} - Express middleware function
@@ -295,7 +276,6 @@ module.exports = {
   isPathSafe,
   validateFileType,
   validateFileContent,
-  getSafeFilename,
   createFileUploadValidator,
   ALLOWED_IMAGE_TYPES,
   ALLOWED_VIDEO_TYPES,


### PR DESCRIPTION
## Summary

Two housekeeping follow-ups surfaced by the codex review of #834.

### 1. Runtime storage was only partially ignored

`backend/storage/` is runtime-generated (media originals, previews, thumbnails, CRM business docs), but only `backend/storage/business-docs/` was git-ignored — local E2E runs leave the rest dangling as untracked, which is how ~12 MB of generated media nearly landed in a commit on #834. Nothing under `backend/storage/` is tracked (`git ls-files` empty), so the whole directory is now ignored.

Same gap in `backend/.dockerignore`: the granular `storage/events/*` / `storage/thumbnails/*` rules missed `storage/previews`, so locally generated previews were copied into production images via `COPY . .`. The image doesn't need any of it — the Dockerfile creates the required directories itself (`RUN mkdir -p`, `backend/Dockerfile:96`) — so `storage` is now excluded wholesale.

### 2. Dead `getSafeFilename` helper removed

`getSafeFilename` in `backend/src/utils/fileSecurityUtils.js` had zero callers across the repo (backend, frontend, scripts, tests). Its private extension whitelist silently drifted from the real validation paths — #834 originally patched it as if it were live code, which is exactly the trap unused security code sets. Removed the function and its export; the live paths (`validateFileType`, `validateFileContent`, `createFileUploadValidator`) are untouched.

## Testing

- `npx jest __tests__/utils` — 263 passed.
- Repo-wide grep confirms no remaining `getSafeFilename` references.
- `git check-ignore backend/storage/previews` resolves against the new rule; `backend/storage/` no longer shows as untracked.
- Pre-existing ESLint errors in `isPathSafe` (`no-useless-escape`, `no-control-regex`) are untouched — they exist identically on `main`.

No UI change — no screenshot.
