### PR TITLE
fix(security): read the password-complexity key the settings UI writes

### DIFF
--- a/backend/__tests__/utils/passwordValidation.complexityKey.test.js
+++ b/backend/__tests__/utils/passwordValidation.complexityKey.test.js
@@ -1,26 +1,33 @@
 /**
- * Regression test for the password-complexity setting key mismatch.
+ * Regression tests for the password-complexity setting read path.
  *
- * The settings UI saves the admin's choice as `security_password_complexity`
- * (useSettingsState.ts prefixes every security field with `security_`), but
- * getPasswordComplexitySettings() queried `security_password_complexity_level`
- * — a key nothing writes — so the configured level was silently ignored and
- * validation always ran on the 'moderate' default.
+ * Bug 1 (key mismatch): the settings UI saves the admin's choice as
+ * `security_password_complexity` (useSettingsState.ts prefixes every
+ * security field with `security_`), but getPasswordComplexitySettings()
+ * queried `security_password_complexity_level` — a key nothing writes —
+ * so the configured level was silently ignored.
+ *
+ * Bug 2 (driver shape, codex review of #843): on SQLite the TEXT column
+ * returns the JSON-stringified value ('"very_strong"'), but on Postgres
+ * (production default) `setting_value` is a json column and comes back
+ * already decoded ('very_strong'). A bare JSON.parse throws on the
+ * decoded shape and the outer catch fell back to 'moderate' — the
+ * setting stayed unenforced on Postgres even with the right key.
  */
 
-const queriedKeys = [];
+const mockQueriedKeys = [];
+let mockStoredValue;
 
 jest.mock('../../src/database/db', () => ({
   db: () => ({
     where(_col, key) {
-      queriedKeys.push(key);
+      mockQueriedKeys.push(key);
       return this;
     },
     first() {
-      // The row as the settings UI writes it (JSON-stringified value).
       return Promise.resolve(
-        queriedKeys[queriedKeys.length - 1] === 'security_password_complexity'
-          ? { setting_key: 'security_password_complexity', setting_value: JSON.stringify('very_strong') }
+        mockQueriedKeys[mockQueriedKeys.length - 1] === 'security_password_complexity'
+          ? { setting_key: 'security_password_complexity', setting_value: mockStoredValue }
           : undefined
       );
     },
@@ -31,9 +38,24 @@ jest.mock('../../src/database/db', () => ({
 const { getPasswordComplexitySettings } = require('../../src/utils/passwordValidation');
 
 describe('getPasswordComplexitySettings', () => {
-  it('reads the key the settings UI actually writes', async () => {
+  beforeEach(() => { mockQueriedKeys.length = 0; });
+
+  it('reads the key the settings UI actually writes (SQLite shape: JSON-stringified)', async () => {
+    mockStoredValue = JSON.stringify('very_strong'); // '"very_strong"'
     const level = await getPasswordComplexitySettings();
-    expect(queriedKeys).toContain('security_password_complexity');
+    expect(mockQueriedKeys).toContain('security_password_complexity');
     expect(level).toBe('very_strong');
+  });
+
+  it('accepts the Postgres json-column shape (already decoded, no quotes)', async () => {
+    mockStoredValue = 'very_strong'; // pg driver auto-parses the json column
+    const level = await getPasswordComplexitySettings();
+    expect(level).toBe('very_strong');
+  });
+
+  it('falls back to moderate on an empty value', async () => {
+    mockStoredValue = '';
+    const level = await getPasswordComplexitySettings();
+    expect(level).toBe('moderate');
   });
 });

--- a/backend/__tests__/utils/passwordValidation.complexityKey.test.js
+++ b/backend/__tests__/utils/passwordValidation.complexityKey.test.js
@@ -1,0 +1,39 @@
+/**
+ * Regression test for the password-complexity setting key mismatch.
+ *
+ * The settings UI saves the admin's choice as `security_password_complexity`
+ * (useSettingsState.ts prefixes every security field with `security_`), but
+ * getPasswordComplexitySettings() queried `security_password_complexity_level`
+ * — a key nothing writes — so the configured level was silently ignored and
+ * validation always ran on the 'moderate' default.
+ */
+
+const queriedKeys = [];
+
+jest.mock('../../src/database/db', () => ({
+  db: () => ({
+    where(_col, key) {
+      queriedKeys.push(key);
+      return this;
+    },
+    first() {
+      // The row as the settings UI writes it (JSON-stringified value).
+      return Promise.resolve(
+        queriedKeys[queriedKeys.length - 1] === 'security_password_complexity'
+          ? { setting_key: 'security_password_complexity', setting_value: JSON.stringify('very_strong') }
+          : undefined
+      );
+    },
+  }),
+  withRetry: (fn) => fn(),
+}));
+
+const { getPasswordComplexitySettings } = require('../../src/utils/passwordValidation');
+
+describe('getPasswordComplexitySettings', () => {
+  it('reads the key the settings UI actually writes', async () => {
+    const level = await getPasswordComplexitySettings();
+    expect(queriedKeys).toContain('security_password_complexity');
+    expect(level).toBe('very_strong');
+  });
+});

--- a/backend/src/utils/passwordValidation.js
+++ b/backend/src/utils/passwordValidation.js
@@ -135,12 +135,20 @@ async function getPasswordComplexitySettings() {
     if (!settings || !settings.setting_value) {
       return 'moderate'; // Default
     }
-    
-    const value = typeof settings.setting_value === 'string' 
-      ? JSON.parse(settings.setting_value)
-      : settings.setting_value;
-    
-    return value;
+
+    // Parse with fallback, mirroring getAppSetting: on SQLite the TEXT
+    // column returns the JSON-stringified value ('"very_strong"'), but on
+    // Postgres the json column comes back already decoded ('very_strong')
+    // — a bare JSON.parse would throw there and the outer catch would
+    // silently fall back to 'moderate' again.
+    let value = settings.setting_value;
+    if (typeof value === 'string') {
+      try {
+        value = JSON.parse(value);
+      } catch (_) { /* already-decoded plain string — keep as-is */ }
+    }
+
+    return value || 'moderate';
   } catch (error) {
     logger.error('Failed to get password complexity settings:', error);
     return 'moderate'; // Default on error - ensures app continues working

--- a/backend/src/utils/passwordValidation.js
+++ b/backend/src/utils/passwordValidation.js
@@ -123,8 +123,12 @@ async function getPasswordComplexitySettings() {
     
     // Use retry wrapper to handle connection failures
     const settings = await withRetry(async () => {
+      // Key must match what the settings UI writes: `security_` prefix +
+      // `password_complexity` (useSettingsState.ts saveSecurityMutation).
+      // The old `security_password_complexity_level` key is written by
+      // nothing, so the admin's choice was silently ignored.
       return await db('app_settings')
-        .where('setting_key', 'security_password_complexity_level')
+        .where('setting_key', 'security_password_complexity')
         .first();
     });
     


### PR DESCRIPTION
## Summary

The admin's password-complexity setting has never had any effect: the settings UI saves it as `security_password_complexity` (`useSettingsState.ts:340` prefixes `security_` onto the `password_complexity` field), but `getPasswordComplexitySettings()` in `backend/src/utils/passwordValidation.js:127` queried `security_password_complexity_level` — a key nothing ever writes. The read always came back empty, so validation silently ran on the `'moderate'` default regardless of what the admin configured.

One-word fix: read the key the UI writes. No migration needed — nothing ever wrote the `_level` key, so there is no data to migrate.

Credit: spotted in the [filpgame fork](https://github.com/filpgame/picpeak) (their main, 2026-07-14) during a fork sweep.

## Changes

- `backend/src/utils/passwordValidation.js` — query `security_password_complexity` instead of `security_password_complexity_level`.
- `backend/__tests__/utils/passwordValidation.complexityKey.test.js` — regression test: mock DB serves the row exactly as the settings UI writes it (JSON-stringified value under the `security_password_complexity` key) and asserts the configured level (`very_strong`) is returned instead of the default.

## Testing

- `npx jest __tests__/utils/passwordValidation.complexityKey.test.js` — 1 passed.
- Pre-push local E2E smoke — 13 passed.

No UI change — no screenshot.

Note: a twin PR targets `stable` — this bug affects both lines.
