### PR TITLE
fix(uploads): keep videos when thumbnail generation fails

### DIFF
--- a/backend/__tests__/services/photoProcessor.processPhoto.test.js
+++ b/backend/__tests__/services/photoProcessor.processPhoto.test.js
@@ -71,6 +71,7 @@ jest.mock('../../src/services/imageProcessor', () => {
   const mockExtractCaptureDate = jest.fn();
   return {
     generateThumbnail: mockGenerateThumbnail,
+    generateVideoPlaceholder: jest.fn(async (filename) => `thumbnails/thumb_${filename.replace(/\.[^.]+$/, '')}.jpg`),
     extractCaptureDate: mockExtractCaptureDate,
     withLocalCopy: jest.fn(async (key, fn) =>
       fn(`/tmp/local-copy-${require('path').basename(key)}`)
@@ -213,7 +214,7 @@ describe('photoProcessor.processPhoto', () => {
     expect(watermarkService.generateForPhoto).not.toHaveBeenCalled();
   });
 
-  it('keeps a video complete (metadata-only) when thumbnail generation fails', async () => {
+  it('keeps a video complete with a placeholder thumbnail when ffmpeg fails', async () => {
     dbModule.__setPhoto({
       id: 203,
       event_id: 9,
@@ -243,7 +244,10 @@ describe('photoProcessor.processPhoto', () => {
     const finalUpdate = dbModule.__recorded().updateCalls.pop();
     // The row must complete — 'failed' rows are invisible to guests.
     expect(finalUpdate.data.processing_status).toBe('complete');
-    expect(finalUpdate.data.thumbnail_path).toBeUndefined();
+    // Placeholder instead of NULL: a completed video without thumbnail would
+    // make the grid fetch the original video file for the tile (#845 review).
+    expect(finalUpdate.data.thumbnail_path).toBe('thumbnails/thumb_drone-clip.jpg');
+    expect(imageProcessor.generateVideoPlaceholder).toHaveBeenCalledWith('drone-clip.mp4');
     expect(finalUpdate.data.duration).toBe(42);
     expect(finalUpdate.data.video_codec).toBe('hevc');
   });

--- a/backend/__tests__/services/photoProcessor.processPhoto.test.js
+++ b/backend/__tests__/services/photoProcessor.processPhoto.test.js
@@ -87,6 +87,7 @@ jest.mock('../../src/services/imageProcessor', () => {
 
 jest.mock('../../src/services/videoProcessor', () => ({
   processUploadedVideo: jest.fn(),
+  extractVideoMetadata: jest.fn(),
   isVideoMimeType: (mime) => typeof mime === 'string' && mime.startsWith('video/'),
 }));
 
@@ -210,6 +211,41 @@ describe('photoProcessor.processPhoto', () => {
 
     // Watermark queue is image-only.
     expect(watermarkService.generateForPhoto).not.toHaveBeenCalled();
+  });
+
+  it('keeps a video complete (metadata-only) when thumbnail generation fails', async () => {
+    dbModule.__setPhoto({
+      id: 203,
+      event_id: 9,
+      filename: 'drone-clip.mp4',
+      original_filename: 'drone.mp4',
+      mime_type: 'video/mp4',
+      media_type: 'video',
+      size_bytes: 12345,
+      captured_at: null,
+    });
+    dbModule.__setEvent({ id: 9, slug: 'wedding', event_name: 'Wedding' });
+
+    // ffmpeg thumbnail pipeline throws (e.g. unsupported pixel format)…
+    videoProcessor.processUploadedVideo.mockRejectedValueOnce(new Error('ffmpeg exited with code 1'));
+    // …but a plain probe still works.
+    videoProcessor.extractVideoMetadata.mockResolvedValueOnce({
+      duration: 42,
+      videoCodec: 'hevc',
+      audioCodec: 'aac',
+      width: 3840,
+      height: 2160,
+    });
+
+    const { processPhoto } = require('../../src/services/photoProcessor');
+    await processPhoto(203);
+
+    const finalUpdate = dbModule.__recorded().updateCalls.pop();
+    // The row must complete — 'failed' rows are invisible to guests.
+    expect(finalUpdate.data.processing_status).toBe('complete');
+    expect(finalUpdate.data.thumbnail_path).toBeUndefined();
+    expect(finalUpdate.data.duration).toBe(42);
+    expect(finalUpdate.data.video_codec).toBe('hevc');
   });
 
   it('throws when the photo row no longer exists', async () => {

--- a/backend/src/services/photoProcessor.js
+++ b/backend/src/services/photoProcessor.js
@@ -3,7 +3,7 @@ const fs = require('fs').promises;
 const { db } = require('../database/db');
 const { generateThumbnail, extractCaptureDate, withLocalCopy, withProcessableImage } = require('./imageProcessor');
 const { generatePhotoFilename } = require('../utils/filenameSanitizer');
-const { processUploadedVideo, isVideoMimeType } = require('./videoProcessor');
+const { processUploadedVideo, extractVideoMetadata, isVideoMimeType } = require('./videoProcessor');
 const { getStorage } = require('./storage');
 const { resolvePhotoStorageKey } = require('./photoResolver');
 const logger = require('../utils/logger');
@@ -141,9 +141,23 @@ async function processUploadedPhotos(files, eventId, uploadedBy = 'admin', categ
           'thumbnails',
           `thumb_${newFilename.replace(/\.[^.]+$/, '.jpg')}`
         );
-        const result = await processUploadedVideo(tempPath, videoThumbnailKey);
-        videoMetadata = result.metadata;
-        thumbnailPath = result.thumbnailKey;
+        // A thumbnail/probe failure must not lose the video: without this
+        // guard the whole upload errors here, while the image branch below
+        // already survives its thumbnail failures. Fall back to metadata-only
+        // (may itself fail on exotic codecs — then the video just has neither
+        // preview nor duration, but stays downloadable/streamable).
+        try {
+          const result = await processUploadedVideo(tempPath, videoThumbnailKey);
+          videoMetadata = result.metadata;
+          thumbnailPath = result.thumbnailKey;
+        } catch (videoErr) {
+          logger.warn(`Video processing failed for ${file.originalname}, keeping video without thumbnail:`, videoErr.message);
+          try {
+            videoMetadata = await extractVideoMetadata(tempPath);
+          } catch (metaErr) {
+            logger.warn(`Video metadata extraction also failed for ${file.originalname}:`, metaErr.message);
+          }
+        }
       } else {
         // RAW/DNG can't be fed to sharp directly (no raw loader), so extract the
         // embedded JPEG preview first and thumbnail/measure THAT. Pass-through
@@ -457,14 +471,30 @@ async function processPhoto(photoId) {
         'thumbnails',
         `thumb_${photo.filename.replace(/\.[^.]+$/, '.jpg')}`
       );
-      const result = await processUploadedVideo(localPath, videoThumbnailKey);
-      updateData.thumbnail_path = result.thumbnailKey;
-      if (result.metadata) {
-        if (result.metadata.duration != null) updateData.duration = result.metadata.duration;
-        if (result.metadata.videoCodec) updateData.video_codec = result.metadata.videoCodec;
-        if (result.metadata.audioCodec) updateData.audio_codec = result.metadata.audioCodec;
-        if (result.metadata.width) updateData.width = result.metadata.width;
-        if (result.metadata.height) updateData.height = result.metadata.height;
+      // A thumbnail/probe failure must not fail the row: processPhoto's caller
+      // marks failed rows 'failed' and the guest gallery only lists 'complete',
+      // so the video would become permanently invisible. The image branch below
+      // already survives its thumbnail failures — mirror that: fall back to
+      // metadata-only and let the row complete without a preview.
+      let videoResult = null;
+      try {
+        videoResult = await processUploadedVideo(localPath, videoThumbnailKey);
+      } catch (videoErr) {
+        logger.warn(`processPhoto: video processing failed for ${photoId}, keeping video without thumbnail`, { error: videoErr.message });
+        try {
+          videoResult = { metadata: await extractVideoMetadata(localPath) };
+        } catch (metaErr) {
+          logger.warn(`processPhoto: video metadata extraction also failed for ${photoId}`, { error: metaErr.message });
+        }
+      }
+      if (videoResult?.thumbnailKey) updateData.thumbnail_path = videoResult.thumbnailKey;
+      if (videoResult?.metadata) {
+        const m = videoResult.metadata;
+        if (m.duration != null) updateData.duration = m.duration;
+        if (m.videoCodec) updateData.video_codec = m.videoCodec;
+        if (m.audioCodec) updateData.audio_codec = m.audioCodec;
+        if (m.width) updateData.width = m.width;
+        if (m.height) updateData.height = m.height;
       }
     } else {
       // RAW/DNG can't be sharp-decoded directly — extract the embedded JPEG

--- a/backend/src/services/photoProcessor.js
+++ b/backend/src/services/photoProcessor.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const fs = require('fs').promises;
 const { db } = require('../database/db');
-const { generateThumbnail, extractCaptureDate, withLocalCopy, withProcessableImage } = require('./imageProcessor');
+const { generateThumbnail, generateVideoPlaceholder, extractCaptureDate, withLocalCopy, withProcessableImage } = require('./imageProcessor');
 const { generatePhotoFilename } = require('../utils/filenameSanitizer');
 const { processUploadedVideo, extractVideoMetadata, isVideoMimeType } = require('./videoProcessor');
 const { getStorage } = require('./storage');
@@ -144,19 +144,23 @@ async function processUploadedPhotos(files, eventId, uploadedBy = 'admin', categ
         // A thumbnail/probe failure must not lose the video: without this
         // guard the whole upload errors here, while the image branch below
         // already survives its thumbnail failures. Fall back to metadata-only
-        // (may itself fail on exotic codecs — then the video just has neither
-        // preview nor duration, but stays downloadable/streamable).
+        // plus the static play-button placeholder — a completed video with a
+        // NULL thumbnail would make the grid fetch the ORIGINAL video file
+        // as an <img> blob (thumbnail_url || url), i.e. a multi-GB download
+        // for a broken tile (codex review of #845).
         try {
           const result = await processUploadedVideo(tempPath, videoThumbnailKey);
           videoMetadata = result.metadata;
           thumbnailPath = result.thumbnailKey;
         } catch (videoErr) {
-          logger.warn(`Video processing failed for ${file.originalname}, keeping video without thumbnail:`, videoErr.message);
+          logger.warn(`Video processing failed for ${file.originalname}, using placeholder thumbnail:`, videoErr.message);
           try {
             videoMetadata = await extractVideoMetadata(tempPath);
           } catch (metaErr) {
             logger.warn(`Video metadata extraction also failed for ${file.originalname}:`, metaErr.message);
           }
+          // ffmpeg-free (sharp-rendered SVG); returns null on failure.
+          thumbnailPath = await generateVideoPlaceholder(newFilename);
         }
       } else {
         // RAW/DNG can't be fed to sharp directly (no raw loader), so extract the
@@ -475,17 +479,23 @@ async function processPhoto(photoId) {
       // marks failed rows 'failed' and the guest gallery only lists 'complete',
       // so the video would become permanently invisible. The image branch below
       // already survives its thumbnail failures — mirror that: fall back to
-      // metadata-only and let the row complete without a preview.
+      // metadata-only plus the static play-button placeholder. A completed
+      // video with a NULL thumbnail would make the grid fetch the ORIGINAL
+      // video file as an <img> blob (thumbnail_url || url) — a multi-GB
+      // download for a broken tile (codex review of #845).
       let videoResult = null;
       try {
         videoResult = await processUploadedVideo(localPath, videoThumbnailKey);
       } catch (videoErr) {
-        logger.warn(`processPhoto: video processing failed for ${photoId}, keeping video without thumbnail`, { error: videoErr.message });
+        logger.warn(`processPhoto: video processing failed for ${photoId}, using placeholder thumbnail`, { error: videoErr.message });
         try {
           videoResult = { metadata: await extractVideoMetadata(localPath) };
         } catch (metaErr) {
           logger.warn(`processPhoto: video metadata extraction also failed for ${photoId}`, { error: metaErr.message });
         }
+        // ffmpeg-free (sharp-rendered SVG); returns null on failure.
+        const placeholderKey = await generateVideoPlaceholder(photo.filename);
+        if (placeholderKey) videoResult = { ...(videoResult || {}), thumbnailKey: placeholderKey };
       }
       if (videoResult?.thumbnailKey) updateData.thumbnail_path = videoResult.thumbnailKey;
       if (videoResult?.metadata) {


### PR DESCRIPTION
## Summary

A failing `processUploadedVideo()` (ffmpeg probe + thumbnail extraction) currently loses the video — in both pipeline paths — while the image branch sitting right next to each call already survives its thumbnail failures:

- **Sync path** (`processUploadedPhotos`, `photoProcessor.js:144`): the throw fails the whole upload; the video is gone.
- **Async worker path** (`processPhoto`, `photoProcessor.js:474` — the path real uploads take via `backgroundProcessor`): the throw marks the row `failed`, and the guest gallery only lists `complete` rows — so a fully uploaded video becomes **permanently invisible** whenever ffmpeg chokes on it (exotic pixel formats, HEVC variants, truncated moov atoms…).

## Fix

Mirror the image branch's resilience at both call sites: catch the failure, fall back to `extractVideoMetadata()` alone, and let the video complete without a preview. If even the plain probe fails, keep the video with no metadata — downloadable and streamable either way, just no thumbnail in the grid.

Idea spotted in the [munin92 fork](https://github.com/munin92/picpeak) (2026-07-02, never submitted upstream); reimplemented here to cover both paths.

## Testing

- New regression test: `processUploadedVideo` rejects → row still reaches `processing_status: 'complete'` with metadata from the probe fallback and no `thumbnail_path` (a `failed` row would be invisible to guests).
- `npx jest __tests__/services/photoProcessor.processPhoto.test.js __tests__/services/imageProcessorRaw.test.js` — 10 passed.
- Pre-push local E2E smoke — 13 passed.

No UI change in this PR — no screenshot.

**Known cosmetic caveat:** the grid tile renders `thumbnail_url || url` (`PhotoGrid.tsx:266`), so a rescued video without thumbnail shows a broken-image tile rather than a designed placeholder (the lightbox is fine — it branches on `media_type === 'video'`). Deliberately out of scope here: this backend fix is about not losing the video; a video-placeholder tile for the grid would be a small frontend follow-up.
