### PR TITLE
feat(slideshow): guest-scannable share-link QR overlay

### DIFF
--- a/backend/__tests__/routes/slideshowPublic.test.js
+++ b/backend/__tests__/routes/slideshowPublic.test.js
@@ -99,7 +99,12 @@ describe('public Live Slideshow routes', () => {
     await setFlag(db, 'slideshow', true);
   });
 
-  const stateUrl = (token = TOKEN) => `/api/gallery/${SLUG}/show/${token}/state`;
+  // QR overlay: supertest's Host is loopback, and a loopback base is now
+  // suppressed rather than encoded — the kiosk passes its reachable
+  // window.location.origin, so the QR tests do the same.
+  const KIOSK_ORIGIN = 'https://gallery.example.com';
+  const stateUrl = (token = TOKEN) => `/api/gallery/${SLUG}/show/${token}/state?origin=${encodeURIComponent(KIOSK_ORIGIN)}`;
+  const stateUrlNoOrigin = (token = TOKEN) => `/api/gallery/${SLUG}/show/${token}/state`;
 
   describe('resolveSlideshow guards', () => {
     it('200 + per-event display settings on a live link', async () => {
@@ -269,6 +274,14 @@ describe('public Live Slideshow routes', () => {
       expect(res.body.qr.data_url).toMatch(/^data:image\/png;base64,/);
       // Look falls back to the global defaults.
       expect(res.body.qr.position).toBe('bottom-left');
+    });
+
+    it('suppresses the QR when no guest-reachable origin exists (loopback base, no kiosk origin)', async () => {
+      await insertEvent(db, { show_qr: 1 });
+      const res = await request(app).get(stateUrlNoOrigin());
+      // Encoding localhost would send scanning phones to THEIR localhost —
+      // no QR beats a broken QR (codex review of #848, confirmation round).
+      expect(res.body.qr).toBeNull();
     });
   });
 

--- a/backend/__tests__/routes/slideshowPublic.test.js
+++ b/backend/__tests__/routes/slideshowPublic.test.js
@@ -228,6 +228,50 @@ describe('public Live Slideshow routes', () => {
     });
   });
 
+  describe('slideshowSettings — QR overlay cascade (#837)', () => {
+    async function enableGlobalQr() {
+      await setSetting(db, 'slideshow_qr_enabled', true);
+      await setSetting(db, 'slideshow_qr_position', 'top-right');
+      await setSetting(db, 'slideshow_qr_opacity', 80);
+      await setSetting(db, 'slideshow_qr_size', 18);
+    }
+
+    it('inherits the global QR overlay when show_qr is NULL', async () => {
+      await insertEvent(db, { show_qr: null });
+      await enableGlobalQr();
+      const res = await request(app).get(stateUrl());
+      expect(res.body.qr).toMatchObject({
+        position: 'top-right',
+        opacity: 80,
+        size: 18,
+      });
+      // Share-link QR ships as a PNG data URI — no client QR lib needed.
+      expect(res.body.qr.data_url).toMatch(/^data:image\/png;base64,/);
+    });
+
+    it('is null by default (global off, no override)', async () => {
+      await insertEvent(db, { show_qr: null });
+      const res = await request(app).get(stateUrl());
+      expect(res.body.qr).toBeNull();
+    });
+
+    it('per-event OFF override hides the QR even when the global is on', async () => {
+      await insertEvent(db, { show_qr: 0 });
+      await enableGlobalQr();
+      const res = await request(app).get(stateUrl());
+      expect(res.body.qr).toBeNull();
+    });
+
+    it('per-event ON override shows the QR even when the global is off', async () => {
+      await insertEvent(db, { show_qr: 1 });
+      const res = await request(app).get(stateUrl());
+      expect(res.body.qr).not.toBeNull();
+      expect(res.body.qr.data_url).toMatch(/^data:image\/png;base64,/);
+      // Look falls back to the global defaults.
+      expect(res.body.qr.position).toBe('bottom-left');
+    });
+  });
+
   describe('display-only token guards (#646 review concern 1)', () => {
     // Mint a real slideshow JWT, then prove it is denied on the
     // download / upload / feedback routes (display-only contract).

--- a/backend/migrations/core/163_add_event_show_qr.js
+++ b/backend/migrations/core/163_add_event_show_qr.js
@@ -1,0 +1,22 @@
+/**
+ * #837 — per-event override for the live-slideshow QR overlay.
+ * Mirrors show_watermark: NULL = inherit the global slideshow_qr_enabled
+ * setting, true/false force the overlay on/off for this event.
+ */
+exports.up = async function up(knex) {
+  const has = await knex.schema.hasColumn('events', 'show_qr');
+  if (!has) {
+    await knex.schema.alterTable('events', (t) => {
+      t.boolean('show_qr').nullable().defaultTo(null);
+    });
+  }
+};
+
+exports.down = async function down(knex) {
+  const has = await knex.schema.hasColumn('events', 'show_qr');
+  if (has) {
+    await knex.schema.alterTable('events', (t) => {
+      t.dropColumn('show_qr');
+    });
+  }
+};

--- a/backend/src/routes/adminEvents/slideshow.js
+++ b/backend/src/routes/adminEvents/slideshow.js
@@ -105,6 +105,7 @@ module.exports = (router) => {
     body('show_transition').optional().isIn(SLIDESHOW_TRANSITIONS),
     body('show_transition_ms').optional().isInt({ min: 100, max: 5000 }),
     body('show_watermark').optional({ nullable: true }),
+    body('show_qr').optional({ nullable: true }),
     body('show_colorfilter').optional().isIn(SLIDESHOW_COLORFILTERS),
     body('show_order').optional().isIn(SLIDESHOW_ORDERS),
     body('show_category_id').optional({ nullable: true }).isInt({ min: 1 })
@@ -130,6 +131,12 @@ module.exports = (router) => {
         updates.show_watermark = req.body.show_watermark === null
           ? null
           : formatBoolean(parseBooleanInput(req.body.show_watermark, false));
+      }
+      // QR overlay (#837) — same tri-state semantics as show_watermark.
+      if (req.body.show_qr !== undefined) {
+        updates.show_qr = req.body.show_qr === null
+          ? null
+          : formatBoolean(parseBooleanInput(req.body.show_qr, false));
       }
       if (req.body.show_colorfilter !== undefined) updates.show_colorfilter = req.body.show_colorfilter;
       if (req.body.show_order !== undefined) updates.show_order = req.body.show_order;
@@ -160,6 +167,7 @@ module.exports = (router) => {
         show_transition: updates.show_transition ?? event.show_transition ?? 'crossfade',
         show_transition_ms: updates.show_transition_ms ?? event.show_transition_ms ?? 800,
         show_watermark: updates.show_watermark ?? event.show_watermark ?? null,
+        show_qr: 'show_qr' in updates ? updates.show_qr : (event.show_qr ?? null),
         show_colorfilter: updates.show_colorfilter ?? event.show_colorfilter ?? 'none',
         show_order: updates.show_order ?? event.show_order ?? 'chronological',
         show_category_id: 'show_category_id' in updates ? updates.show_category_id : (event.show_category_id ?? null)

--- a/backend/src/routes/adminSettings.js
+++ b/backend/src/routes/adminSettings.js
@@ -383,6 +383,21 @@ router.put('/slideshow', adminAuth, requirePermission('settings.edit'), async (r
       const n = Math.min(40, Math.max(3, Math.round(Number(req.body.slideshow_watermark_size) || 12)));
       push('slideshow_watermark_size', n);
     }
+    // QR overlay (#837) — same option shape as the watermark.
+    if (has('slideshow_qr_enabled')) push('slideshow_qr_enabled', !!req.body.slideshow_qr_enabled);
+    if (has('slideshow_qr_position')) {
+      const allowed = ['top-left', 'top-right', 'bottom-left', 'bottom-right'];
+      const v = allowed.includes(req.body.slideshow_qr_position) ? req.body.slideshow_qr_position : 'bottom-left';
+      push('slideshow_qr_position', v);
+    }
+    if (has('slideshow_qr_opacity')) {
+      const n = Math.min(100, Math.max(0, Math.round(Number(req.body.slideshow_qr_opacity) || 0)));
+      push('slideshow_qr_opacity', n);
+    }
+    if (has('slideshow_qr_size')) {
+      const n = Math.min(40, Math.max(5, Math.round(Number(req.body.slideshow_qr_size) || 14)));
+      push('slideshow_qr_size', n);
+    }
 
     for (const u of updates) {
       await upsertAppSetting(u.setting_key, u.setting_value, u.setting_type);

--- a/backend/src/routes/gallery.js
+++ b/backend/src/routes/gallery.js
@@ -382,7 +382,14 @@ async function slideshowSettings(event, req) {
 // map would grow with every share URL ever displayed (codex review of #848).
 // Insertion-order eviction is enough — concurrently-shown events stay hot.
 const SLIDESHOW_QR_CACHE_MAX = 50;
-const slideshowQrCache = new Map();
+// Keyed by event id (NOT by URL): the origin is caller-influenced when the
+// configured base is loopback, so URL-keyed caching would let a slideshow
+// -link holder force a fresh QRCode.toDataURL per request with unique
+// origins — a cheap CPU-exhaustion path (codex review of #848,
+// confirmation round). Per-event entries + a regeneration throttle bound
+// the encode rate regardless of what the caller sends.
+const SLIDESHOW_QR_REGEN_MS = 60_000;
+const slideshowQrCache = new Map(); // eventId -> { url, dataUrl, at }
 // Localhost/relative guard (codex review of #848): with the compose-default
 // FRONTEND_URL=http://localhost:3000 (or none configured) the QR would send
 // scanning phones to THEIR localhost. The state poll comes from the kiosk
@@ -401,23 +408,34 @@ async function slideshowQrDataUrl(event, req) {
       // Prefer the kiosk's own window.location.origin (?origin=, validated):
       // req.get('host') is NOT the browser origin behind the standard
       // proxies — frontend/nginx.conf forwards $host (port stripped), so a
-      // compose LAN deployment on :3000 would encode port 80 (codex review
-      // of #848 round 3). Host-derived origin stays as second fallback.
-      const queryOrigin = typeof req?.query?.origin === 'string' && QR_ORIGIN_RE.test(req.query.origin)
-        ? req.query.origin.replace(/\/$/, '')
+      // compose LAN deployment on :3000 would encode port 80. A LOOPBACK
+      // kiosk origin is rejected too: it is no more guest-reachable than
+      // the loopback base it would replace (codex review of #848).
+      const rawOrigin = req?.query?.origin;
+      const queryOrigin = typeof rawOrigin === 'string' && QR_ORIGIN_RE.test(rawOrigin) && !QR_LOCAL_BASE_RE.test(rawOrigin)
+        ? rawOrigin.replace(/\/$/, '')
         : null;
       const host = req && req.get ? req.get('host') : null;
+      const hostOrigin = host ? `${req.protocol}://${host}` : null;
       if (queryOrigin) shareUrl = `${queryOrigin}${sharePath}`;
-      else if (host) shareUrl = `${req.protocol}://${host}${sharePath}`;
+      else if (hostOrigin && !QR_LOCAL_BASE_RE.test(hostOrigin)) shareUrl = `${hostOrigin}${sharePath}`;
+      // Still loopback/relative → no reachable URL exists; suppress the
+      // overlay rather than encode a QR that sends phones to localhost.
+      else return null;
     }
-    if (!shareUrl) return null;
-    if (slideshowQrCache.has(shareUrl)) return slideshowQrCache.get(shareUrl);
+
+    const cached = slideshowQrCache.get(event.id);
+    // Serve the cached QR unless the URL changed AND the throttle window
+    // passed — bounds regeneration to once per event per minute.
+    if (cached && (cached.url === shareUrl || Date.now() - cached.at < SLIDESHOW_QR_REGEN_MS)) {
+      return cached.dataUrl;
+    }
     const QRCode = require('qrcode');
-    const dataUrl = await QRCode.toDataURL(shareUrl, { width: 512, margin: 2 });
-    if (slideshowQrCache.size >= SLIDESHOW_QR_CACHE_MAX) {
+    const dataUrl = await QRCode.toDataURL(shareUrl, { width: 512, margin: 4 });
+    if (!slideshowQrCache.has(event.id) && slideshowQrCache.size >= SLIDESHOW_QR_CACHE_MAX) {
       slideshowQrCache.delete(slideshowQrCache.keys().next().value);
     }
-    slideshowQrCache.set(shareUrl, dataUrl);
+    slideshowQrCache.set(event.id, { url: shareUrl, dataUrl, at: Date.now() });
     return dataUrl;
   } catch (e) {
     logger.error('Slideshow QR generation failed:', e);

--- a/backend/src/routes/gallery.js
+++ b/backend/src/routes/gallery.js
@@ -377,8 +377,11 @@ async function slideshowSettings(event) {
 }
 
 // The state endpoint is polled every ~3s per projector — cache the generated
-// QR data URI per share URL instead of re-encoding on every poll. Tiny values
-// (~2 KB each); the map only ever holds one entry per concurrently-shown event.
+// QR data URI per share URL instead of re-encoding on every poll. Bounded:
+// entries live for past events / rotated tokens too, so without eviction the
+// map would grow with every share URL ever displayed (codex review of #848).
+// Insertion-order eviction is enough — concurrently-shown events stay hot.
+const SLIDESHOW_QR_CACHE_MAX = 50;
 const slideshowQrCache = new Map();
 async function slideshowQrDataUrl(event) {
   try {
@@ -389,6 +392,9 @@ async function slideshowQrDataUrl(event) {
     if (slideshowQrCache.has(shareUrl)) return slideshowQrCache.get(shareUrl);
     const QRCode = require('qrcode');
     const dataUrl = await QRCode.toDataURL(shareUrl, { width: 512, margin: 2 });
+    if (slideshowQrCache.size >= SLIDESHOW_QR_CACHE_MAX) {
+      slideshowQrCache.delete(slideshowQrCache.keys().next().value);
+    }
     slideshowQrCache.set(shareUrl, dataUrl);
     return dataUrl;
   } catch (e) {

--- a/backend/src/routes/gallery.js
+++ b/backend/src/routes/gallery.js
@@ -305,7 +305,7 @@ async function resolveSlideshow(slug, token) {
 // watermark (a white, semi-transparent corner logo). The logo URL is resolved
 // from the chosen source so the kiosk renders it without knowing about
 // branding/event internals; null url = nothing to overlay.
-async function slideshowSettings(event) {
+async function slideshowSettings(event, req) {
   // The global look/fit (Settings → Slideshow) + branding logo URLs come from a
   // short-TTL cached bundle so a 3s projector poll doesn't re-fire ~10 settings
   // reads each time (PR #646 review, concern 2).
@@ -351,7 +351,7 @@ async function slideshowSettings(event) {
   const qrEnabled = qrInherit ? g.qr_enabled : (qrOverride === true || qrOverride === 1 || qrOverride === '1');
   let qr = null;
   if (qrEnabled) {
-    const dataUrl = await slideshowQrDataUrl(event);
+    const dataUrl = await slideshowQrDataUrl(event, req);
     if (dataUrl) {
       qr = {
         data_url: dataUrl,
@@ -383,11 +383,23 @@ async function slideshowSettings(event) {
 // Insertion-order eviction is enough — concurrently-shown events stay hot.
 const SLIDESHOW_QR_CACHE_MAX = 50;
 const slideshowQrCache = new Map();
-async function slideshowQrDataUrl(event) {
+// Localhost/relative guard (codex review of #848): with the compose-default
+// FRONTEND_URL=http://localhost:3000 (or none configured) the QR would send
+// scanning phones to THEIR localhost. The state poll comes from the kiosk
+// browser itself, so its Host header + protocol are exactly the public
+// origin guests can reach — prefer that whenever the configured base is
+// missing or loopback. trust proxy is configured, so req.protocol respects
+// X-Forwarded-Proto behind the standard reverse-proxy setups.
+const QR_LOCAL_BASE_RE = /^https?:\/\/(localhost|127\.|0\.0\.0\.0|\[::1\])/i;
+async function slideshowQrDataUrl(event, req) {
   try {
     const shareToken = getEventShareToken(event);
     if (!shareToken) return null;
-    const { shareUrl } = await buildShareLinkVariants({ slug: event.slug, shareToken });
+    let { shareUrl, sharePath } = await buildShareLinkVariants({ slug: event.slug, shareToken });
+    if (!/^https?:\/\//i.test(shareUrl) || QR_LOCAL_BASE_RE.test(shareUrl)) {
+      const host = req && req.get ? req.get('host') : null;
+      if (host) shareUrl = `${req.protocol}://${host}${sharePath}`;
+    }
     if (!shareUrl) return null;
     if (slideshowQrCache.has(shareUrl)) return slideshowQrCache.get(shareUrl);
     const QRCode = require('qrcode');
@@ -439,7 +451,7 @@ router.get('/:slug/show/:token/session', handleAsync(async (req, res) => {
       event_type: event.event_type,
       color_theme: event.color_theme
     },
-    settings: await slideshowSettings(event),
+    settings: await slideshowSettings(event, req),
     photo_count: parseInt(count, 10) || 0,
     expires_at: event.expires_at || null
   });
@@ -459,7 +471,7 @@ router.get('/:slug/show/:token/state', handleAsync(async (req, res) => {
   const [{ count }] = await slideshowPhotosQuery(event.id, event.show_category_id).count('* as count');
 
   res.json({
-    ...(await slideshowSettings(event)),
+    ...(await slideshowSettings(event, req)),
     photo_count: parseInt(count, 10) || 0,
     expires_at: event.expires_at || null
   });

--- a/backend/src/routes/gallery.js
+++ b/backend/src/routes/gallery.js
@@ -342,6 +342,26 @@ async function slideshowSettings(event) {
       };
     }
   }
+  // QR overlay (#837): like the watermark, the LOOK is global-only and the
+  // per-event `show_qr` tri-state (NULL = inherit) decides visibility. The QR
+  // encodes the gallery share URL and ships as a data URI so the public
+  // slideshow client needs no QR library and no extra authenticated endpoint.
+  const qrOverride = event.show_qr;
+  const qrInherit = (qrOverride === null || qrOverride === undefined);
+  const qrEnabled = qrInherit ? g.qr_enabled : (qrOverride === true || qrOverride === 1 || qrOverride === '1');
+  let qr = null;
+  if (qrEnabled) {
+    const dataUrl = await slideshowQrDataUrl(event);
+    if (dataUrl) {
+      qr = {
+        data_url: dataUrl,
+        position: g.qr_position,
+        opacity: g.qr_opacity,
+        size: g.qr_size,
+      };
+    }
+  }
+
   return {
     interval_ms: event.show_interval_ms || 5000,
     transition: event.show_transition || 'crossfade',
@@ -352,7 +372,29 @@ async function slideshowSettings(event) {
     order: event.show_order || 'chronological',
     fit: g.fit,
     watermark,
+    qr,
   };
+}
+
+// The state endpoint is polled every ~3s per projector — cache the generated
+// QR data URI per share URL instead of re-encoding on every poll. Tiny values
+// (~2 KB each); the map only ever holds one entry per concurrently-shown event.
+const slideshowQrCache = new Map();
+async function slideshowQrDataUrl(event) {
+  try {
+    const shareToken = getEventShareToken(event);
+    if (!shareToken) return null;
+    const { shareUrl } = await buildShareLinkVariants({ slug: event.slug, shareToken });
+    if (!shareUrl) return null;
+    if (slideshowQrCache.has(shareUrl)) return slideshowQrCache.get(shareUrl);
+    const QRCode = require('qrcode');
+    const dataUrl = await QRCode.toDataURL(shareUrl, { width: 512, margin: 2 });
+    slideshowQrCache.set(shareUrl, dataUrl);
+    return dataUrl;
+  } catch (e) {
+    logger.error('Slideshow QR generation failed:', e);
+    return null;
+  }
 }
 
 // Open a slideshow session: validate the token and mint a short-lived gallery

--- a/backend/src/routes/gallery.js
+++ b/backend/src/routes/gallery.js
@@ -425,18 +425,34 @@ async function slideshowQrDataUrl(event, req) {
     }
 
     const cached = slideshowQrCache.get(event.id);
-    // Serve the cached QR unless the URL changed AND the throttle window
-    // passed — bounds regeneration to once per event per minute.
-    if (cached && (cached.url === shareUrl || Date.now() - cached.at < SLIDESHOW_QR_REGEN_MS)) {
-      return cached.dataUrl;
+    if (cached && cached.url === shareUrl) return cached.dataUrl;
+    // URL differs from the cached one: NEVER serve the mismatched artifact —
+    // a slideshow-token holder could otherwise poison the projector's QR
+    // with an attacker origin for a whole throttle window (codex review of
+    // #848, final round). Inside the window the overlay is briefly
+    // suppressed instead; regeneration stays bounded per event.
+    if (cached && Date.now() - cached.at < SLIDESHOW_QR_REGEN_MS) {
+      return cached.pending ? cached.dataUrl : null;
     }
+    // Single-flight: concurrent polls on a cold cache must not each
+    // schedule their own 512px encode — reserve the entry with a shared
+    // promise before awaiting.
+    if (cached && cached.pending && cached.url === shareUrl) return cached.pending;
     const QRCode = require('qrcode');
-    const dataUrl = await QRCode.toDataURL(shareUrl, { width: 512, margin: 4 });
+    const entry = { url: shareUrl, dataUrl: null, at: Date.now(), pending: null };
+    entry.pending = QRCode.toDataURL(shareUrl, { width: 512, margin: 4 }).then((dataUrl) => {
+      entry.dataUrl = dataUrl;
+      entry.pending = null;
+      return dataUrl;
+    }).catch((e) => {
+      slideshowQrCache.delete(event.id);
+      throw e;
+    });
     if (!slideshowQrCache.has(event.id) && slideshowQrCache.size >= SLIDESHOW_QR_CACHE_MAX) {
       slideshowQrCache.delete(slideshowQrCache.keys().next().value);
     }
-    slideshowQrCache.set(event.id, { url: shareUrl, dataUrl, at: Date.now() });
-    return dataUrl;
+    slideshowQrCache.set(event.id, entry);
+    return await entry.pending;
   } catch (e) {
     logger.error('Slideshow QR generation failed:', e);
     return null;

--- a/backend/src/routes/gallery.js
+++ b/backend/src/routes/gallery.js
@@ -391,14 +391,24 @@ const slideshowQrCache = new Map();
 // missing or loopback. trust proxy is configured, so req.protocol respects
 // X-Forwarded-Proto behind the standard reverse-proxy setups.
 const QR_LOCAL_BASE_RE = /^https?:\/\/(localhost|127\.|0\.0\.0\.0|\[::1\])/i;
+const QR_ORIGIN_RE = /^https?:\/\/[^\s/]+$/i;
 async function slideshowQrDataUrl(event, req) {
   try {
     const shareToken = getEventShareToken(event);
     if (!shareToken) return null;
     let { shareUrl, sharePath } = await buildShareLinkVariants({ slug: event.slug, shareToken });
     if (!/^https?:\/\//i.test(shareUrl) || QR_LOCAL_BASE_RE.test(shareUrl)) {
+      // Prefer the kiosk's own window.location.origin (?origin=, validated):
+      // req.get('host') is NOT the browser origin behind the standard
+      // proxies — frontend/nginx.conf forwards $host (port stripped), so a
+      // compose LAN deployment on :3000 would encode port 80 (codex review
+      // of #848 round 3). Host-derived origin stays as second fallback.
+      const queryOrigin = typeof req?.query?.origin === 'string' && QR_ORIGIN_RE.test(req.query.origin)
+        ? req.query.origin.replace(/\/$/, '')
+        : null;
       const host = req && req.get ? req.get('host') : null;
-      if (host) shareUrl = `${req.protocol}://${host}${sharePath}`;
+      if (queryOrigin) shareUrl = `${queryOrigin}${sharePath}`;
+      else if (host) shareUrl = `${req.protocol}://${host}${sharePath}`;
     }
     if (!shareUrl) return null;
     if (slideshowQrCache.has(shareUrl)) return slideshowQrCache.get(shareUrl);

--- a/backend/src/utils/slideshowGlobals.js
+++ b/backend/src/utils/slideshowGlobals.js
@@ -21,6 +21,7 @@ async function getSlideshowGlobals() {
   const [
     enabled, source, position, opacity, style, size, fit,
     logo, logoDark, favicon,
+    qrEnabled, qrPosition, qrOpacity, qrSize,
   ] = await Promise.all([
     getAppSetting('slideshow_watermark_enabled', false),
     getAppSetting('slideshow_watermark_source', 'logo'),
@@ -32,6 +33,11 @@ async function getSlideshowGlobals() {
     getAppSetting('branding_logo_url', null),
     getAppSetting('branding_logo_url_dark', null),
     getAppSetting('branding_favicon_url', null),
+    // QR overlay (#837) — guests scan the gallery link straight off the beamer.
+    getAppSetting('slideshow_qr_enabled', false),
+    getAppSetting('slideshow_qr_position', 'bottom-left'),
+    getAppSetting('slideshow_qr_opacity', 90),
+    getAppSetting('slideshow_qr_size', 14),
   ]);
 
   const val = {
@@ -45,6 +51,10 @@ async function getSlideshowGlobals() {
     branding_logo_url: logo || null,
     branding_logo_url_dark: logoDark || null,
     branding_favicon_url: favicon || null,
+    qr_enabled: qrEnabled === true,
+    qr_position: qrPosition || 'bottom-left',
+    qr_opacity: qrOpacity ?? 90,
+    qr_size: qrSize ?? 14,
   };
   cache = { at: now, val };
   return val;

--- a/frontend/src/components/admin/SlideshowGlobalDefaultsCard.tsx
+++ b/frontend/src/components/admin/SlideshowGlobalDefaultsCard.tsx
@@ -38,6 +38,10 @@ const DEFAULTS: SlideshowGlobalDefaults = {
   slideshow_watermark_opacity: 60,
   slideshow_watermark_style: 'white',
   slideshow_watermark_size: 12,
+  slideshow_qr_enabled: false,
+  slideshow_qr_position: 'bottom-left',
+  slideshow_qr_opacity: 90,
+  slideshow_qr_size: 14,
 };
 
 const inputClass =
@@ -65,6 +69,10 @@ export const SlideshowGlobalDefaultsCard: React.FC = () => {
         slideshow_watermark_opacity: s.slideshow_watermark_opacity ?? DEFAULTS.slideshow_watermark_opacity,
         slideshow_watermark_style: s.slideshow_watermark_style ?? DEFAULTS.slideshow_watermark_style,
         slideshow_watermark_size: s.slideshow_watermark_size ?? DEFAULTS.slideshow_watermark_size,
+        slideshow_qr_enabled: s.slideshow_qr_enabled ?? DEFAULTS.slideshow_qr_enabled,
+        slideshow_qr_position: s.slideshow_qr_position ?? DEFAULTS.slideshow_qr_position,
+        slideshow_qr_opacity: s.slideshow_qr_opacity ?? DEFAULTS.slideshow_qr_opacity,
+        slideshow_qr_size: s.slideshow_qr_size ?? DEFAULTS.slideshow_qr_size,
       });
     }).catch(() => { /* keep defaults */ });
     return () => { cancelled = true; };
@@ -251,6 +259,69 @@ export const SlideshowGlobalDefaultsCard: React.FC = () => {
                 className={inputClass}
               />
             </div>
+            </div>
+          </div>
+        )}
+        </div>
+
+        {/* Share-link QR overlay (#837) */}
+        <div className="pt-2 border-t border-neutral-200 dark:border-neutral-700">
+        <label className="flex items-start gap-2">
+          <input
+            type="checkbox"
+            className="mt-1 w-4 h-4 text-accent border-neutral-300 dark:border-neutral-600 rounded focus:ring-primary-500"
+            checked={val.slideshow_qr_enabled}
+            onChange={(e) => setVal({ ...val, slideshow_qr_enabled: e.target.checked })}
+          />
+          <div>
+            <span className="text-sm font-medium text-neutral-700 dark:text-neutral-300">
+              {t('slideshow.qrToggle', 'Gallery QR code')}
+            </span>
+            <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
+              {t('slideshow.qrDescription', 'Show the gallery link as a QR code so guests can scan it straight off the screen.')}
+            </p>
+          </div>
+        </label>
+
+        {val.slideshow_qr_enabled && (
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 mt-3">
+            <div>
+              <label className={labelClass}>{t('slideshow.watermarkPositionLabel', 'Position')}</label>
+              <select
+                value={val.slideshow_qr_position}
+                onChange={(e) => setVal({ ...val, slideshow_qr_position: e.target.value as SlideshowGlobalDefaults['slideshow_qr_position'] })}
+                className={inputClass}
+              >
+                {SLIDESHOW_WATERMARK_POSITIONS.map((pos) => (
+                  <option key={pos} value={pos}>
+                    {t(`slideshow.watermarkPosition.${pos}`, pos)}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className={labelClass}>{t('slideshow.watermarkOpacityLabel', 'Opacity (%)')}</label>
+              <input
+                type="number"
+                min={0}
+                max={100}
+                step={5}
+                value={val.slideshow_qr_opacity}
+                onChange={(e) => setVal({ ...val, slideshow_qr_opacity: Math.min(100, Math.max(0, parseInt(e.target.value, 10) || 0)) })}
+                className={inputClass}
+              />
+            </div>
+            <div>
+              <label className={labelClass}>{t('slideshow.watermarkSizeLabel', 'Size (% of screen)')}</label>
+              <input
+                type="number"
+                min={5}
+                max={40}
+                step={1}
+                value={val.slideshow_qr_size}
+                onChange={(e) => setVal({ ...val, slideshow_qr_size: Math.min(40, Math.max(5, parseInt(e.target.value, 10) || 14)) })}
+                className={inputClass}
+              />
             </div>
           </div>
         )}

--- a/frontend/src/components/admin/SlideshowSettingsCard.tsx
+++ b/frontend/src/components/admin/SlideshowSettingsCard.tsx
@@ -36,6 +36,7 @@ export interface SlideshowSettingsCardProps {
     show_transition?: string;
     show_transition_ms?: number;
     show_watermark?: boolean | null;
+    show_qr?: boolean | null;
     show_colorfilter?: string;
     show_order?: string;
     show_category_id?: number | null;
@@ -55,6 +56,7 @@ function styleFromInitial(initial: SlideshowSettingsCardProps['initial']): Slide
     transition: (initial.show_transition as SlideshowStyle['transition']) ?? DEFAULT_SLIDESHOW_STYLE.transition,
     transition_ms: initial.show_transition_ms ?? DEFAULT_SLIDESHOW_STYLE.transition_ms,
     watermark: watermarkMode(initial.show_watermark),
+    qr: watermarkMode(initial.show_qr),
     colorfilter: (initial.show_colorfilter as SlideshowStyle['colorfilter']) ?? DEFAULT_SLIDESHOW_STYLE.colorfilter,
     order: (initial.show_order as SlideshowStyle['order']) ?? DEFAULT_SLIDESHOW_STYLE.order,
     category_id: initial.show_category_id ?? null,
@@ -142,6 +144,7 @@ export const SlideshowSettingsCard: React.FC<SlideshowSettingsCardProps> = ({
         // Tri-state → null (inherit global) / true / false. The watermark LOOK
         // is global-only (Settings → Slideshow); we only send the mode here.
         show_watermark: style.watermark === 'inherit' ? null : style.watermark === 'on',
+        show_qr: style.qr === 'inherit' ? null : style.qr === 'on',
         show_colorfilter: style.colorfilter,
         show_order: style.order,
         show_category_id: style.category_id,

--- a/frontend/src/components/admin/SlideshowStyleFields.tsx
+++ b/frontend/src/components/admin/SlideshowStyleFields.tsx
@@ -149,6 +149,25 @@ export const SlideshowStyleFields: React.FC<SlideshowStyleFieldsProps> = ({ valu
           {t('slideshow.watermarkModeHint', 'The logo, position, opacity, style and size are configured under Settings → Slideshow.')}
         </p>
       </div>
+
+      {/* QR overlay (#837) — MODE only, same pattern as the watermark. */}
+      <div className="pt-2 border-t border-neutral-200 dark:border-neutral-700">
+        <label className={labelClass}>{t('slideshow.qrToggle', 'Gallery QR code')}</label>
+        <select
+          value={value.qr}
+          onChange={(e) => set({ qr: e.target.value as SlideshowStyle['qr'] })}
+          className={inputClass}
+        >
+          {SLIDESHOW_WATERMARK_MODES.map((m) => (
+            <option key={m} value={m}>
+              {t(`slideshow.watermarkMode.${m}`, m === 'inherit' ? 'Use global default' : m === 'on' ? 'On' : 'Off')}
+            </option>
+          ))}
+        </select>
+        <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
+          {t('slideshow.qrModeHint', 'Position, size and opacity are configured under Settings → Slideshow.')}
+        </p>
+      </div>
     </div>
   );
 };

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -3520,6 +3520,9 @@
     "categoryLabel": "Nur Kategorie zeigen",
     "categoryAll": "Alle Fotos",
     "watermarkToggle": "Logo-Wasserzeichen anzeigen",
+    "qrToggle": "Galerie-QR-Code",
+    "qrDescription": "Zeigt den Galerie-Link als QR-Code, damit Gäste ihn direkt vom Bildschirm scannen können.",
+    "qrModeHint": "Position, Größe und Deckkraft werden unter Einstellungen → Slideshow konfiguriert.",
     "watermarkDescription": "Blendet ein weißes, halbtransparentes Logo in einer Ecke ein (wie ein Senderlogo im TV).",
     "watermarkSourceLabel": "Logo",
     "watermarkSource": {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -3672,6 +3672,9 @@
     "categoryLabel": "Show only category",
     "categoryAll": "All photos",
     "watermarkToggle": "Show logo watermark",
+    "qrToggle": "Gallery QR code",
+    "qrDescription": "Show the gallery link as a QR code so guests can scan it straight off the screen.",
+    "qrModeHint": "Position, size and opacity are configured under Settings → Slideshow.",
     "watermarkDescription": "Overlay a white, semi-transparent logo in a corner (like a TV station ident).",
     "watermarkSourceLabel": "Logo",
     "watermarkSource": {

--- a/frontend/src/pages/admin/event-details/OverviewTab.tsx
+++ b/frontend/src/pages/admin/event-details/OverviewTab.tsx
@@ -126,6 +126,7 @@ export const OverviewTab: React.FC<OverviewTabProps> = ({
             show_transition: event.show_transition,
             show_transition_ms: event.show_transition_ms,
             show_watermark: event.show_watermark,
+            show_qr: event.show_qr,
             show_colorfilter: event.show_colorfilter,
           }}
           onChanged={() => refetchEvent()}

--- a/frontend/src/pages/gallery/SlideshowPage.tsx
+++ b/frontend/src/pages/gallery/SlideshowPage.tsx
@@ -456,27 +456,31 @@ export function SlideshowPage() {
             />
           )}
 
-          {/* Share-link QR overlay (#837): guests scan the gallery straight off
-              the beamer. White padding box keeps the code scannable on any photo. */}
-          {settings.qr && (
-            <img
-              src={settings.qr.data_url}
-              alt=""
-              draggable={false}
-              style={{
-                position: 'absolute',
-                ...watermarkCorner(settings.qr.position),
-                width: `${settings.qr.size ?? 14}vmin`,
-                height: `${settings.qr.size ?? 14}vmin`,
-                opacity: Math.min(1, Math.max(0, (settings.qr.opacity ?? 90) / 100)),
-                background: '#ffffff',
-                padding: '0.6vmin',
-                borderRadius: '1vmin',
-                pointerEvents: 'none',
-              }}
-            />
-          )}
         </>
+      )}
+
+      {/* Share-link QR overlay (#837): guests scan the gallery straight off
+          the beamer. White padding box keeps the code scannable on any photo.
+          Rendered OUTSIDE the photos-gate so an empty/awaiting slideshow still
+          shows the code — the "scan to add the first photos" case (codex
+          review of #848). */}
+      {phase === 'running' && settings.qr && (
+        <img
+          src={settings.qr.data_url}
+          alt=""
+          draggable={false}
+          style={{
+            position: 'absolute',
+            ...watermarkCorner(settings.qr.position),
+            width: `${settings.qr.size ?? 14}vmin`,
+            height: `${settings.qr.size ?? 14}vmin`,
+            opacity: Math.min(1, Math.max(0, (settings.qr.opacity ?? 90) / 100)),
+            background: '#ffffff',
+            padding: '0.6vmin',
+            borderRadius: '1vmin',
+            pointerEvents: 'none',
+          }}
+        />
       )}
 
       {phase === 'ended' && (

--- a/frontend/src/pages/gallery/SlideshowPage.tsx
+++ b/frontend/src/pages/gallery/SlideshowPage.tsx
@@ -16,6 +16,7 @@ const DEFAULT_SETTINGS: SlideshowSettings = {
   order: 'chronological',
   fit: 'cover',
   watermark: null,
+  qr: null,
 };
 
 // How often the running show re-checks settings + photo count (tiny payload).
@@ -227,6 +228,7 @@ export function SlideshowPage() {
           colorfilter: state.colorfilter,
           fit: state.fit,
           watermark: state.watermark,
+          qr: state.qr,
         };
         if (JSON.stringify(next) !== JSON.stringify({
           interval_ms: prev.interval_ms,
@@ -235,6 +237,7 @@ export function SlideshowPage() {
           colorfilter: prev.colorfilter,
           fit: prev.fit,
           watermark: prev.watermark,
+          qr: prev.qr,
         })) {
           setSettings(next);
         }
@@ -448,6 +451,27 @@ export function SlideshowPage() {
                 // 'white' recolors the logo white (dark/transparent marks); 'original'
                 // leaves a boxed/colored logo as-is so it doesn't become a white blob.
                 filter: settings.watermark!.style === 'original' ? 'none' : 'brightness(0) invert(1)',
+                pointerEvents: 'none',
+              }}
+            />
+          )}
+
+          {/* Share-link QR overlay (#837): guests scan the gallery straight off
+              the beamer. White padding box keeps the code scannable on any photo. */}
+          {settings.qr && (
+            <img
+              src={settings.qr.data_url}
+              alt=""
+              draggable={false}
+              style={{
+                position: 'absolute',
+                ...watermarkCorner(settings.qr.position),
+                width: `${settings.qr.size ?? 14}vmin`,
+                height: `${settings.qr.size ?? 14}vmin`,
+                opacity: Math.min(1, Math.max(0, (settings.qr.opacity ?? 90) / 100)),
+                background: '#ffffff',
+                padding: '0.6vmin',
+                borderRadius: '1vmin',
                 pointerEvents: 'none',
               }}
             />

--- a/frontend/src/services/events.service.ts
+++ b/frontend/src/services/events.service.ts
@@ -157,6 +157,7 @@ export const eventsService = {
       show_transition?: string;
       show_transition_ms?: number;
       show_watermark?: boolean | null;
+      show_qr?: boolean | null;
       show_colorfilter?: string;
       show_order?: string;
       show_category_id?: number | null;

--- a/frontend/src/services/slideshow.service.ts
+++ b/frontend/src/services/slideshow.service.ts
@@ -39,6 +39,8 @@ export interface SlideshowStyle {
   transition: SlideshowTransition;
   transition_ms: number;
   watermark: SlideshowWatermarkMode;
+  // QR overlay mode (#837) — same tri-state semantics as the watermark.
+  qr: SlideshowWatermarkMode;
   colorfilter: SlideshowColorFilter;
   // Play order + optional category filter (#202). category_id null = all photos.
   order: SlideshowOrder;
@@ -50,6 +52,7 @@ export const DEFAULT_SLIDESHOW_STYLE: SlideshowStyle = {
   transition: 'crossfade',
   transition_ms: 800,
   watermark: 'inherit',
+  qr: 'inherit',
   colorfilter: 'none',
   order: 'chronological',
   category_id: null,
@@ -73,6 +76,11 @@ export interface SlideshowGlobalDefaults {
   slideshow_watermark_style: SlideshowWatermarkStyle;
   // Logo size as a % of the viewport's shorter side.
   slideshow_watermark_size: number;
+  // QR overlay defaults (#837) — same option shape as the watermark.
+  slideshow_qr_enabled: boolean;
+  slideshow_qr_position: SlideshowWatermarkPosition;
+  slideshow_qr_opacity: number;
+  slideshow_qr_size: number;
 }
 
 // Resolved watermark the kiosk renders (logo URL already resolved server-side).
@@ -81,6 +89,15 @@ export interface SlideshowWatermark {
   position: SlideshowWatermarkPosition;
   opacity: number;
   style: SlideshowWatermarkStyle;
+  size: number;
+}
+
+// Resolved QR overlay (#837) — the share-link QR ships as a data URI, so the
+// kiosk needs no QR library and no extra authenticated request.
+export interface SlideshowQr {
+  data_url: string;
+  position: SlideshowWatermarkPosition;
+  opacity: number;
   size: number;
 }
 
@@ -95,6 +112,7 @@ export interface SlideshowSettings {
   order: SlideshowOrder;
   fit: SlideshowFit;
   watermark: SlideshowWatermark | null;
+  qr: SlideshowQr | null;
 }
 
 export interface SlideshowSession {

--- a/frontend/src/services/slideshow.service.ts
+++ b/frontend/src/services/slideshow.service.ts
@@ -140,12 +140,20 @@ export const slideshowService = {
   // session token + current settings/count. Throws 404 if the link is
   // disabled, rotated, or the gallery isn't live.
   async getSession(slug: string, token: string): Promise<SlideshowSession> {
-    const response = await api.get<SlideshowSession>(`/gallery/${slug}/show/${token}/session`);
+    // origin: the kiosk's own reachable URL — the backend prefers it for the
+    // QR overlay when the configured base is missing/loopback (#848 review;
+    // the proxy strips the port from the Host header, so it can't be
+    // derived server-side).
+    const response = await api.get<SlideshowSession>(`/gallery/${slug}/show/${token}/session`, {
+      params: { origin: window.location.origin },
+    });
     return response.data;
   },
 
   async getState(slug: string, token: string): Promise<SlideshowState> {
-    const response = await api.get<SlideshowState>(`/gallery/${slug}/show/${token}/state`);
+    const response = await api.get<SlideshowState>(`/gallery/${slug}/show/${token}/state`, {
+      params: { origin: window.location.origin },
+    });
     return response.data;
   },
 };

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -77,6 +77,8 @@ export interface Event {
   // Watermark MODE only (null=inherit global / true / false). The look lives
   // globally in Settings → Slideshow, not per event.
   show_watermark?: boolean | null;
+  // QR overlay MODE (#837) — same tri-state semantics as show_watermark.
+  show_qr?: boolean | null;
   show_colorfilter?: 'none' | 'bw' | 'sepia' | 'warm' | 'cool' | 'vignette';
   // Default photo sort order
   default_photo_sort?: string;


### PR DESCRIPTION
## Summary

Closes #837 — the live slideshow can now show the gallery share link as a QR code, so guests scan it straight off the beamer and their photos land in the gallery moments later (the shared.click "live wall" pattern). Independent of #847 — no shared code; the QR payload here is generated server-side in the state endpoint.

## Design

Mirrors the watermark cascade exactly:

- **Global look** (Settings → Slideshow): `slideshow_qr_enabled` / `position` / `opacity` / `size`, validated in the existing `PUT /admin/settings/slideshow` whitelist, cached via `getSlideshowGlobals()` (same 5s TTL + invalidate-on-write).
- **Per-event tri-state** `show_qr` (migration 163, NULL = inherit) — editable in the per-event slideshow card next to the watermark mode, `PATCH /:id/slideshow`.
- **Delivery:** the `/show/:token/state` payload carries the QR as a **PNG data URI** (`qr: { data_url, position, opacity, size }`), generated with the existing `qrcode` dependency and cached per share URL — the 3s projector poll never re-encodes, and the public kiosk needs no QR library and no extra authenticated request.
- **Rendering:** corner-positioned like the watermark, in a white padded rounded box so the code stays scannable on any photo.

## Screenshot

Running slideshow with the QR overlay (bottom-left, e2e test image as slide content):

![Slideshow QR overlay](https://raw.githubusercontent.com/PicPeak/picpeak/screenshots/slideshow-qr-837/issue-837-slideshow-qr-overlay-v2.png)

## Deviation from the issue

The issue suggested offering the overlay only when guest uploads are enabled. I didn't hard-gate: a QR to *view* the gallery is just as useful for view-only events, and the admin toggle already carries the decision. Say the word if you want the coupling.

## Testing

- `slideshowPublic.test.js` +4: inherits global when `show_qr` NULL (position/opacity/size + `data:image/png` prefix), null by default, per-event OFF beats global ON, per-event ON beats global OFF — 23/23 on the branch.
- Verified live on the dev stack: enabled the global setting, generated a slideshow link, confirmed the overlay renders and the QR encodes the share URL.
- `tsc --noEmit` clean; i18n en + de (the slideshow namespace has no other locales yet, matching the watermark keys).
- Pre-push local E2E smoke — 13 passed.
