### PR TITLE
fix(tests): raise jest timeouts to survive the growing migration chain

### DIFF
--- a/backend/__tests__/integration/adminBackupCoverage.test.js
+++ b/backend/__tests__/integration/adminBackupCoverage.test.js
@@ -40,7 +40,7 @@ jest.mock('../../src/middleware/permissions', () => ({
   requirePermission: () => (_req, _res, next) => next(),
 }));
 
-jest.setTimeout(30000);
+jest.setTimeout(120000);
 
 describe('GET /api/admin/system-health/backup-coverage', () => {
   let db;

--- a/backend/__tests__/integration/adminBackupIntegrity.test.js
+++ b/backend/__tests__/integration/adminBackupIntegrity.test.js
@@ -29,7 +29,7 @@ jest.mock('../../src/middleware/permissions', () => ({
   requirePermission: () => (_req, _res, next) => next(),
 }));
 
-jest.setTimeout(30000);
+jest.setTimeout(120000);
 
 describe('GET /api/admin/system-health/backup-integrity', () => {
   let cleanup;

--- a/backend/__tests__/integration/backupService.configurableWalker.test.js
+++ b/backend/__tests__/integration/backupService.configurableWalker.test.js
@@ -23,7 +23,7 @@ const path = require('path');
 
 const { bootCrmDb } = require('./helpers/crmDb');
 
-jest.setTimeout(30000);
+jest.setTimeout(120000);
 
 describe('backupService — configurable walker (backup_paths)', () => {
   let db;

--- a/backend/__tests__/integration/backupService.inlineDbDump.test.js
+++ b/backend/__tests__/integration/backupService.inlineDbDump.test.js
@@ -34,7 +34,7 @@ jest.mock('../../src/services/databaseBackup', () => ({
   DatabaseBackupService: class {},
 }));
 
-jest.setTimeout(30000);
+jest.setTimeout(120000);
 
 describe('backupService — inline DB dump + fail-loud guard', () => {
   let db;

--- a/backend/__tests__/integration/backupService.perPathStats.test.js
+++ b/backend/__tests__/integration/backupService.perPathStats.test.js
@@ -23,7 +23,7 @@ const path = require('path');
 
 const { bootCrmDb } = require('./helpers/crmDb');
 
-jest.setTimeout(30000);
+jest.setTimeout(120000);
 
 describe('backupService — per-Stage-B-path statistics', () => {
   let db;

--- a/backend/__tests__/integration/backupService.smoke.test.js
+++ b/backend/__tests__/integration/backupService.smoke.test.js
@@ -14,7 +14,7 @@ const path = require('path');
 
 const { bootCrmDb } = require('./helpers/crmDb');
 
-jest.setTimeout(30000);
+jest.setTimeout(120000);
 
 describe('backupService — config + file collection + manifest (smoke)', () => {
   let db;

--- a/backend/__tests__/integration/bookingCutover.test.js
+++ b/backend/__tests__/integration/bookingCutover.test.js
@@ -7,7 +7,7 @@
 const crypto = require('crypto');
 const { bootCrmDb, seedMinimal } = require('./helpers/crmDb');
 
-jest.setTimeout(30000);
+jest.setTimeout(120000);
 
 describe('booking cutover — draft invoices on hold', () => {
   let db; let cleanup; let adminId; let customerId; let quoteService;

--- a/backend/__tests__/integration/categoryReorder.test.js
+++ b/backend/__tests__/integration/categoryReorder.test.js
@@ -15,7 +15,7 @@ const {
   bootCrmDb, seedMinimal, assignAdminRole, mintAdminToken, buildRouteApp,
 } = require('./helpers/crmDb');
 
-jest.setTimeout(30000);
+jest.setTimeout(120000);
 
 describe('category ordering (#782)', () => {
   let db;

--- a/backend/__tests__/integration/discountLineItems.test.js
+++ b/backend/__tests__/integration/discountLineItems.test.js
@@ -14,7 +14,7 @@ const { bootCrmDb, seedMinimal } = require('./helpers/crmDb');
 // Service-level CRM calls cold-require heavy modules (pdfService,
 // nodemailer, etc.) on first use; the global 5 s per-test budget is
 // too tight for that. Bump it for this file only.
-jest.setTimeout(30000);
+jest.setTimeout(120000);
 
 describe('discount line items (negative unit_price_minor)', () => {
   let db;

--- a/backend/__tests__/integration/eventTypeRename.test.js
+++ b/backend/__tests__/integration/eventTypeRename.test.js
@@ -6,7 +6,7 @@
 const { bootCrmDb, seedMinimal } = require('./helpers/crmDb');
 
 // bootCrmDb runs the full core-migration set in beforeAll.
-jest.setTimeout(30000);
+jest.setTimeout(120000);
 
 describe('event type slug rename cascade', () => {
   let db;

--- a/backend/__tests__/integration/galleryShortUrlRoute.test.js
+++ b/backend/__tests__/integration/galleryShortUrlRoute.test.js
@@ -17,7 +17,7 @@ const request = require('supertest');
 
 const { bootCrmDb } = require('./helpers/crmDb');
 
-jest.setTimeout(60000);
+jest.setTimeout(120000);
 
 let db; let cleanup; let service; let app;
 

--- a/backend/__tests__/integration/galleryShortUrls.test.js
+++ b/backend/__tests__/integration/galleryShortUrls.test.js
@@ -19,7 +19,7 @@
  */
 const { bootCrmDb } = require('./helpers/crmDb');
 
-jest.setTimeout(60000);
+jest.setTimeout(120000);
 
 let db; let cleanup; let service; let adminId;
 

--- a/backend/__tests__/integration/incomingInvoiceRebill.test.js
+++ b/backend/__tests__/integration/incomingInvoiceRebill.test.js
@@ -13,7 +13,7 @@ const { bootCrmDb, seedMinimal } = require('./helpers/crmDb');
 
 // Service-level CRM calls cold-require heavy modules (pdfService, nodemailer)
 // on first use; bump the budget for this file.
-jest.setTimeout(60000);
+jest.setTimeout(120000);
 
 describe('incoming-invoice categorise / re-bill chain', () => {
   let db;

--- a/backend/__tests__/integration/installFromBackupBoot.test.js
+++ b/backend/__tests__/integration/installFromBackupBoot.test.js
@@ -32,7 +32,7 @@ jest.mock('../../src/services/restoreService', () => ({
   },
 }));
 
-jest.setTimeout(30000);
+jest.setTimeout(120000);
 
 describe('installFromBackupBoot', () => {
   let db;

--- a/backend/__tests__/integration/invoiceDunning.test.js
+++ b/backend/__tests__/integration/invoiceDunning.test.js
@@ -13,7 +13,7 @@ const { bootCrmDb, seedMinimal } = require('./helpers/crmDb');
 // bootCrmDb runs the full core-migration set in beforeAll; under full-suite
 // parallel load on a small CI runner that can exceed the 5s default. Match the
 // other migration-heavy CRM suites (discountLineItems, incomingInvoiceRebill).
-jest.setTimeout(30000);
+jest.setTimeout(120000);
 
 let db;
 let cleanup;

--- a/backend/__tests__/integration/resetAdminMfaCli.test.js
+++ b/backend/__tests__/integration/resetAdminMfaCli.test.js
@@ -13,7 +13,7 @@ const { execFileSync } = require('child_process');
 
 const { bootCrmDb } = require('./helpers/crmDb');
 
-jest.setTimeout(60000);
+jest.setTimeout(120000);
 
 let db;
 let cleanup;

--- a/backend/__tests__/integration/workflowEngine.test.js
+++ b/backend/__tests__/integration/workflowEngine.test.js
@@ -10,7 +10,7 @@ const { bootCrmDb } = require('./helpers/crmDb');
 // bootCrmDb runs the full core-migration set in beforeAll; under full-suite
 // parallel load on a small CI runner that can exceed the 5s default. Match the
 // other migration-heavy CRM suites (discountLineItems, incomingInvoiceRebill).
-jest.setTimeout(30000);
+jest.setTimeout(120000);
 
 let db;
 let cleanup;

--- a/backend/__tests__/integration/workflowRoutes.test.js
+++ b/backend/__tests__/integration/workflowRoutes.test.js
@@ -9,7 +9,7 @@ const {
 // bootCrmDb runs the full core-migration set in beforeAll; under full-suite
 // parallel load on a small CI runner that can exceed the 5s default. Match the
 // other migration-heavy CRM suites (discountLineItems, incomingInvoiceRebill).
-jest.setTimeout(30000);
+jest.setTimeout(120000);
 
 let db;
 let cleanup;

--- a/backend/__tests__/routes/adminMfa.test.js
+++ b/backend/__tests__/routes/adminMfa.test.js
@@ -39,7 +39,7 @@ const {
   bootCrmDb, mintAdminToken, buildRouteApp,
 } = require('../integration/helpers/crmDb');
 
-jest.setTimeout(60000);
+jest.setTimeout(120000);
 
 let db;
 let cleanup;

--- a/backend/__tests__/services/backupIntegrityService.test.js
+++ b/backend/__tests__/services/backupIntegrityService.test.js
@@ -22,7 +22,7 @@ const crypto = require('crypto');
 
 const { bootCrmDb, seedMinimal } = require('../integration/helpers/crmDb');
 
-jest.setTimeout(30000);
+jest.setTimeout(120000);
 
 describe('backupIntegrityService.verifyDocumentArtefacts', () => {
   let db;

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,5 +1,10 @@
 module.exports = {
   testEnvironment: 'node',
+  // bootCrmDb() runs EVERY core migration in beforeAll; the chain keeps
+  // growing (163-165 pushed several suites past jest's default on CI
+  // runners — the 3.94 release PR failed on exactly this). 120s matches
+  // the convention the newer suites already pin explicitly.
+  testTimeout: 120000,
   coverageDirectory: 'coverage',
   collectCoverageFrom: [
     'src/**/*.js',


### PR DESCRIPTION
Fixes the `backend` job failure on release PR #859 — full analysis in the commit message. TL;DR: `bootCrmDb()` runs every core migration in `beforeAll`, and with migrations 163–165 merged the setup now crosses `workflowEngine.test.js`'s own `jest.setTimeout(30000)` on CI runners (the job log shows migration 099 still seeding after the hook timed out — a timing failure, not a logic one; the identical pass was green on #857's rebase minutes earlier).

Two layers: `testTimeout: 120000` in `jest.config.js` as the project default, plus raising the 19 suite-level `jest.setTimeout(30000/60000)` pins to 120s (local pins override the config default, so they'd keep flaking otherwise). No test logic changed.

After this merges, release-please updates #859 and its backend job re-runs against the fix.