### PR TITLE
fix: sync gallery feedback filters after lightbox like/rating in simple mode

### DIFF
--- a/frontend/src/components/gallery/PhotoLightbox.tsx
+++ b/frontend/src/components/gallery/PhotoLightbox.tsx
@@ -288,6 +288,11 @@ export const PhotoLightbox: React.FC<PhotoLightboxProps> = ({
         setLikeCount(c => Math.max(0, c + (next ? 1 : -1)));
         return next;
       });
+      // Keep the gallery's photo list (like_count drives the feedback
+      // filter chips) in sync — the guest-mode path above already does
+      // this; without it, likes made in the lightbox don't appear in
+      // the Likes filter until a full page reload.
+      if (onFeedbackChange) onFeedbackChange();
     } catch (err) {
       if (handleLimitError(err)) return;
       // eslint-disable-next-line no-console
@@ -342,6 +347,9 @@ export const PhotoLightbox: React.FC<PhotoLightboxProps> = ({
       setAvgRating(Number(fresh.summary?.average_rating) || 0);
       setTotalRatings(Number(fresh.summary?.total_ratings) || 0);
     } catch {}
+    // Sync gallery photo list so the Rated filter reflects this rating
+    // without a reload (parity with the guest-mode path above).
+    if (onFeedbackChange) onFeedbackChange();
   };
 
   const goToPrevious = () => {
@@ -1010,6 +1018,9 @@ export const PhotoLightbox: React.FC<PhotoLightboxProps> = ({
             });
             setMyRating(pendingAction.rating);
           }
+          // Sync gallery photo list (feedback filter chips) — parity with
+          // the direct submit paths.
+          if (onFeedbackChange) onFeedbackChange();
           setPendingAction(null);
         }}
         feedbackType={pendingAction?.type === 'rating' ? 'rating' : 'like'}


### PR DESCRIPTION
## The bug

In **simple identity mode**, likes and ratings submitted from the lightbox never notify the gallery view, so the photo list's `like_count` (which drives the Likes/Rated feedback-filter chips) stays stale until a full page reload.

What a gallery guest sees:
- a photo they liked in the lightbox is **missing from the "Likes" filter**
- a photo they unliked **stays stuck in the filter**
- correct again only after a hard reload

The guest-identity-mode paths already call `onFeedbackChange()` after submitting, and the grid `PhotoCard` paths do too — the simple-mode lightbox paths were the only ones missing it.

## Repro (before this fix)

1. Event with feedback enabled, `identity_mode: simple`, `allow_likes` on
2. Open the client gallery → open a photo in the lightbox → like it
3. Close the lightbox → open the "Likes" feedback filter
4. The liked photo is absent (appears only after reload); unliking likewise leaves the photo stuck in the filter

Backend records are always correct — this is purely the gallery view's stale `like_count` snapshot.

## The fix

`PhotoLightbox.tsx`: call `onFeedbackChange()` (already plumbed via `PhotoGridWithLayouts` → `() => refetch()`) after successful submits in the three simple-mode paths that were missing it:

- `submitLike` simple-mode branch
- `submitRating` simple-mode branch
- the `FeedbackIdentityModal` `onSubmit` handler

Mirrors the existing guest-mode behavior; no API or backend changes.

## Verification

Local Docker build of `main`: liked a photo in the lightbox after navigating with Next → the Likes filter shows it immediately, no reload; filter contents match the admin feedback API exactly. Also verified on a `3.45` stable-image deployment that the same gap exists there, so a stable backport would be welcome.

_Screenshot of the fixed behavior to follow in a comment (per CONTRIBUTING screenshot policy for UI changes — the change is behavioral, not visual, so before/after look identical except filter contents)._
