### PR TITLE
fix(gallery): don't close the lightbox when clicking beside the photo (#883)

### DIFF
--- a/frontend/src/components/gallery/PhotoLightbox.tsx
+++ b/frontend/src/components/gallery/PhotoLightbox.tsx
@@ -407,13 +407,6 @@ export const PhotoLightbox: React.FC<PhotoLightboxProps> = ({
     setIsDragging(false);
   };
 
-  const handleImageClick = (e: React.MouseEvent) => {
-    // Only close if clicking the background, not the image
-    if (e.target === e.currentTarget) {
-      onClose();
-    }
-  };
-
   // Touch event handlers: pinch-to-zoom (2 fingers) + single-finger
   // carousel-style swipe nav. Swipe is suppressed while zoomed in so the
   // user can pan instead. The carousel is also disabled mid-animation.
@@ -860,7 +853,6 @@ export const PhotoLightbox: React.FC<PhotoLightboxProps> = ({
               key={slideKey(photo, slot)}
               className="h-full flex items-center justify-center"
               style={{ flex: '0 0 33.3333%' }}
-              onClick={handleImageClick}
             >
               <AuthenticatedImage
                 // Same preview-prefer-with-fallback logic as the
@@ -915,7 +907,6 @@ export const PhotoLightbox: React.FC<PhotoLightboxProps> = ({
           <div
             ref={trackContainerRef}
             className="absolute top-0 left-0 bottom-0 overflow-hidden z-0"
-            onClick={isVideoCurrent ? undefined : handleImageClick}
             onMouseDown={isVideoCurrent ? undefined : handleMouseDown}
             onMouseMove={isVideoCurrent ? undefined : handleMouseMove}
             onMouseUp={isVideoCurrent ? undefined : handleMouseUp}


### PR DESCRIPTION
Closes #883.

## The problem

While paging through a gallery in the lightbox, a missed click on the black bars beside the photo (instead of the prev/next arrows) closed the lightbox and dropped the guest back into the grid — they then had to scroll to find where they left off. Reported by a photographer whose clients hit this constantly.

## The fix

`PhotoLightbox.tsx`: remove the close-on-backdrop-click handler (`handleImageClick`) and its two attachment points (the track container and the current-slide wrapper). Clicking the black area now does nothing — the lightbox only closes via the **X button** or **Escape**, matching Picdrop's behavior referenced in the issue.

Pure deletion, no new state or props. Zoom/pan drag, swipe navigation, and the arrow/toolbar buttons are unaffected (they live on their own elements and never depended on the backdrop handler).

## Verification

- `npm run build` clean; eslint on the file: no new warnings.
- Dev server against a local gallery: clicked the black bars left/right of a portrait photo repeatedly — lightbox stays open; X and Escape still close it; arrows still navigate.

_Screenshot of the lightbox staying open after a backdrop click follows in a comment (CONTRIBUTING screenshot policy)._
