### PR TITLE
fix(gallery): keep the lightbox toolbar from masking the photo (#888)

### DIFF
--- a/frontend/src/components/gallery/PhotoLightbox.tsx
+++ b/frontend/src/components/gallery/PhotoLightbox.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useLayoutEffect, useRef } from 'react';
 import { useDevToolsProtection } from '../../hooks/useDevToolsProtection';
 import { X, ChevronLeft, ChevronRight, Download, ZoomIn, ZoomOut, Minimize2, MessageSquare, Heart, Star } from 'lucide-react';
 import type { Photo } from '../../types';
@@ -101,6 +101,21 @@ export const PhotoLightbox: React.FC<PhotoLightboxProps> = ({
     const onResize = () => setIsSmallScreen(window.innerWidth < 640);
     window.addEventListener('resize', onResize);
     return () => window.removeEventListener('resize', onResize);
+  }, []);
+
+  // The bottom toolbar is opaque and the image area stops above it (#888)
+  // so the toolbar never masks part of the photo. Its height varies
+  // (flex-wrap on small screens, optional filename line, safe-area
+  // padding), so measure it and keep the measurement fresh.
+  const toolbarRef = useRef<HTMLDivElement>(null);
+  const [toolbarHeight, setToolbarHeight] = useState(0);
+  useLayoutEffect(() => {
+    const el = toolbarRef.current;
+    if (!el) return;
+    setToolbarHeight(el.offsetHeight);
+    const observer = new ResizeObserver(() => setToolbarHeight(el.offsetHeight));
+    observer.observe(el);
+    return () => observer.disconnect();
   }, []);
 
 
@@ -656,9 +671,12 @@ export const PhotoLightbox: React.FC<PhotoLightboxProps> = ({
       {/* Bottom toolbar. flex-wrap + reduced gap/padding on mobile prevent
          the action row from clipping when feedback (likes / 5-star ratings /
          comments) is enabled. pb-[env(safe-area-inset-bottom)] keeps the
-         buttons above the iOS home indicator. */}
+         buttons above the iOS home indicator. Opaque, and the image area
+         above is shortened by toolbarHeight so it never masks the photo
+         (#888). */}
       <div
-        className="absolute bottom-0 left-0 bg-gradient-to-t from-black/80 to-transparent px-3 pt-3 pb-3 sm:p-4 z-20"
+        ref={toolbarRef}
+        className="absolute bottom-0 left-0 bg-black px-3 pt-3 pb-3 sm:p-4 z-20"
         style={{
           right: isDesktopFeedback ? `${desktopFeedbackWidth}px` : 0,
           paddingBottom: 'max(0.75rem, env(safe-area-inset-bottom))'
@@ -925,7 +943,7 @@ export const PhotoLightbox: React.FC<PhotoLightboxProps> = ({
         return (
           <div
             ref={trackContainerRef}
-            className="absolute top-0 left-0 bottom-0 overflow-hidden z-0"
+            className="absolute top-0 left-0 overflow-hidden z-0"
             onDoubleClick={isVideoCurrent ? undefined : handleDoubleClick}
             onMouseDown={isVideoCurrent ? undefined : handleMouseDown}
             onMouseMove={isVideoCurrent ? undefined : handleMouseMove}
@@ -938,6 +956,9 @@ export const PhotoLightbox: React.FC<PhotoLightboxProps> = ({
             style={{
               cursor: isVideoCurrent ? 'default' : (zoom > 1 ? (isDragging ? 'grabbing' : 'grab') : 'default'),
               right: isDesktopFeedback ? `${desktopFeedbackWidth}px` : 0,
+              // Stop above the opaque toolbar so it never masks the
+              // photo (#888).
+              bottom: `${toolbarHeight}px`,
               // Tell the browser we handle horizontal gestures ourselves so
               // it doesn't fight us with edge-swipe back navigation, native
               // pinch-zoom, etc. Videos keep default touch behaviour.


### PR DESCRIPTION
Closes #888.

## The problem

The lightbox's bottom info/action bar is an `absolute` translucent-gradient overlay on top of the image area, so the lower edge of every photo sat hidden underneath it — the reporter's client noticed part of the photo being obscured.

## The fix

`PhotoLightbox.tsx`, following the solution proposed in the issue (opaque bar, photo fully visible above it — Picdrop behavior):

- The toolbar background changes from `bg-gradient-to-t from-black/80 to-transparent` to solid `bg-black`.
- The image/video track container now stops **above** the toolbar instead of running underneath it: the toolbar's height is measured with a `ResizeObserver` and applied as the container's `bottom` offset. Measurement (rather than a fixed offset) because the bar's height is genuinely variable — `flex-wrap` on narrow screens, the optional original-filename line (#508), the desktop feedback panel changing the wrap width, and iOS safe-area padding.

`object-contain` then scales the photo into the reduced area, so nothing is ever cropped or covered.

## Verification

- `npm run build` clean; eslint on the file: no new warnings.
- Dev server, portrait + landscape photos: image bottom edge lands exactly on the toolbar's top edge (measured 719/719 on desktop, 537/537 at 375px mobile width where the toolbar wraps to two rows). Zoom, swipe nav, and the desktop feedback panel unaffected.

_Screenshots (desktop + mobile, photo ending flush above the opaque bar) follow in a comment._
