### PR TITLE
fix(tests): raise jest timeouts to the 120s convention (stable)

### DIFF
--- a/backend/__tests__/integration/adminBackupCoverage.test.js
+++ b/backend/__tests__/integration/adminBackupCoverage.test.js
@@ -40,7 +40,7 @@ jest.mock('../../src/middleware/permissions', () => ({
   requirePermission: () => (_req, _res, next) => next(),
 }));
 
-jest.setTimeout(30000);
+jest.setTimeout(120000);
 
 describe('GET /api/admin/system-health/backup-coverage', () => {
   let db;

--- a/backend/__tests__/integration/adminBackupIntegrity.test.js
+++ b/backend/__tests__/integration/adminBackupIntegrity.test.js
@@ -29,7 +29,7 @@ jest.mock('../../src/middleware/permissions', () => ({
   requirePermission: () => (_req, _res, next) => next(),
 }));
 
-jest.setTimeout(30000);
+jest.setTimeout(120000);
 
 describe('GET /api/admin/system-health/backup-integrity', () => {
   let cleanup;

--- a/backend/__tests__/integration/backupService.configurableWalker.test.js
+++ b/backend/__tests__/integration/backupService.configurableWalker.test.js
@@ -23,7 +23,7 @@ const path = require('path');
 
 const { bootCrmDb } = require('./helpers/crmDb');
 
-jest.setTimeout(30000);
+jest.setTimeout(120000);
 
 describe('backupService — configurable walker (backup_paths)', () => {
   let db;

--- a/backend/__tests__/integration/backupService.inlineDbDump.test.js
+++ b/backend/__tests__/integration/backupService.inlineDbDump.test.js
@@ -34,7 +34,7 @@ jest.mock('../../src/services/databaseBackup', () => ({
   DatabaseBackupService: class {},
 }));
 
-jest.setTimeout(30000);
+jest.setTimeout(120000);
 
 describe('backupService — inline DB dump + fail-loud guard', () => {
   let db;

--- a/backend/__tests__/integration/backupService.perPathStats.test.js
+++ b/backend/__tests__/integration/backupService.perPathStats.test.js
@@ -23,7 +23,7 @@ const path = require('path');
 
 const { bootCrmDb } = require('./helpers/crmDb');
 
-jest.setTimeout(30000);
+jest.setTimeout(120000);
 
 describe('backupService — per-Stage-B-path statistics', () => {
   let db;

--- a/backend/__tests__/integration/backupService.smoke.test.js
+++ b/backend/__tests__/integration/backupService.smoke.test.js
@@ -14,7 +14,7 @@ const path = require('path');
 
 const { bootCrmDb } = require('./helpers/crmDb');
 
-jest.setTimeout(30000);
+jest.setTimeout(120000);
 
 describe('backupService — config + file collection + manifest (smoke)', () => {
   let db;

--- a/backend/__tests__/integration/bookingCutover.test.js
+++ b/backend/__tests__/integration/bookingCutover.test.js
@@ -7,7 +7,7 @@
 const crypto = require('crypto');
 const { bootCrmDb, seedMinimal } = require('./helpers/crmDb');
 
-jest.setTimeout(30000);
+jest.setTimeout(120000);
 
 describe('booking cutover — draft invoices on hold', () => {
   let db; let cleanup; let adminId; let customerId; let quoteService;

--- a/backend/__tests__/integration/discountLineItems.test.js
+++ b/backend/__tests__/integration/discountLineItems.test.js
@@ -14,7 +14,7 @@ const { bootCrmDb, seedMinimal } = require('./helpers/crmDb');
 // Service-level CRM calls cold-require heavy modules (pdfService,
 // nodemailer, etc.) on first use; the global 5 s per-test budget is
 // too tight for that. Bump it for this file only.
-jest.setTimeout(30000);
+jest.setTimeout(120000);
 
 describe('discount line items (negative unit_price_minor)', () => {
   let db;

--- a/backend/__tests__/integration/eventTypeRename.test.js
+++ b/backend/__tests__/integration/eventTypeRename.test.js
@@ -6,7 +6,7 @@
 const { bootCrmDb, seedMinimal } = require('./helpers/crmDb');
 
 // bootCrmDb runs the full core-migration set in beforeAll.
-jest.setTimeout(30000);
+jest.setTimeout(120000);
 
 describe('event type slug rename cascade', () => {
   let db;

--- a/backend/__tests__/integration/galleryShortUrlRoute.test.js
+++ b/backend/__tests__/integration/galleryShortUrlRoute.test.js
@@ -17,7 +17,7 @@ const request = require('supertest');
 
 const { bootCrmDb } = require('./helpers/crmDb');
 
-jest.setTimeout(60000);
+jest.setTimeout(120000);
 
 let db; let cleanup; let service; let app;
 

--- a/backend/__tests__/integration/galleryShortUrls.test.js
+++ b/backend/__tests__/integration/galleryShortUrls.test.js
@@ -19,7 +19,7 @@
  */
 const { bootCrmDb } = require('./helpers/crmDb');
 
-jest.setTimeout(60000);
+jest.setTimeout(120000);
 
 let db; let cleanup; let service; let adminId;
 

--- a/backend/__tests__/integration/incomingInvoiceRebill.test.js
+++ b/backend/__tests__/integration/incomingInvoiceRebill.test.js
@@ -13,7 +13,7 @@ const { bootCrmDb, seedMinimal } = require('./helpers/crmDb');
 
 // Service-level CRM calls cold-require heavy modules (pdfService, nodemailer)
 // on first use; bump the budget for this file.
-jest.setTimeout(60000);
+jest.setTimeout(120000);
 
 describe('incoming-invoice categorise / re-bill chain', () => {
   let db;

--- a/backend/__tests__/integration/installFromBackupBoot.test.js
+++ b/backend/__tests__/integration/installFromBackupBoot.test.js
@@ -32,7 +32,7 @@ jest.mock('../../src/services/restoreService', () => ({
   },
 }));
 
-jest.setTimeout(30000);
+jest.setTimeout(120000);
 
 describe('installFromBackupBoot', () => {
   let db;

--- a/backend/__tests__/integration/invoiceDunning.test.js
+++ b/backend/__tests__/integration/invoiceDunning.test.js
@@ -13,7 +13,7 @@ const { bootCrmDb, seedMinimal } = require('./helpers/crmDb');
 // bootCrmDb runs the full core-migration set in beforeAll; under full-suite
 // parallel load on a small CI runner that can exceed the 5s default. Match the
 // other migration-heavy CRM suites (discountLineItems, incomingInvoiceRebill).
-jest.setTimeout(30000);
+jest.setTimeout(120000);
 
 let db;
 let cleanup;

--- a/backend/__tests__/integration/picpeakExport.test.js
+++ b/backend/__tests__/integration/picpeakExport.test.js
@@ -21,7 +21,7 @@ beforeAll(async () => {
   ({ db, cleanup, tmpDir } = await bootCrmDb());
   process.env.STORAGE_PATH = tmpDir; // isolate file collection to the temp dir
   ({ createPicpeak } = require('../../src/services/picpeakExportService'));
-}, 60000);
+}, 120000);
 
 afterAll(async () => {
   await cleanup();

--- a/backend/__tests__/integration/picpeakRoundtrip.test.js
+++ b/backend/__tests__/integration/picpeakRoundtrip.test.js
@@ -28,7 +28,7 @@ beforeAll(async () => {
   ({ importFromPicpeak, validateManifest } = require('../../src/services/picpeakImportService'));
   const role = await db('roles').where({ name: 'super_admin' }).first();
   superAdminRoleId = role.id;
-}, 60000);
+}, 120000);
 
 afterAll(async () => {
   await cleanup();

--- a/backend/__tests__/integration/resetAdminMfaCli.test.js
+++ b/backend/__tests__/integration/resetAdminMfaCli.test.js
@@ -13,14 +13,14 @@ const { execFileSync } = require('child_process');
 
 const { bootCrmDb } = require('./helpers/crmDb');
 
-jest.setTimeout(60000);
+jest.setTimeout(120000);
 
 let db;
 let cleanup;
 
 beforeAll(async () => {
   ({ db, cleanup } = await bootCrmDb());
-}, 60000);
+}, 120000);
 
 afterAll(async () => {
   if (cleanup) await cleanup();

--- a/backend/__tests__/integration/setupService.test.js
+++ b/backend/__tests__/integration/setupService.test.js
@@ -27,7 +27,7 @@ beforeAll(async () => {
   setupService = require('../../src/services/setupService');
   ({ getAppSetting, upsertAppSetting } = require('../../src/utils/appSettings'));
   app = buildRouteApp('/api/setup', require('../../src/routes/setup'));
-}, 60000);
+}, 120000);
 
 afterAll(async () => {
   await cleanup();

--- a/backend/__tests__/integration/workflowEngine.test.js
+++ b/backend/__tests__/integration/workflowEngine.test.js
@@ -10,7 +10,7 @@ const { bootCrmDb } = require('./helpers/crmDb');
 // bootCrmDb runs the full core-migration set in beforeAll; under full-suite
 // parallel load on a small CI runner that can exceed the 5s default. Match the
 // other migration-heavy CRM suites (discountLineItems, incomingInvoiceRebill).
-jest.setTimeout(30000);
+jest.setTimeout(120000);
 
 let db;
 let cleanup;

--- a/backend/__tests__/integration/workflowRoutes.test.js
+++ b/backend/__tests__/integration/workflowRoutes.test.js
@@ -9,7 +9,7 @@ const {
 // bootCrmDb runs the full core-migration set in beforeAll; under full-suite
 // parallel load on a small CI runner that can exceed the 5s default. Match the
 // other migration-heavy CRM suites (discountLineItems, incomingInvoiceRebill).
-jest.setTimeout(30000);
+jest.setTimeout(120000);
 
 let db;
 let cleanup;

--- a/backend/__tests__/routes/adminCrmAuth.test.js
+++ b/backend/__tests__/routes/adminCrmAuth.test.js
@@ -83,7 +83,7 @@ describe('admin CRM routes — auth + permission gate', () => {
     // Invalid: signed with a different secret. adminAuth must reject.
     const jwt = require('jsonwebtoken');
     invalidToken = jwt.sign({ id: adminId, type: 'admin' }, 'WRONG-SECRET', { issuer: 'picpeak-auth' });
-  }, 60000);
+  }, 120000);
 
   afterAll(async () => {
     if (cleanup) await cleanup();

--- a/backend/__tests__/routes/adminMfa.test.js
+++ b/backend/__tests__/routes/adminMfa.test.js
@@ -39,7 +39,7 @@ const {
   bootCrmDb, mintAdminToken, buildRouteApp,
 } = require('../integration/helpers/crmDb');
 
-jest.setTimeout(60000);
+jest.setTimeout(120000);
 
 let db;
 let cleanup;
@@ -95,7 +95,7 @@ beforeAll(async () => {
   ({ db, cleanup } = await bootCrmDb());
   adminApp = buildRouteApp('/api/admin/auth', require('../../src/routes/adminAuth'));
   authApp = buildRouteApp('/api/auth', require('../../src/routes/auth'));
-}, 60000);
+}, 120000);
 
 afterAll(async () => {
   if (cleanup) await cleanup();

--- a/backend/__tests__/routes/publicContracts.test.js
+++ b/backend/__tests__/routes/publicContracts.test.js
@@ -51,7 +51,7 @@ describe('publicContracts routes', () => {
     contractId = inserted[0]?.id ?? inserted[0];
 
     app = buildRouteApp('/api/public/contracts', require('../../src/routes/publicContracts'));
-  }, 60000);
+  }, 120000);
 
   afterAll(async () => {
     if (cleanup) await cleanup();

--- a/backend/__tests__/routes/publicPaymentCheck.test.js
+++ b/backend/__tests__/routes/publicPaymentCheck.test.js
@@ -33,7 +33,7 @@ describe('publicPaymentCheck routes', () => {
     ({ db, cleanup } = await bootCrmDb());
     await seedMinimal(db);
     app = buildRouteApp('/api/public/payment-check', require('../../src/routes/publicPaymentCheck'));
-  }, 60000);
+  }, 120000);
 
   afterAll(async () => {
     if (cleanup) await cleanup();

--- a/backend/__tests__/routes/publicQuotes.test.js
+++ b/backend/__tests__/routes/publicQuotes.test.js
@@ -60,7 +60,7 @@ describe('publicQuotes routes', () => {
     quoteId = inserted[0]?.id ?? inserted[0];
 
     app = buildRouteApp('/api/public/quotes', require('../../src/routes/publicQuotes'));
-  }, 60000);
+  }, 120000);
 
   afterAll(async () => {
     if (cleanup) await cleanup();

--- a/backend/__tests__/routes/slideshowAdmin.test.js
+++ b/backend/__tests__/routes/slideshowAdmin.test.js
@@ -75,7 +75,7 @@ describe('admin Live Slideshow endpoints', () => {
     app.use((err, req, res, next) => {
       res.status(err.statusCode || err.status || 500).json({ error: err.message, code: err.code });
     });
-  }, 30000);
+  }, 120000);
 
   afterAll(async () => { await cleanup(); });
 

--- a/backend/__tests__/routes/slideshowPublic.test.js
+++ b/backend/__tests__/routes/slideshowPublic.test.js
@@ -67,11 +67,10 @@ async function insertEvent(db, over = {}) {
 describe('public Live Slideshow routes', () => {
   let db; let cleanup; let app;
 
-  // bootCrmDb runs the full migration set against a fresh SQLite file, which
-  // takes <2s locally but has been observed to exceed Jest's default 5s
-  // `beforeAll` timeout on slower GitHub Actions runners (~5.4s — runner-to-
-  // runner I/O variance). Raise the hook timeout so this doesn't intermittently
-  // block PRs on CI; doesn't affect happy-path local runs.
+  // bootCrmDb runs the full migration set against a fresh SQLite file and the
+  // chain keeps growing via backports. Hook-argument timeouts OVERRIDE the
+  // 120s jest.config default (same trap as the jest.setTimeout pins) — keep
+  // this at 120000, matching the config.
   beforeAll(async () => {
     ({ db, cleanup } = await bootCrmDb());
     await seedMinimal(db);
@@ -86,7 +85,7 @@ describe('public Live Slideshow routes', () => {
     app.use((err, req, res, next) => {
       res.status(err.statusCode || err.status || 500).json({ error: err.message, code: err.code });
     });
-  }, 30000);
+  }, 120000);
 
   afterAll(async () => { await cleanup(); });
 

--- a/backend/__tests__/services/backupIntegrityService.test.js
+++ b/backend/__tests__/services/backupIntegrityService.test.js
@@ -22,7 +22,7 @@ const crypto = require('crypto');
 
 const { bootCrmDb, seedMinimal } = require('../integration/helpers/crmDb');
 
-jest.setTimeout(30000);
+jest.setTimeout(120000);
 
 describe('backupIntegrityService.verifyDocumentArtefacts', () => {
   let db;

--- a/backend/__tests__/services/trackerFactory.test.js
+++ b/backend/__tests__/services/trackerFactory.test.js
@@ -27,7 +27,7 @@ let db; let cleanup;
 
 beforeAll(async () => {
   ({ db, cleanup } = await bootCrmDb());
-}, 30000);
+}, 120000);
 
 afterAll(async () => { if (cleanup) await cleanup(); });
 

--- a/backend/__tests__/services/userManagementService.activateDelete.test.js
+++ b/backend/__tests__/services/userManagementService.activateDelete.test.js
@@ -48,7 +48,7 @@ describe('userManagementService — activate + delete (#574 follow-up)', () => {
       is_active: 1, created_at: new Date(),
     }).returning('id');
     targetId = targetInsert[0]?.id ?? targetInsert[0];
-  }, 60000);
+  }, 120000);
 
   afterAll(async () => {
     if (cleanup) await cleanup();

--- a/backend/__tests__/utils/feedbackPerGuestLimit.test.js
+++ b/backend/__tests__/utils/feedbackPerGuestLimit.test.js
@@ -115,7 +115,7 @@ beforeAll(async () => {
     }).returning('id');
     photoIds.push(r[0]?.id ?? r[0]);
   }
-}, 30000);
+}, 120000);
 
 afterAll(async () => { if (cleanup) await cleanup(); });
 

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,5 +1,9 @@
 module.exports = {
   testEnvironment: 'node',
+  // bootCrmDb() runs EVERY core migration in beforeAll and the chain keeps
+  // growing (134 migrations and counting via backports). 120s matches the
+  // beta-branch convention from #860.
+  testTimeout: 120000,
   coverageDirectory: 'coverage',
   collectCoverageFrom: [
     'src/**/*.js',


### PR DESCRIPTION
Stable counterpart of #900 — and a fuller one, because stable never received #860 either.

## Why stable needs this

The Tests workflow runs on stable pushes and PRs, so `chore(stable)` release PRs hit the same backend Jest job that just blocked `3.97.0-beta.0` on the beta side. Stable's exposure is worse than main's was:

- `jest.config.js` on stable has **no `testTimeout`** — #860 never landed here, so anything unpinned still runs on Jest's 5s default.
- 19 suite-level `jest.setTimeout(30000/60000)` pins (the class #860 raised on the beta line).
- 15 hook-**argument** pins on migration-booting `beforeAll` hooks (the class #900 raised) — and stable's migration chain is 134 core migrations vs main's 142, so `bootCrmDb()` costs nearly the same there.

## The change

1. `jest.config.js`: `testTimeout: 120000` (mirrors main).
2. All 19 sub-120s `jest.setTimeout` pins → `120000`.
3. All 15 sub-120s hook-argument pins on `bootCrmDb`-booting `beforeAll` hooks → `120000`; stale comment in `slideshowPublic.test.js` updated.

Deliberately untouched (same scoping as #900): `webhookDelivery` / `imageProcessor.storage` / `storageBackend` (pinned hooks do non-migration setup) and `publicQuotes.test.js`'s 30s pin on the rate-limit lockout *test*.

No test logic changed anywhere.

## Verification

`slideshowPublic` + `feedbackPerGuestLimit` run green locally against the stable tree (27 tests). Full suite runs in CI on this PR.
