### PR TITLE
fix(analytics): make per-photo view/download counters actually count (#895) (stable)

### DIFF
--- a/backend/__tests__/routes/photoEngagementCounters.test.js
+++ b/backend/__tests__/routes/photoEngagementCounters.test.js
@@ -1,0 +1,237 @@
+/**
+ * Per-photo engagement counters (#895).
+ *
+ * Pins the contract that the admin EVENT > IMAGES table depends on:
+ *  - photos.view_count increments when the full-size photo is served
+ *    (it existed in the schema + admin UI but had NO writer at all)
+ *  - the slideshow kiosk never increments views (migration 138 design)
+ *  - single-photo downloads increment download_count (regression pin)
+ *  - zip downloads (download-all, download-selected) increment
+ *    download_count for the contained photos — previously they didn't,
+ *    so zip-heavy galleries showed 0 per-photo downloads forever
+ *  - the admin event-detail total_downloads counts singles AND zips
+ *    (it counted action='download' only, disagreeing with the dashboard)
+ */
+
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+process.env.NODE_ENV = 'test';
+process.env.TEST_DATABASE_PATH = path.join(
+  fs.mkdtempSync(path.join(os.tmpdir(), 'picpeak-engagement-')), 'db.sqlite',
+);
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'engagement-test-secret';
+// Real files on disk so /photo and the zip routes actually stream bytes.
+process.env.STORAGE_PATH = fs.mkdtempSync(path.join(os.tmpdir(), 'picpeak-engagement-storage-'));
+
+const request = require('supertest');
+const express = require('express');
+const cookieParser = require('cookie-parser');
+const bcrypt = require('bcrypt');
+const jwt = require('jsonwebtoken');
+
+const { bootCrmDb, seedMinimal } = require('../integration/helpers/crmDb');
+
+const SLUG = 'engagement-test-event';
+
+describe('photo engagement counters (#895)', () => {
+  let db;
+  let cleanup;
+  let app;
+  let eventId;
+  let photoIds;
+  let adminToken;
+
+  const galleryToken = (extra = {}) => jwt.sign(
+    { eventId, eventSlug: SLUG, type: 'gallery', ...extra },
+    process.env.JWT_SECRET,
+    { expiresIn: '1h', issuer: 'picpeak-auth' }
+  );
+
+  const getPhoto = async (id) => db('photos').where('id', id).first();
+  // The counter writes are fire-and-forget on purpose — give the event
+  // loop a beat before asserting.
+  const settle = () => new Promise((r) => setTimeout(r, 100));
+
+  beforeAll(async () => {
+    ({ db, cleanup } = await bootCrmDb());
+    await seedMinimal(db);
+
+    const inserted = await db('events').insert({
+      slug: SLUG,
+      event_type: 'wedding',
+      event_name: 'Engagement Test',
+      event_date: '2026-08-01',
+      host_email: 'host@example.com',
+      admin_email: 'admin@example.com',
+      password_hash: 'x',
+      share_link: `/gallery/${SLUG}/share`,
+      share_token: 'engagement-test-share',
+      expires_at: new Date(Date.now() + 7 * 24 * 3600 * 1000).toISOString(),
+      is_active: 1,
+      is_archived: 0,
+      is_draft: 0,
+      allow_downloads: 1,
+      created_at: new Date().toISOString(),
+    }).returning('id');
+    eventId = inserted[0]?.id ?? inserted[0];
+
+    const photoDir = path.join(process.env.STORAGE_PATH, 'events/active', SLUG);
+    fs.mkdirSync(photoDir, { recursive: true });
+
+    photoIds = [];
+    for (let i = 0; i < 3; i++) {
+      const filename = `photo-${i}.jpg`;
+      fs.writeFileSync(path.join(photoDir, filename), Buffer.from(`fake-jpeg-bytes-${i}`));
+      const p = await db('photos').insert({
+        event_id: eventId,
+        filename,
+        path: `${SLUG}/${filename}`,
+        type: 'individual',
+        uploaded_at: new Date().toISOString(),
+      }).returning('id');
+      photoIds.push(p[0]?.id ?? p[0]);
+    }
+
+    const superRole = await db('roles').where({ name: 'super_admin' }).first();
+    const [rootId] = await db('admin_users').insert({
+      username: 'engagement-admin',
+      email: 'engagement-admin@example.com',
+      password_hash: await bcrypt.hash('EngagementAdmin123', 4),
+      role_id: superRole.id,
+      is_active: 1,
+      created_at: new Date(),
+      updated_at: new Date(),
+    }).returning('id').then((r) => [r[0]?.id || r[0]]);
+    adminToken = jwt.sign(
+      { id: rootId, username: 'engagement-admin', type: 'admin', role: 'super_admin', loginTime: Date.now() },
+      process.env.JWT_SECRET,
+      { expiresIn: '1h', issuer: 'picpeak-auth' }
+    );
+
+    app = express();
+    app.use(express.json());
+    app.use(cookieParser());
+    app.use('/api/gallery', require('../../src/routes/gallery'));
+    app.use('/api/admin/events', require('../../src/routes/adminEvents'));
+  }, 120000);
+
+  afterAll(async () => {
+    if (cleanup) await cleanup();
+  });
+
+  beforeEach(async () => {
+    await db('photos').where('event_id', eventId).update({ view_count: 0, download_count: 0 });
+    await db('access_logs').where('event_id', eventId).del();
+  });
+
+  describe('view_count (#895 — previously never written)', () => {
+    it('increments when the full-size photo is served', async () => {
+      const res = await request(app)
+        .get(`/api/gallery/${SLUG}/photo/${photoIds[0]}`)
+        .set('Authorization', `Bearer ${galleryToken()}`);
+      expect(res.status).toBe(200);
+      await settle();
+      expect((await getPhoto(photoIds[0])).view_count).toBe(1);
+
+      await request(app)
+        .get(`/api/gallery/${SLUG}/photo/${photoIds[0]}`)
+        .set('Authorization', `Bearer ${galleryToken()}`);
+      await settle();
+      expect((await getPhoto(photoIds[0])).view_count).toBe(2);
+      // Other photos untouched
+      expect((await getPhoto(photoIds[1])).view_count).toBe(0);
+    });
+
+    it('does NOT count the slideshow kiosk (migration 138 design)', async () => {
+      const res = await request(app)
+        .get(`/api/gallery/${SLUG}/photo/${photoIds[0]}`)
+        .set('Authorization', `Bearer ${galleryToken({ accessLevel: 'slideshow' })}`);
+      expect(res.status).toBe(200);
+      await settle();
+      expect((await getPhoto(photoIds[0])).view_count).toBe(0);
+    });
+
+    it('does NOT count follow-up video Range requests (seeks are not views)', async () => {
+      await db('photos').where('id', photoIds[2]).update({ media_type: 'video', mime_type: 'video/mp4' });
+      try {
+        await request(app)
+          .get(`/api/gallery/${SLUG}/photo/${photoIds[2]}`)
+          .set('Authorization', `Bearer ${galleryToken()}`)
+          .set('Range', 'bytes=5-');
+        await settle();
+        expect((await getPhoto(photoIds[2])).view_count).toBe(0);
+
+        // The opening request (start of playback) does count.
+        await request(app)
+          .get(`/api/gallery/${SLUG}/photo/${photoIds[2]}`)
+          .set('Authorization', `Bearer ${galleryToken()}`)
+          .set('Range', 'bytes=0-');
+        await settle();
+        expect((await getPhoto(photoIds[2])).view_count).toBe(1);
+      } finally {
+        await db('photos').where('id', photoIds[2]).update({ media_type: null, mime_type: null });
+      }
+    });
+  });
+
+  describe('download_count', () => {
+    it('single-photo download increments (regression pin)', async () => {
+      const res = await request(app)
+        .get(`/api/gallery/${SLUG}/download/${photoIds[0]}`)
+        .set('Authorization', `Bearer ${galleryToken()}`);
+      expect(res.status).toBe(200);
+      await settle();
+      expect((await getPhoto(photoIds[0])).download_count).toBe(1);
+      expect((await getPhoto(photoIds[1])).download_count).toBe(0);
+    });
+
+    it('download-selected increments exactly the selected photos (#895)', async () => {
+      const res = await request(app)
+        .post(`/api/gallery/${SLUG}/download-selected`)
+        .set('Authorization', `Bearer ${galleryToken()}`)
+        .send({ photo_ids: [photoIds[0], photoIds[1]] });
+      expect(res.status).toBe(200);
+      await settle();
+      expect((await getPhoto(photoIds[0])).download_count).toBe(1);
+      expect((await getPhoto(photoIds[1])).download_count).toBe(1);
+      expect((await getPhoto(photoIds[2])).download_count).toBe(0);
+    });
+
+    it('download-all increments every downloadable photo (#895)', async () => {
+      const res = await request(app)
+        .get(`/api/gallery/${SLUG}/download-all`)
+        .set('Authorization', `Bearer ${galleryToken()}`);
+      expect(res.status).toBe(200);
+      await settle();
+      for (const id of photoIds) {
+        expect((await getPhoto(id)).download_count).toBe(1);
+      }
+    });
+  });
+
+  describe('admin event-detail total_downloads (#895 — one definition everywhere)', () => {
+    it('counts singles and every zip variant, one row each', async () => {
+      const row = (action) => ({
+        event_id: eventId,
+        ip_address: '127.0.0.1',
+        user_agent: 'jest',
+        action,
+      });
+      await db('access_logs').insert([
+        row('download'),
+        row('download_all'),
+        row('download_all_presigned'),
+        row('download_selected'),
+        row('view'), // not a download
+      ]);
+
+      const res = await request(app)
+        .get(`/api/admin/events/${eventId}`)
+        .set('Authorization', `Bearer ${adminToken}`);
+      expect(res.status).toBe(200);
+      expect(res.body.total_downloads).toBe(4);
+    });
+  });
+});

--- a/backend/__tests__/routes/photoEngagementCounters.test.js
+++ b/backend/__tests__/routes/photoEngagementCounters.test.js
@@ -126,53 +126,39 @@ describe('photo engagement counters (#895)', () => {
     await db('access_logs').where('event_id', eventId).del();
   });
 
-  describe('view_count (#895 — previously never written)', () => {
-    it('increments when the full-size photo is served', async () => {
-      const res = await request(app)
-        .get(`/api/gallery/${SLUG}/photo/${photoIds[0]}`)
-        .set('Authorization', `Bearer ${galleryToken()}`);
-      expect(res.status).toBe(200);
-      await settle();
+  describe('view_count via the view beacon (#895 — previously never written)', () => {
+    const beacon = (photoId, token = galleryToken()) => request(app)
+      .post(`/api/gallery/${SLUG}/photo/${photoId}/view`)
+      .set('Authorization', `Bearer ${token}`);
+
+    it('increments exactly the beaconed photo', async () => {
+      expect((await beacon(photoIds[0])).status).toBe(204);
       expect((await getPhoto(photoIds[0])).view_count).toBe(1);
 
-      await request(app)
-        .get(`/api/gallery/${SLUG}/photo/${photoIds[0]}`)
-        .set('Authorization', `Bearer ${galleryToken()}`);
-      await settle();
+      expect((await beacon(photoIds[0])).status).toBe(204);
       expect((await getPhoto(photoIds[0])).view_count).toBe(2);
       // Other photos untouched
       expect((await getPhoto(photoIds[1])).view_count).toBe(0);
     });
 
-    it('does NOT count the slideshow kiosk (migration 138 design)', async () => {
+    it('serving the image bytes does NOT count (preloads must not inflate)', async () => {
       const res = await request(app)
         .get(`/api/gallery/${SLUG}/photo/${photoIds[0]}`)
-        .set('Authorization', `Bearer ${galleryToken({ accessLevel: 'slideshow' })}`);
+        .set('Authorization', `Bearer ${galleryToken()}`);
       expect(res.status).toBe(200);
       await settle();
       expect((await getPhoto(photoIds[0])).view_count).toBe(0);
     });
 
-    it('does NOT count follow-up video Range requests (seeks are not views)', async () => {
-      await db('photos').where('id', photoIds[2]).update({ media_type: 'video', mime_type: 'video/mp4' });
-      try {
-        await request(app)
-          .get(`/api/gallery/${SLUG}/photo/${photoIds[2]}`)
-          .set('Authorization', `Bearer ${galleryToken()}`)
-          .set('Range', 'bytes=5-');
-        await settle();
-        expect((await getPhoto(photoIds[2])).view_count).toBe(0);
+    it('rejects the slideshow kiosk (migration 138 design)', async () => {
+      const res = await beacon(photoIds[0], galleryToken({ accessLevel: 'slideshow' }));
+      expect(res.status).toBeGreaterThanOrEqual(400);
+      expect((await getPhoto(photoIds[0])).view_count).toBe(0);
+    });
 
-        // The opening request (start of playback) does count.
-        await request(app)
-          .get(`/api/gallery/${SLUG}/photo/${photoIds[2]}`)
-          .set('Authorization', `Bearer ${galleryToken()}`)
-          .set('Range', 'bytes=0-');
-        await settle();
-        expect((await getPhoto(photoIds[2])).view_count).toBe(1);
-      } finally {
-        await db('photos').where('id', photoIds[2]).update({ media_type: null, mime_type: null });
-      }
+    it("404s a photo that isn't in the event", async () => {
+      const res = await beacon(999999);
+      expect(res.status).toBe(404);
     });
   });
 
@@ -208,6 +194,60 @@ describe('photo engagement counters (#895)', () => {
       for (const id of photoIds) {
         expect((await getPhoto(id)).download_count).toBe(1);
       }
+    });
+
+    it('skipped archive entries do not count (missing source file)', async () => {
+      // Own event so the on-the-fly archiver path is guaranteed — the
+      // main event may have a cached zip from the previous test's
+      // background generation, and racing its build/invalidate hangs.
+      const slug2 = `${SLUG}-skip`;
+      const ev = await db('events').insert({
+        slug: slug2,
+        event_type: 'wedding',
+        event_name: 'Engagement Skip Test',
+        event_date: '2026-08-01',
+        host_email: 'host@example.com',
+        admin_email: 'admin@example.com',
+        password_hash: 'x',
+        share_link: `/gallery/${slug2}/share`,
+        share_token: 'engagement-skip-share',
+        expires_at: new Date(Date.now() + 7 * 24 * 3600 * 1000).toISOString(),
+        is_active: 1,
+        is_archived: 0,
+        is_draft: 0,
+        allow_downloads: 1,
+        created_at: new Date().toISOString(),
+      }).returning('id');
+      const eventId2 = ev[0]?.id ?? ev[0];
+      const dir2 = path.join(process.env.STORAGE_PATH, 'events/active', slug2);
+      fs.mkdirSync(dir2, { recursive: true });
+      const ids2 = [];
+      for (let i = 0; i < 2; i++) {
+        // Only photo 0 gets a real file — photo 1's source is missing.
+        if (i === 0) fs.writeFileSync(path.join(dir2, `photo-${i}.jpg`), Buffer.from('skip-test-bytes'));
+        const p = await db('photos').insert({
+          event_id: eventId2,
+          filename: `photo-${i}.jpg`,
+          path: `${slug2}/photo-${i}.jpg`,
+          type: 'individual',
+          uploaded_at: new Date().toISOString(),
+        }).returning('id');
+        ids2.push(p[0]?.id ?? p[0]);
+      }
+      const token2 = jwt.sign(
+        { eventId: eventId2, eventSlug: slug2, type: 'gallery' },
+        process.env.JWT_SECRET,
+        { expiresIn: '1h', issuer: 'picpeak-auth' }
+      );
+
+      const res = await request(app)
+        .get(`/api/gallery/${slug2}/download-all`)
+        .set('Authorization', `Bearer ${token2}`);
+      expect(res.status).toBe(200);
+      await settle();
+      expect((await db('photos').where('id', ids2[0]).first()).download_count).toBe(1);
+      // photo-1's source was missing → skipped from the zip → not counted
+      expect((await db('photos').where('id', ids2[1]).first()).download_count).toBe(0);
     });
   });
 

--- a/backend/src/routes/adminDashboard.js
+++ b/backend/src/routes/adminDashboard.js
@@ -69,7 +69,7 @@ router.get('/stats', adminAuth, requirePermission('analytics.view'), async (req,
 
     // Get total downloads (last 30 days) - include both single and bulk downloads
     const totalDownloads = await db('access_logs')
-      .whereIn('action', ['download', 'download_all'])
+      .whereIn('action', ['download', 'download_all', 'download_all_presigned', 'download_selected'])
       .where('timestamp', '>=', thirtyDaysAgo.toISOString())
       .count('id as count')
       .first();
@@ -99,7 +99,7 @@ router.get('/stats', adminAuth, requirePermission('analytics.view'), async (req,
       .first();
 
     const previousDownloads = await db('access_logs')
-      .whereIn('action', ['download', 'download_all'])
+      .whereIn('action', ['download', 'download_all', 'download_all_presigned', 'download_selected'])
       .where('timestamp', '>=', sixtyDaysAgo.toISOString())
       .where('timestamp', '<', thirtyDaysAgo.toISOString())
       .count('id as count')
@@ -271,7 +271,7 @@ router.get('/analytics', adminAuth, requirePermission('analytics.view'), async (
     // Get downloads per day - include both single and bulk downloads
     const downloadsData = await db('access_logs')
       .select(db.raw('DATE(timestamp) as date'), db.raw('COUNT(*) as count'))
-      .whereIn('action', ['download', 'download_all'])
+      .whereIn('action', ['download', 'download_all', 'download_all_presigned', 'download_selected'])
       .where('timestamp', '>=', startDateStr)
       .groupByRaw('DATE(timestamp)');
 
@@ -307,7 +307,7 @@ router.get('/analytics', adminAuth, requirePermission('analytics.view'), async (
       .select('events.id', 'events.event_name', 'events.slug')
       .select(db.raw('COUNT(CASE WHEN action = \'view\' THEN 1 END) as views'))
       .select(db.raw('COUNT(DISTINCT CASE WHEN action = \'view\' THEN ip_address END) as uniqueVisitors'))
-      .select(db.raw('COUNT(CASE WHEN action IN (\'download\', \'download_all\') THEN 1 END) as downloads'))
+      .select(db.raw('COUNT(CASE WHEN action IN (\'download\', \'download_all\', \'download_all_presigned\', \'download_selected\') THEN 1 END) as downloads'))
       .join('events', 'access_logs.event_id', 'events.id')
       .where('access_logs.timestamp', '>=', startDateStr)
       .groupBy('events.id', 'events.event_name', 'events.slug')
@@ -377,7 +377,7 @@ router.get('/analytics', adminAuth, requirePermission('analytics.view'), async (
       .first();
 
     const totalDownloadsCount = await db('access_logs')
-      .whereIn('action', ['download', 'download_all'])
+      .whereIn('action', ['download', 'download_all', 'download_all_presigned', 'download_selected'])
       .where('timestamp', '>=', startDateStr)
       .count('id as count')
       .first();

--- a/backend/src/routes/adminEvents/crud.js
+++ b/backend/src/routes/adminEvents/crud.js
@@ -771,9 +771,11 @@ module.exports = (router) => {
         .where('action', 'view')
         .count('* as totalViews');
 
+      // One row per download event: singles AND zips (#895). Must stay in
+      // sync with adminDashboard's definition or the two surfaces disagree.
       const [{ totalDownloads }] = await db('access_logs')
         .where('event_id', id)
-        .where('action', 'download')
+        .whereIn('action', ['download', 'download_all', 'download_all_presigned', 'download_selected'])
         .count('* as totalDownloads');
 
       const [{ uniqueVisitors }] = await db('access_logs')

--- a/backend/src/routes/gallery.js
+++ b/backend/src/routes/gallery.js
@@ -933,6 +933,27 @@ router.get('/:slug/download/:photoId', verifyGalleryAccess, denySlideshowToken, 
 });
 
 // Download all photos as ZIP
+// Zip downloads count toward each contained photo's download_count (#895)
+// — previously only single-photo downloads did, so galleries whose guests
+// grab the zip showed 0 per-photo downloads forever. Uses the same
+// category allow_downloads filter the archive builders use; for the
+// pre-generated zip this mirrors its contents rather than reading them.
+// Fire-and-forget at the call sites: counters must never fail a download.
+async function bumpEventDownloadCounts(eventId) {
+  const ids = await db('photos')
+    .leftJoin('photo_categories', 'photos.category_id', 'photo_categories.id')
+    .where('photos.event_id', eventId)
+    .where(function () {
+      this.whereNull('photos.category_id')
+        .orWhere('photo_categories.allow_downloads', true)
+        .orWhereNull('photo_categories.allow_downloads');
+    })
+    .pluck('photos.id');
+  if (ids.length > 0) {
+    await db('photos').whereIn('id', ids).increment('download_count', 1);
+  }
+}
+
 router.get('/:slug/download-all', verifyGalleryAccess, denySlideshowToken, async (req, res) => {
   try {
     // Check if downloads are allowed for this event
@@ -962,6 +983,7 @@ router.get('/:slug/download-all', verifyGalleryAccess, denySlideshowToken, async
             user_agent: req.headers['user-agent'],
             action: 'download_all_presigned'
           }).catch(() => {});
+          bumpEventDownloadCounts(req.event.id).catch(() => {});
           res.redirect(302, url);
           return;
         } catch (err) {
@@ -985,6 +1007,7 @@ router.get('/:slug/download-all', verifyGalleryAccess, denySlideshowToken, async
         user_agent: req.headers['user-agent'],
         action: 'download_all'
       }).catch(() => {});
+      bumpEventDownloadCounts(req.event.id).catch(() => {});
       return;
     }
 
@@ -1098,6 +1121,9 @@ router.get('/:slug/download-all', verifyGalleryAccess, denySlideshowToken, async
       user_agent: req.headers['user-agent'],
       action: 'download_all'
     });
+    // Exactly the photos streamed into this archive (#895).
+    db('photos').whereIn('id', photos.map((p) => p.id))
+      .increment('download_count', 1).catch(() => {});
   } catch (error) {
     errorResponse(res, error, 500, 'Failed to create download archive');
   }
@@ -1215,6 +1241,9 @@ router.post('/:slug/download-selected', verifyGalleryAccess, denySlideshowToken,
       user_agent: req.headers['user-agent'],
       action: 'download_selected'
     });
+    // Exactly the validated photos that went into this archive (#895).
+    db('photos').whereIn('id', photos.map((p) => p.id))
+      .increment('download_count', 1).catch(() => {});
   } catch (error) {
     errorResponse(res, error, 500, 'Failed to download selected photos');
   }
@@ -1254,6 +1283,19 @@ router.get('/:slug/photo/:photoId',
           secureEndpoint: `/api/secure-images/${req.params.slug}/generate-token`,
           photoId: photoId
         });
+      }
+
+      // Per-photo view counter (#895) — photos.view_count existed in the
+      // schema and the admin UI but nothing ever incremented it. Fire-and-
+      // forget: analytics must never block or fail the byte-serving path.
+      // Skipped for the slideshow kiosk (excluded from visitor analytics —
+      // migration 138 design) and for follow-up video Range requests
+      // (every seek would otherwise count as another view).
+      if (
+        req.accessLevel !== 'slideshow' &&
+        (!isVideo || !req.headers.range || req.headers.range.startsWith('bytes=0-'))
+      ) {
+        db('photos').where('id', photoId).increment('view_count', 1).catch(() => {});
       }
 
       // Resolve where to read the photo bytes from. For external/reference
@@ -1686,6 +1728,18 @@ router.get('/:slug/preview/:photoId',
           slug: req.params.slug, photoId, eventId: req.event.id, previewPath,
         });
         return res.redirect(`/api/gallery/${req.params.slug}/photo/${photoId}`);
+      }
+
+      // Per-photo view counter (#895). The lightbox fetches this tier when
+      // the admin enabled previews (#492), so it has to count here too —
+      // otherwise enabling previews would silently stop view tracking.
+      // Before the ETag check on purpose: a 304 revalidation is still a
+      // guest looking at the photo. The redirect fallbacks above don't
+      // count — the /photo route they land on does. The slideshow kiosk
+      // prefers preview_url and loops forever, so it's excluded here just
+      // like in /photo (migration 138 design).
+      if (req.accessLevel !== 'slideshow') {
+        db('photos').where('id', photoId).increment('view_count', 1).catch(() => {});
       }
 
       const mtimeMs = stat.mtime ? stat.mtime.getTime() : 0;

--- a/backend/src/routes/gallery.js
+++ b/backend/src/routes/gallery.js
@@ -935,23 +935,15 @@ router.get('/:slug/download/:photoId', verifyGalleryAccess, denySlideshowToken, 
 // Download all photos as ZIP
 // Zip downloads count toward each contained photo's download_count (#895)
 // — previously only single-photo downloads did, so galleries whose guests
-// grab the zip showed 0 per-photo downloads forever. Uses the same
-// category allow_downloads filter the archive builders use; for the
-// pre-generated zip this mirrors its contents rather than reading them.
-// Fire-and-forget at the call sites: counters must never fail a download.
+// grab the zip showed 0 per-photo downloads forever. Used by the
+// pre-generated-zip branches only: it mirrors downloadZipService._build,
+// which zips EVERY event photo with no per-category allow_downloads
+// filter — the counter has to reflect what actually shipped. (That the
+// prebuilt zip ignores per-category download opt-outs is a separate,
+// pre-existing issue.) Fire-and-forget at the call sites: counters must
+// never fail a download.
 async function bumpEventDownloadCounts(eventId) {
-  const ids = await db('photos')
-    .leftJoin('photo_categories', 'photos.category_id', 'photo_categories.id')
-    .where('photos.event_id', eventId)
-    .where(function () {
-      this.whereNull('photos.category_id')
-        .orWhere('photo_categories.allow_downloads', true)
-        .orWhereNull('photo_categories.allow_downloads');
-    })
-    .pluck('photos.id');
-  if (ids.length > 0) {
-    await db('photos').whereIn('id', ids).increment('download_count', 1);
-  }
+  await db('photos').where('event_id', eventId).increment('download_count', 1);
 }
 
 router.get('/:slug/download-all', verifyGalleryAccess, denySlideshowToken, async (req, res) => {
@@ -1067,6 +1059,10 @@ router.get('/:slug/download-all', verifyGalleryAccess, denySlideshowToken, async
     // get a deterministic `_1` suffix before the entries hit the archive.
     const useOriginalBulk = await getUseOriginalFilenames();
     const bulkEntryNames = getZipEntryNames(photos, useOriginalBulk);
+    // Only photos whose append succeeded count as downloaded (#895) — the
+    // catch below deliberately skips missing/corrupt sources, and those
+    // never make it into the archive.
+    const appendedIds = [];
     for (let i = 0; i < photos.length; i += 1) {
       const photo = photos[i];
       const storageKey = resolvePhotoStorageKey(req.event, photo);
@@ -1080,6 +1076,21 @@ router.get('/:slug/download-all', verifyGalleryAccess, denySlideshowToken, async
       }
 
       try {
+        // Verify the source exists BEFORE appending: storage.get() hands
+        // archiver a lazy stream whose error fires outside this try/catch
+        // — the archive 'error' handler then kills the whole response
+        // instead of skipping one photo (#895 review). stat/existsSync
+        // fail synchronously, so a missing source is skipped cleanly and
+        // never counted.
+        if (storageKey) {
+          const srcStat = await storage.stat(storageKey);
+          if (!srcStat) {
+            throw new Error(`Photo missing in storage: ${storageKey}`);
+          }
+        } else if (!fs.existsSync(resolvePhotoFilePath(req.event, photo))) {
+          throw new Error('Photo file missing on disk');
+        }
+
         if (shouldApplyWatermark && effectiveSettings) {
           // Watermark service operates on a local path. For managed photos in
           // S3 mode, materialize a tmp local copy first.
@@ -1099,9 +1110,9 @@ router.get('/:slug/download-all', verifyGalleryAccess, denySlideshowToken, async
           const stream = await storage.get(storageKey);
           archive.append(stream, { name: archiveName });
         } else {
-          const filePath = resolvePhotoFilePath(req.event, photo);
-          archive.file(filePath, { name: archiveName });
+          archive.file(resolvePhotoFilePath(req.event, photo), { name: archiveName });
         }
+        appendedIds.push(photo.id);
       } catch (err) {
         logger.warn('Skipping photo in bulk download due to error', {
           slug: req.params.slug,
@@ -1121,9 +1132,12 @@ router.get('/:slug/download-all', verifyGalleryAccess, denySlideshowToken, async
       user_agent: req.headers['user-agent'],
       action: 'download_all'
     });
-    // Exactly the photos streamed into this archive (#895).
-    db('photos').whereIn('id', photos.map((p) => p.id))
-      .increment('download_count', 1).catch(() => {});
+    // Exactly the photos that made it into this archive (#895) — skipped
+    // (missing/corrupt) sources don't count.
+    if (appendedIds.length > 0) {
+      db('photos').whereIn('id', appendedIds)
+        .increment('download_count', 1).catch(() => {});
+    }
   } catch (error) {
     errorResponse(res, error, 500, 'Failed to create download archive');
   }
@@ -1205,11 +1219,25 @@ router.post('/:slug/download-selected', verifyGalleryAccess, denySlideshowToken,
     // #493: same display-name resolution as bulk download, with dedup.
     const useOriginalSelected = await getUseOriginalFilenames();
     const selectedEntryNames = getZipEntryNames(photos, useOriginalSelected);
+    // Only photos whose append succeeded count as downloaded (#895).
+    const appendedIds = [];
     for (let i = 0; i < photos.length; i += 1) {
       const photo = photos[i];
       const name = selectedEntryNames[i] || `photo-${photo.id}.jpg`;
       const storageKey = resolveSelectedKey(req.event, photo);
       try {
+        // Same pre-append source check as download-all (#895 review):
+        // a lazy stream's async error would kill the response instead of
+        // skipping the photo, and a skipped photo must not be counted.
+        if (storageKey) {
+          const srcStat = await selectedStorage.stat(storageKey);
+          if (!srcStat) {
+            throw new Error(`Photo missing in storage: ${storageKey}`);
+          }
+        } else if (!fs.existsSync(resolvePhotoFilePath(req.event, photo))) {
+          throw new Error('Photo file missing on disk');
+        }
+
         if (shouldApplyWatermark && effectiveSettings) {
           const buf = storageKey
             ? await withSelectedLocalCopy(storageKey, (lp) =>
@@ -1223,6 +1251,7 @@ router.post('/:slug/download-selected', verifyGalleryAccess, denySlideshowToken,
         } else {
           archive.file(resolvePhotoFilePath(req.event, photo), { name });
         }
+        appendedIds.push(photo.id);
       } catch (err) {
         logger.warn('Skipping selected photo due to error', {
           slug: req.params.slug,
@@ -1241,14 +1270,49 @@ router.post('/:slug/download-selected', verifyGalleryAccess, denySlideshowToken,
       user_agent: req.headers['user-agent'],
       action: 'download_selected'
     });
-    // Exactly the validated photos that went into this archive (#895).
-    db('photos').whereIn('id', photos.map((p) => p.id))
-      .increment('download_count', 1).catch(() => {});
+    // Exactly the photos that made it into this archive (#895) — skipped
+    // (missing/corrupt) sources don't count.
+    if (appendedIds.length > 0) {
+      db('photos').whereIn('id', appendedIds)
+        .increment('download_count', 1).catch(() => {});
+    }
   } catch (error) {
     errorResponse(res, error, 500, 'Failed to download selected photos');
   }
 });
 
+
+// Explicit per-photo view beacon (#895). Counting views on the image-
+// serving routes is wrong in both directions: the lightbox preloads the
+// prev/next neighbours (three fetches per open), while a preloaded
+// neighbour that becomes the current slide is never re-fetched (#505
+// keeps the DOM node alive across the swipe) — so request-level counters
+// overcount preloads AND undercount swipe-throughs. Instead the lightbox
+// pings this endpoint exactly when a photo becomes the visible slide.
+// This also covers enhanced/maximum-protection galleries, whose bytes
+// are served by /api/secure-images and never pass the routes below.
+// The slideshow kiosk is excluded (denySlideshowToken; migration 138).
+router.post('/:slug/photo/:photoId/view',
+  verifyGalleryAccess,
+  denySlideshowToken,
+  blockHiddenGallery,
+  async (req, res) => {
+    try {
+      const photo = await db('photos')
+        .where({ id: req.params.photoId, event_id: req.event.id })
+        .first('id', 'visibility');
+      if (!photo) {
+        return res.status(404).json({ error: 'Photo not found' });
+      }
+      if (photo.visibility === 'hidden' && req.accessLevel !== 'client') {
+        return res.status(403).json({ error: 'Photo not available' });
+      }
+      await db('photos').where('id', photo.id).increment('view_count', 1);
+      res.status(204).end();
+    } catch (error) {
+      errorResponse(res, error, 500, 'Failed to record view');
+    }
+  });
 
 // View single photo (with watermark if enabled)
 router.get('/:slug/photo/:photoId',
@@ -1283,19 +1347,6 @@ router.get('/:slug/photo/:photoId',
           secureEndpoint: `/api/secure-images/${req.params.slug}/generate-token`,
           photoId: photoId
         });
-      }
-
-      // Per-photo view counter (#895) — photos.view_count existed in the
-      // schema and the admin UI but nothing ever incremented it. Fire-and-
-      // forget: analytics must never block or fail the byte-serving path.
-      // Skipped for the slideshow kiosk (excluded from visitor analytics —
-      // migration 138 design) and for follow-up video Range requests
-      // (every seek would otherwise count as another view).
-      if (
-        req.accessLevel !== 'slideshow' &&
-        (!isVideo || !req.headers.range || req.headers.range.startsWith('bytes=0-'))
-      ) {
-        db('photos').where('id', photoId).increment('view_count', 1).catch(() => {});
       }
 
       // Resolve where to read the photo bytes from. For external/reference
@@ -1728,18 +1779,6 @@ router.get('/:slug/preview/:photoId',
           slug: req.params.slug, photoId, eventId: req.event.id, previewPath,
         });
         return res.redirect(`/api/gallery/${req.params.slug}/photo/${photoId}`);
-      }
-
-      // Per-photo view counter (#895). The lightbox fetches this tier when
-      // the admin enabled previews (#492), so it has to count here too —
-      // otherwise enabling previews would silently stop view tracking.
-      // Before the ETag check on purpose: a 304 revalidation is still a
-      // guest looking at the photo. The redirect fallbacks above don't
-      // count — the /photo route they land on does. The slideshow kiosk
-      // prefers preview_url and loops forever, so it's excluded here just
-      // like in /photo (migration 138 design).
-      if (req.accessLevel !== 'slideshow') {
-        db('photos').where('id', photoId).increment('view_count', 1).catch(() => {});
       }
 
       const mtimeMs = stat.mtime ? stat.mtime.getTime() : 0;

--- a/backend/src/routes/gallery.js
+++ b/backend/src/routes/gallery.js
@@ -940,7 +940,10 @@ router.get('/:slug/download/:photoId', verifyGalleryAccess, denySlideshowToken, 
 // which zips EVERY event photo with no per-category allow_downloads
 // filter — the counter has to reflect what actually shipped. (That the
 // prebuilt zip ignores per-category download opt-outs is a separate,
-// pre-existing issue.) Fire-and-forget at the call sites: counters must
+// pre-existing issue.) Known approximation: _build skips entries whose
+// WATERMARK step fails and still publishes the zip; counting those
+// would need a persisted archive manifest, which isn't worth it for
+// that tail case. Fire-and-forget at the call sites: counters must
 // never fail a download.
 async function bumpEventDownloadCounts(eventId) {
   await db('photos').where('event_id', eventId).increment('download_count', 1);
@@ -1295,7 +1298,6 @@ router.post('/:slug/download-selected', verifyGalleryAccess, denySlideshowToken,
 router.post('/:slug/photo/:photoId/view',
   verifyGalleryAccess,
   denySlideshowToken,
-  blockHiddenGallery,
   async (req, res) => {
     try {
       const photo = await db('photos')

--- a/backend/src/routes/gallery.js
+++ b/backend/src/routes/gallery.js
@@ -1079,18 +1079,19 @@ router.get('/:slug/download-all', verifyGalleryAccess, denySlideshowToken, async
       }
 
       try {
-        // Verify the source exists BEFORE appending: storage.get() hands
-        // archiver a lazy stream whose error fires outside this try/catch
-        // — the archive 'error' handler then kills the whole response
-        // instead of skipping one photo (#895 review). stat/existsSync
-        // fail synchronously, so a missing source is skipped cleanly and
-        // never counted.
-        if (storageKey) {
+        // Verify the source exists BEFORE appending — but only for local
+        // sources: fs.createReadStream is lazy, so its error fires outside
+        // this try/catch and the archive 'error' handler then kills the
+        // whole response instead of skipping one photo (#895 review). S3's
+        // get() awaits GetObject and rejects right here on a missing key,
+        // so a preflight HEAD per entry would just be a redundant serial
+        // round trip (500-photo zip = 500 extra HEADs).
+        if (storageKey && storage.kind() === 'local') {
           const srcStat = await storage.stat(storageKey);
           if (!srcStat) {
             throw new Error(`Photo missing in storage: ${storageKey}`);
           }
-        } else if (!fs.existsSync(resolvePhotoFilePath(req.event, photo))) {
+        } else if (!storageKey && !fs.existsSync(resolvePhotoFilePath(req.event, photo))) {
           throw new Error('Photo file missing on disk');
         }
 
@@ -1229,15 +1230,16 @@ router.post('/:slug/download-selected', verifyGalleryAccess, denySlideshowToken,
       const name = selectedEntryNames[i] || `photo-${photo.id}.jpg`;
       const storageKey = resolveSelectedKey(req.event, photo);
       try {
-        // Same pre-append source check as download-all (#895 review):
-        // a lazy stream's async error would kill the response instead of
-        // skipping the photo, and a skipped photo must not be counted.
-        if (storageKey) {
+        // Same pre-append source check as download-all (#895 review),
+        // local backend only: a lazy fs stream's async error would kill
+        // the response instead of skipping the photo; S3's get() rejects
+        // at the await below, so no redundant per-entry HEAD there.
+        if (storageKey && selectedStorage.kind() === 'local') {
           const srcStat = await selectedStorage.stat(storageKey);
           if (!srcStat) {
             throw new Error(`Photo missing in storage: ${storageKey}`);
           }
-        } else if (!fs.existsSync(resolvePhotoFilePath(req.event, photo))) {
+        } else if (!storageKey && !fs.existsSync(resolvePhotoFilePath(req.event, photo))) {
           throw new Error('Photo file missing on disk');
         }
 

--- a/frontend/src/components/gallery/PhotoLightbox.tsx
+++ b/frontend/src/components/gallery/PhotoLightbox.tsx
@@ -6,6 +6,7 @@ import { useSavePhotoToDevice } from '../../hooks/useGallery';
 import { AuthenticatedImage } from '../common';
 import { PhotoFeedback } from './PhotoFeedback';
 import { feedbackService } from '../../services/feedback.service';
+import { galleryService } from '../../services/gallery.service';
 import { FeedbackIdentityModal } from './FeedbackIdentityModal';
 import { VideoPlayer } from './VideoPlayer';
 import { useGuestIdentityOptional } from '../../contexts/GuestIdentityContext';
@@ -101,6 +102,17 @@ export const PhotoLightbox: React.FC<PhotoLightboxProps> = ({
     window.addEventListener('resize', onResize);
     return () => window.removeEventListener('resize', onResize);
   }, []);
+
+  // View beacon (#895): count exactly the photo that became the visible
+  // slide. The image fetches themselves can't be counted — preloaded
+  // neighbours would inflate, and a neighbour promoted by a swipe is
+  // never re-fetched (#505).
+  const currentPhotoId = photos[currentIndex]?.id;
+  useEffect(() => {
+    if (currentPhotoId !== undefined) {
+      galleryService.trackPhotoView(slug, currentPhotoId);
+    }
+  }, [slug, currentPhotoId]);
 
 
   // Save-aware download. On mobile (where Web Share + files is supported)

--- a/frontend/src/components/gallery/layouts/GalleryPremiumLayout.tsx
+++ b/frontend/src/components/gallery/layouts/GalleryPremiumLayout.tsx
@@ -563,6 +563,14 @@ export const GalleryPremiumLayout: React.FC<GalleryPremiumLayoutProps> = ({
         close={() => setLightboxIndex(-1)}
         index={lightboxIndex}
         slides={slides}
+        // View beacon (#895): yarl fires `view` on open and on every
+        // slide change — same semantics as PhotoLightbox's beacon.
+        on={{
+          view: ({ index }) => {
+            const photo = filteredPhotos[index];
+            if (photo) galleryService.trackPhotoView(slug, photo.id);
+          },
+        }}
         plugins={[
           Thumbnails,
           Zoom,

--- a/frontend/src/services/gallery.service.ts
+++ b/frontend/src/services/gallery.service.ts
@@ -198,6 +198,15 @@ export const galleryService = {
     this.triggerBrowserDownload(fetched.blob, fetched.serverFilename || filename);
   },
 
+  // Per-photo view beacon (#895). Fired by the lightbox when a photo
+  // becomes the visible slide — request-level counting on the image
+  // endpoints can't tell the current slide from its preloaded
+  // neighbours. Fire-and-forget: view counting must never surface an
+  // error to the guest.
+  trackPhotoView(slug: string, photoId: number): void {
+    api.post(`/gallery/${slug}/photo/${photoId}/view`).catch(() => {});
+  },
+
   // Download all photos as ZIP
   // When a pre-generated zip is available, use native browser download (Content-Length → progress bar).
   // Otherwise fall back to blob download.


### PR DESCRIPTION
Stable port of #904 (issue #895).

## Root causes (three stacked defects)

1. **`photos.view_count` had no writer** — the column exists since the base schema and the admin IMAGES table + photo viewer display it, but no code path ever incremented it. Matches the reporter's observation that no per-photo tracking request fires: there was none.
2. **Zip downloads never counted per-photo** — only `GET /download/:photoId` incremented `download_count`, so zip-heavy galleries showed 0 per-photo downloads forever.
3. **Every admin surface had its own definition of "downloads"** (the reporter's 46 ≠ 45 ≠ 0): event details counted `action='download'` only; the dashboard counted `download`+`download_all` but silently excluded `download_selected` and `download_all_presigned`.

## The fix

**Views — explicit beacon, not serving-route counters.** `POST /:slug/photo/:photoId/view`, fired by the lightbox exactly when a photo becomes the visible slide (`PhotoLightbox` effect on the current index; `GalleryPremiumLayout` via yarl's `on.view`). Counting on the image routes was rejected during review because it's wrong in both directions: the lightbox preloads prev/next neighbours (3 fetches per open), while a preloaded neighbour promoted by a swipe is never re-fetched (#505 keeps the DOM node) — and enhanced/maximum galleries never hit `/photo` at all (bytes come from `/api/secure-images`). The beacon is layout- and protection-agnostic. Slideshow kiosk excluded (`denySlideshowToken`, migration-138 design). Known gap: the story layout has no "current photo" notion and doesn't beacon yet.

**Downloads — count what actually shipped.**
- `download-selected` / on-the-fly `download-all`: increment exactly the successfully appended entries (`appendedIds`), with a pre-append `stat`/`existsSync` on the **local** backend only — LocalFs streams are lazy and their async error used to kill the whole zip response instead of skipping one photo (pre-existing hang, now fixed). S3's `get()` rejects inside the loop's try/catch, so no redundant per-entry HEAD there.
- Prebuilt-zip branches (streamed + S3-presigned): `bumpEventDownloadCounts()` mirrors `downloadZipService._build` (ALL event photos). Documented approximation: `_build` can skip entries whose watermark step fails and still publish; exact counting there would need a persisted zip manifest. That the prebuilt zip ignores per-category `allow_downloads` is a separate pre-existing issue.

**One "downloads" definition everywhere**: all five admin queries now count `download, download_all, download_all_presigned, download_selected` — a zip stays one download at event level while per-photo counters reflect its contents.

## Review

3 rounds of external (Codex) review drove the design: round 1 killed the serving-route counters (preload overcount, secure-route gap, count-before-validation), round 2 added the premium-layout beacon, round 3 removed the redundant S3 preflight.

## Tests

`__tests__/routes/photoEngagementCounters.test.js` — 9 tests with real files on disk: beacon semantics (increment, repeat, wrong-event 404, slideshow rejection), serving-the-bytes-does-NOT-count, single-download regression pin, selected/all zip increments, skipped-archive-entry exclusion, and the unified event-detail `total_downloads`. Adjacent gallery suites stay green.

## Notes

- Historic data is not backfilled: `view_count` starts counting at deploy; past zips can't be attributed per-photo retroactively.
- This IS the stable port: same commits cherry-picked; stable has no blockHiddenGallery (reveal mode is beta-only), and its PhotoLightbox predates the beta quick-win changes, so the beacon effect anchors differently.
