### PR TITLE
fix(admin): serve videos with their real MIME type in the admin photo view (#908) (stable)

### DIFF
--- a/backend/__tests__/routes/adminPhotoContentType.test.js
+++ b/backend/__tests__/routes/adminPhotoContentType.test.js
@@ -6,11 +6,15 @@
  * URL into a blob whose type inherits the header, and browsers refuse to
  * play a <video> blob labeled image/* — blank/grey admin video preview.
  *
- * Pins:
- *  - stored photos.mime_type wins (video/mp4 for videos)
- *  - videos without a stored mime_type still get video/mp4
- *  - images without a stored mime_type fall back to the extension
- *  - extensionless files get image/jpeg, never the invalid bare `image/`
+ * Pins (incl. external-review hardening):
+ *  - the header is ALWAYS image/* or video/*: a stored non-media MIME
+ *    (chunked uploads store the client-sent type unvalidated) is never
+ *    echoed — text/html inline under the app origin would be XSS
+ *  - stored video/ MIME wins; MIME-less videos map from the extension
+ *    (.mov → video/quicktime), unknown video extensions get video/mp4
+ *  - images IGNORE the stored MIME (migration 039 backfilled image/jpeg
+ *    onto every legacy row, PNGs included) and use the extension,
+ *    normalized (jpg → image/jpeg); extensionless files get image/jpeg
  */
 
 const path = require('path');
@@ -111,11 +115,39 @@ describe('admin photo view Content-Type (#908)', () => {
     expect(res.headers['content-type']).toBe('video/mp4');
   });
 
-  it('falls back to video/mp4 for a video row without a stored mime_type', async () => {
+  it('maps MIME-less videos from their extension (.mov → video/quicktime)', async () => {
     const id = await addPhoto('clip-nomime.mov', { media_type: 'video' });
     const res = await getPhotoRes(id);
     expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toBe('video/quicktime');
+  });
+
+  it('falls back to video/mp4 for a video with an unknown extension', async () => {
+    const id = await addPhoto('clip-unknown.xyz', { media_type: 'video' });
+    const res = await getPhotoRes(id);
+    expect(res.status).toBe(200);
     expect(res.headers['content-type']).toBe('video/mp4');
+  });
+
+  it('never echoes a stored non-media MIME type (inline XSS guard)', async () => {
+    const id = await addPhoto('evil.png', { mime_type: 'text/html' });
+    const res = await getPhotoRes(id);
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toBe('image/png');
+  });
+
+  it('ignores the migration-039 image/jpeg backfill on legacy PNG rows', async () => {
+    const id = await addPhoto('legacy.png', { mime_type: 'image/jpeg' });
+    const res = await getPhotoRes(id);
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toBe('image/png');
+  });
+
+  it('normalizes jpg to the canonical image/jpeg', async () => {
+    const id = await addPhoto('shot.jpg');
+    const res = await getPhotoRes(id);
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toBe('image/jpeg');
   });
 
   it('keeps the extension fallback for images without a stored mime_type', async () => {

--- a/backend/__tests__/routes/adminPhotoContentType.test.js
+++ b/backend/__tests__/routes/adminPhotoContentType.test.js
@@ -147,6 +147,23 @@ describe('admin photo view Content-Type (#908)', () => {
     expect(res2.headers['content-type']).toBe('video/webm');
   });
 
+  it('preserves an auto-imported avif via the safe stored-MIME allowlist', async () => {
+    // .avif isn't in EXTENSION_TO_MIME; s3AutoImporter stores image/avif.
+    // Map-only would mislabel it image/jpeg — the allowlist keeps it.
+    const id = await addPhoto('imported.avif', { mime_type: 'image/avif' });
+    const res = await getPhotoRes(id);
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toBe('image/avif');
+  });
+
+  it('does NOT honor a stored scriptable image type (image/svg+xml)', async () => {
+    // svg is inline-scriptable and must never be echoed — allowlist excludes it.
+    const id = await addPhoto('vector.svg', { mime_type: 'image/svg+xml' });
+    const res = await getPhotoRes(id);
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toBe('image/jpeg');
+  });
+
   it('never echoes a stored non-media MIME type (inline XSS guard)', async () => {
     const id = await addPhoto('evil.png', { mime_type: 'text/html' });
     const res = await getPhotoRes(id);

--- a/backend/__tests__/routes/adminPhotoContentType.test.js
+++ b/backend/__tests__/routes/adminPhotoContentType.test.js
@@ -129,6 +129,24 @@ describe('admin photo view Content-Type (#908)', () => {
     expect(res.headers['content-type']).toBe('video/mp4');
   });
 
+  it('rejects malformed video/ MIME values that would break setHeader', async () => {
+    // Header-invalid chars in the stored value must not 500 the route —
+    // fall back to the extension map instead.
+    const id = await addPhoto('crlf.mp4', {
+      media_type: 'video',
+      mime_type: 'video/mp4\r\nX-Evil: 1',
+    });
+    const res = await getPhotoRes(id);
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toBe('video/mp4');
+    expect(res.headers['x-evil']).toBeUndefined();
+
+    const bare = await addPhoto('bare.webm', { media_type: 'video', mime_type: 'video/' });
+    const res2 = await getPhotoRes(bare);
+    expect(res2.status).toBe(200);
+    expect(res2.headers['content-type']).toBe('video/webm');
+  });
+
   it('never echoes a stored non-media MIME type (inline XSS guard)', async () => {
     const id = await addPhoto('evil.png', { mime_type: 'text/html' });
     const res = await getPhotoRes(id);

--- a/backend/__tests__/routes/adminPhotoContentType.test.js
+++ b/backend/__tests__/routes/adminPhotoContentType.test.js
@@ -1,0 +1,134 @@
+/**
+ * Admin photo view route Content-Type (#908).
+ *
+ * The route built `image/<ext>` from the filename, producing invalid
+ * types like image/mp4 for videos. AdminAuthenticatedVideo fetches this
+ * URL into a blob whose type inherits the header, and browsers refuse to
+ * play a <video> blob labeled image/* — blank/grey admin video preview.
+ *
+ * Pins:
+ *  - stored photos.mime_type wins (video/mp4 for videos)
+ *  - videos without a stored mime_type still get video/mp4
+ *  - images without a stored mime_type fall back to the extension
+ *  - extensionless files get image/jpeg, never the invalid bare `image/`
+ */
+
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+process.env.NODE_ENV = 'test';
+process.env.TEST_DATABASE_PATH = path.join(
+  fs.mkdtempSync(path.join(os.tmpdir(), 'picpeak-admin-ct-')), 'db.sqlite',
+);
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'admin-ct-test-secret';
+process.env.STORAGE_PATH = fs.mkdtempSync(path.join(os.tmpdir(), 'picpeak-admin-ct-storage-'));
+
+const request = require('supertest');
+const express = require('express');
+const bcrypt = require('bcrypt');
+const jwt = require('jsonwebtoken');
+
+const { bootCrmDb, seedMinimal } = require('../integration/helpers/crmDb');
+
+const SLUG = 'admin-ct-test-event';
+
+describe('admin photo view Content-Type (#908)', () => {
+  let db;
+  let cleanup;
+  let app;
+  let eventId;
+  let adminToken;
+
+  const addPhoto = async (filename, extra = {}) => {
+    const dir = path.join(process.env.STORAGE_PATH, 'events/active', SLUG);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, filename), Buffer.from(`bytes-${filename}`));
+    const r = await db('photos').insert({
+      event_id: eventId,
+      filename,
+      path: `${SLUG}/${filename}`,
+      type: 'individual',
+      uploaded_at: new Date().toISOString(),
+      ...extra,
+    }).returning('id');
+    return r[0]?.id ?? r[0];
+  };
+
+  const getPhotoRes = (photoId) => request(app)
+    .get(`/api/admin/photos/${eventId}/photo/${photoId}`)
+    .set('Authorization', `Bearer ${adminToken}`);
+
+  beforeAll(async () => {
+    ({ db, cleanup } = await bootCrmDb());
+    await seedMinimal(db);
+
+    const inserted = await db('events').insert({
+      slug: SLUG,
+      event_type: 'wedding',
+      event_name: 'Admin CT Test',
+      event_date: '2026-08-01',
+      host_email: 'host@example.com',
+      admin_email: 'admin@example.com',
+      password_hash: 'x',
+      share_link: `/gallery/${SLUG}/share`,
+      share_token: 'admin-ct-share',
+      expires_at: new Date(Date.now() + 7 * 24 * 3600 * 1000).toISOString(),
+      is_active: 1,
+      is_archived: 0,
+      is_draft: 0,
+      created_at: new Date().toISOString(),
+    }).returning('id');
+    eventId = inserted[0]?.id ?? inserted[0];
+
+    const superRole = await db('roles').where({ name: 'super_admin' }).first();
+    const [rootId] = await db('admin_users').insert({
+      username: 'admin-ct-admin',
+      email: 'admin-ct-admin@example.com',
+      password_hash: await bcrypt.hash('AdminCt123', 4),
+      role_id: superRole.id,
+      is_active: 1,
+      created_at: new Date(),
+      updated_at: new Date(),
+    }).returning('id').then((r) => [r[0]?.id || r[0]]);
+    adminToken = jwt.sign(
+      { id: rootId, username: 'admin-ct-admin', type: 'admin', role: 'super_admin', loginTime: Date.now() },
+      process.env.JWT_SECRET,
+      { expiresIn: '1h', issuer: 'picpeak-auth' }
+    );
+
+    app = express();
+    app.use(express.json());
+    app.use('/api/admin/photos', require('../../src/routes/adminPhotos'));
+  }, 120000);
+
+  afterAll(async () => { if (cleanup) await cleanup(); });
+
+  it('serves a video with its stored mime_type, not image/<ext>', async () => {
+    const id = await addPhoto('clip.mp4', { media_type: 'video', mime_type: 'video/mp4' });
+    const res = await getPhotoRes(id);
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toBe('video/mp4');
+  });
+
+  it('falls back to video/mp4 for a video row without a stored mime_type', async () => {
+    const id = await addPhoto('clip-nomime.mov', { media_type: 'video' });
+    const res = await getPhotoRes(id);
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toBe('video/mp4');
+  });
+
+  it('keeps the extension fallback for images without a stored mime_type', async () => {
+    const id = await addPhoto('shot.png');
+    const res = await getPhotoRes(id);
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toBe('image/png');
+  });
+
+  it('extensionless files get image/jpeg, never a bare image/', async () => {
+    const id = await addPhoto('noext');
+    const res = await getPhotoRes(id);
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toBe('image/jpeg');
+  });
+});

--- a/backend/__tests__/routes/adminPhotoContentType.test.js
+++ b/backend/__tests__/routes/adminPhotoContentType.test.js
@@ -156,6 +156,13 @@ describe('admin photo view Content-Type (#908)', () => {
     expect(res.headers['content-type']).toBe('image/avif');
   });
 
+  it('preserves other importer raster types too (apng, x-icon)', async () => {
+    const apng = await addPhoto('anim.apng', { mime_type: 'image/apng' });
+    expect((await getPhotoRes(apng)).headers['content-type']).toBe('image/apng');
+    const ico = await addPhoto('fav.ico', { mime_type: 'image/x-icon' });
+    expect((await getPhotoRes(ico)).headers['content-type']).toBe('image/x-icon');
+  });
+
   it('does NOT honor a stored scriptable image type (image/svg+xml)', async () => {
     // svg is inline-scriptable and must never be echoed — allowlist excludes it.
     const id = await addPhoto('vector.svg', { mime_type: 'image/svg+xml' });

--- a/backend/__tests__/routes/adminPhotoContentType.test.js
+++ b/backend/__tests__/routes/adminPhotoContentType.test.js
@@ -175,6 +175,21 @@ describe('admin photo view Content-Type (#908)', () => {
     expect(res.headers['content-type']).toBe('image/png');
   });
 
+  it('handles Object.prototype key extensions without a 500 (.constructor)', async () => {
+    // The extension-to-MIME lookup must be own-property only — a raw
+    // index access returns an inherited function for these keys and the
+    // downstream startsWith throws. Serve image/jpeg instead of 500.
+    const id = await addPhoto('payload.constructor');
+    const res = await getPhotoRes(id);
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toBe('image/jpeg');
+
+    const id2 = await addPhoto('payload.__proto__', { media_type: 'video' });
+    const res2 = await getPhotoRes(id2);
+    expect(res2.status).toBe(200);
+    expect(res2.headers['content-type']).toBe('video/mp4');
+  });
+
   it('does not synthesize types from unmapped image extensions', async () => {
     // Raw interpolation would produce image/svg+xml (scriptable inline)
     // or arbitrary strings from client-controlled filenames — the shared

--- a/backend/__tests__/routes/adminPhotoContentType.test.js
+++ b/backend/__tests__/routes/adminPhotoContentType.test.js
@@ -175,6 +175,21 @@ describe('admin photo view Content-Type (#908)', () => {
     expect(res.headers['content-type']).toBe('image/png');
   });
 
+  it('does not synthesize types from unmapped image extensions', async () => {
+    // Raw interpolation would produce image/svg+xml (scriptable inline)
+    // or arbitrary strings from client-controlled filenames — the shared
+    // map is the allowlist, everything else is served as image/jpeg.
+    const svg = await addPhoto('vector.svg+xml');
+    const res = await getPhotoRes(svg);
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toBe('image/jpeg');
+
+    const weird = await addPhoto('weird.xyz');
+    const res2 = await getPhotoRes(weird);
+    expect(res2.status).toBe(200);
+    expect(res2.headers['content-type']).toBe('image/jpeg');
+  });
+
   it('extensionless files get image/jpeg, never a bare image/', async () => {
     const id = await addPhoto('noext');
     const res = await getPhotoRes(id);

--- a/backend/src/routes/adminPhotos.js
+++ b/backend/src/routes/adminPhotos.js
@@ -1156,18 +1156,32 @@ router.get('/:eventId/photo/:photoId', adminAuth, requirePermission('photos.view
     const storedVideoMime = photo.mime_type && /^video\/[\w.+-]+$/.test(photo.mime_type)
       ? photo.mime_type
       : null;
+    // Honor a stored image MIME only when it is a known-safe RASTER type
+    // (#908 review round 2): the S3 auto-importer stores correct types for
+    // formats whose extension isn't in EXTENSION_TO_MIME (avif/bmp/tiff/
+    // heic), so map-only would mislabel them as image/jpeg. Allowlist, not
+    // a regex — image/svg+xml is a scriptable inline type and must never
+    // pass, and migration 039's blanket image/jpeg backfill on legacy rows
+    // is why the extension still wins ahead of this (see below).
+    const SAFE_IMAGE_MIME = new Set([
+      'image/jpeg', 'image/png', 'image/webp', 'image/gif',
+      'image/avif', 'image/bmp', 'image/tiff', 'image/heic', 'image/heif',
+    ]);
+    const storedImageMime = SAFE_IMAGE_MIME.has(photo.mime_type) ? photo.mime_type : null;
     const isVideo = photo.media_type === 'video' ||
       Boolean(storedVideoMime) ||
       Boolean(extMime && extMime.startsWith('video/'));
-    // Map-only on the image side too: interpolating the raw extension
-    // would synthesize image/svg+xml (scriptable inline) or header-invalid
-    // values from client-controlled chunked-upload filenames. Anything the
-    // shared map doesn't know is served as image/jpeg — browsers sniff
-    // image bytes in <img>/blob contexts, so a mislabel is harmless where
-    // an injected type is not.
+    // Never interpolate the raw extension on the image side: it would
+    // synthesize image/svg+xml (scriptable inline) or header-invalid values
+    // from client-controlled chunked-upload filenames. Precedence is
+    // mapped-extension (also corrects the 039 legacy-jpeg backfill on PNGs)
+    // -> safe stored raster MIME (auto-imported avif/bmp/tiff) -> image/jpeg.
+    // A stored type outside the allowlist degrades to image/jpeg; browsers
+    // sniff image bytes in <img>/blob contexts, so a mislabel is harmless
+    // where an injected type is not.
     const contentType = isVideo
       ? storedVideoMime || (extMime && extMime.startsWith('video/') ? extMime : null) || 'video/mp4'
-      : (extMime && extMime.startsWith('image/') ? extMime : null) || 'image/jpeg';
+      : (extMime && extMime.startsWith('image/') ? extMime : null) || storedImageMime || 'image/jpeg';
     res.setHeader('Content-Type', contentType);
     res.setHeader('Cache-Control', 'private, max-age=3600');
     res.setHeader('Cross-Origin-Resource-Policy', 'cross-origin');

--- a/backend/src/routes/adminPhotos.js
+++ b/backend/src/routes/adminPhotos.js
@@ -1126,19 +1126,33 @@ router.get('/:eventId/photo/:photoId', adminAuth, requirePermission('photos.view
     const event = await db('events').where('id', eventId).first();
     const storageKey = resolvePhotoStorageKey(event, photo);
 
-    // Content-Type from the stored MIME type (#908) — the extension-based
-    // `image/<ext>` produced invalid types like image/mp4 for videos, and
-    // AdminAuthenticatedVideo's blob inherits it, so browsers refused to
-    // play admin video previews. Fallbacks mirror the download handler:
-    // videos to video/mp4, images to the extension (jpeg when there is
-    // none — a bare `image/` is invalid too).
+    // Content-Type resolution (#908 + external review). Invariant: the
+    // header is ALWAYS image/* or video/*.
+    //  - photos.mime_type is never echoed verbatim unless it is a video/
+    //    type: the chunked-upload path stores the client-sent MIME
+    //    unvalidated, so a stored text/html served inline under the app
+    //    origin would be a same-origin XSS gift.
+    //  - Images ignore the stored value entirely — migration 039
+    //    backfilled image/jpeg onto every legacy row (PNGs included), so
+    //    the extension is the more trustworthy signal; normalized via the
+    //    shared map (image/jpg → image/jpeg), jpeg fallback when unknown.
+    //  - Videos prefer a stored video/ type, then the extension map
+    //    (.mov → video/quicktime, .webm → video/webm, …), then video/mp4.
+    //    The old ext-derived image/<ext> (image/mp4) is what made the
+    //    admin player's blob unplayable (#908).
+    const { EXTENSION_TO_MIME } = require('../services/uploadSettings');
+    const ext = path.extname(photo.filename).slice(1).toLowerCase();
+    const extMime = EXTENSION_TO_MIME[ext] || null;
+    const storedVideoMime = photo.mime_type && photo.mime_type.startsWith('video/')
+      ? photo.mime_type
+      : null;
     const isVideo = photo.media_type === 'video' ||
-      (photo.mime_type && photo.mime_type.startsWith('video/'));
-    res.setHeader(
-      'Content-Type',
-      photo.mime_type ||
-        (isVideo ? 'video/mp4' : `image/${path.extname(photo.filename).slice(1) || 'jpeg'}`)
-    );
+      Boolean(storedVideoMime) ||
+      Boolean(extMime && extMime.startsWith('video/'));
+    const contentType = isVideo
+      ? storedVideoMime || (extMime && extMime.startsWith('video/') ? extMime : null) || 'video/mp4'
+      : (extMime && extMime.startsWith('image/') ? extMime : null) || `image/${ext || 'jpeg'}`;
+    res.setHeader('Content-Type', contentType);
     res.setHeader('Cache-Control', 'private, max-age=3600');
     res.setHeader('Cross-Origin-Resource-Policy', 'cross-origin');
 

--- a/backend/src/routes/adminPhotos.js
+++ b/backend/src/routes/adminPhotos.js
@@ -1126,7 +1126,19 @@ router.get('/:eventId/photo/:photoId', adminAuth, requirePermission('photos.view
     const event = await db('events').where('id', eventId).first();
     const storageKey = resolvePhotoStorageKey(event, photo);
 
-    res.setHeader('Content-Type', `image/${path.extname(photo.filename).slice(1)}`);
+    // Content-Type from the stored MIME type (#908) — the extension-based
+    // `image/<ext>` produced invalid types like image/mp4 for videos, and
+    // AdminAuthenticatedVideo's blob inherits it, so browsers refused to
+    // play admin video previews. Fallbacks mirror the download handler:
+    // videos to video/mp4, images to the extension (jpeg when there is
+    // none — a bare `image/` is invalid too).
+    const isVideo = photo.media_type === 'video' ||
+      (photo.mime_type && photo.mime_type.startsWith('video/'));
+    res.setHeader(
+      'Content-Type',
+      photo.mime_type ||
+        (isVideo ? 'video/mp4' : `image/${path.extname(photo.filename).slice(1) || 'jpeg'}`)
+    );
     res.setHeader('Cache-Control', 'private, max-age=3600');
     res.setHeader('Cross-Origin-Resource-Policy', 'cross-origin');
 

--- a/backend/src/routes/adminPhotos.js
+++ b/backend/src/routes/adminPhotos.js
@@ -1143,7 +1143,11 @@ router.get('/:eventId/photo/:photoId', adminAuth, requirePermission('photos.view
     const { EXTENSION_TO_MIME } = require('../services/uploadSettings');
     const ext = path.extname(photo.filename).slice(1).toLowerCase();
     const extMime = EXTENSION_TO_MIME[ext] || null;
-    const storedVideoMime = photo.mime_type && photo.mime_type.startsWith('video/')
+    // Full-token validation, not just a prefix check: the stored value is
+    // client-controlled, and header-invalid characters (video/mp4\r\nX: y)
+    // would make setHeader throw — a permanent 500 for that photo. Bare
+    // 'video/' is equally invalid; both fall back to the extension map.
+    const storedVideoMime = photo.mime_type && /^video\/[\w.+-]+$/.test(photo.mime_type)
       ? photo.mime_type
       : null;
     const isVideo = photo.media_type === 'video' ||

--- a/backend/src/routes/adminPhotos.js
+++ b/backend/src/routes/adminPhotos.js
@@ -1153,9 +1153,15 @@ router.get('/:eventId/photo/:photoId', adminAuth, requirePermission('photos.view
     const isVideo = photo.media_type === 'video' ||
       Boolean(storedVideoMime) ||
       Boolean(extMime && extMime.startsWith('video/'));
+    // Map-only on the image side too: interpolating the raw extension
+    // would synthesize image/svg+xml (scriptable inline) or header-invalid
+    // values from client-controlled chunked-upload filenames. Anything the
+    // shared map doesn't know is served as image/jpeg — browsers sniff
+    // image bytes in <img>/blob contexts, so a mislabel is harmless where
+    // an injected type is not.
     const contentType = isVideo
       ? storedVideoMime || (extMime && extMime.startsWith('video/') ? extMime : null) || 'video/mp4'
-      : (extMime && extMime.startsWith('image/') ? extMime : null) || `image/${ext || 'jpeg'}`;
+      : (extMime && extMime.startsWith('image/') ? extMime : null) || 'image/jpeg';
     res.setHeader('Content-Type', contentType);
     res.setHeader('Cache-Control', 'private, max-age=3600');
     res.setHeader('Cross-Origin-Resource-Policy', 'cross-origin');

--- a/backend/src/routes/adminPhotos.js
+++ b/backend/src/routes/adminPhotos.js
@@ -1142,7 +1142,13 @@ router.get('/:eventId/photo/:photoId', adminAuth, requirePermission('photos.view
     //    admin player's blob unplayable (#908).
     const { EXTENSION_TO_MIME } = require('../services/uploadSettings');
     const ext = path.extname(photo.filename).slice(1).toLowerCase();
-    const extMime = EXTENSION_TO_MIME[ext] || null;
+    // Own-property lookup (review): a client-controlled filename ending in
+    // .constructor / .__proto__ / .toString would otherwise return an
+    // inherited Object.prototype member, and the extMime.startsWith below
+    // would throw — a permanent 500 for that photo instead of the fallback.
+    const extMime = Object.prototype.hasOwnProperty.call(EXTENSION_TO_MIME, ext)
+      ? EXTENSION_TO_MIME[ext]
+      : null;
     // Full-token validation, not just a prefix check: the stored value is
     // client-controlled, and header-invalid characters (video/mp4\r\nX: y)
     // would make setHeader throw — a permanent 500 for that photo. Bare

--- a/backend/src/routes/adminPhotos.js
+++ b/backend/src/routes/adminPhotos.js
@@ -1156,18 +1156,20 @@ router.get('/:eventId/photo/:photoId', adminAuth, requirePermission('photos.view
     const storedVideoMime = photo.mime_type && /^video\/[\w.+-]+$/.test(photo.mime_type)
       ? photo.mime_type
       : null;
-    // Honor a stored image MIME only when it is a known-safe RASTER type
-    // (#908 review round 2): the S3 auto-importer stores correct types for
-    // formats whose extension isn't in EXTENSION_TO_MIME (avif/bmp/tiff/
-    // heic), so map-only would mislabel them as image/jpeg. Allowlist, not
-    // a regex — image/svg+xml is a scriptable inline type and must never
-    // pass, and migration 039's blanket image/jpeg backfill on legacy rows
-    // is why the extension still wins ahead of this (see below).
-    const SAFE_IMAGE_MIME = new Set([
-      'image/jpeg', 'image/png', 'image/webp', 'image/gif',
-      'image/avif', 'image/bmp', 'image/tiff', 'image/heic', 'image/heif',
-    ]);
-    const storedImageMime = SAFE_IMAGE_MIME.has(photo.mime_type) ? photo.mime_type : null;
+    // Honor a stored image MIME for any header-safe RASTER type (#908
+    // review): the S3 auto-importer accepts arbitrary image/* from
+    // mime-types and stores it (avif/bmp/tiff/heic/apng/ico/jxl/…), and a
+    // hand-listed allowlist kept missing formats. Allow image/<token> but
+    // NEVER the scriptable svg / *+xml family (image/svg+xml executes
+    // inline). The strict token + anchors also block header injection
+    // (image/x\r\nY:). Migration 039's blanket image/jpeg backfill on
+    // legacy rows is why the mapped extension still wins ahead of this.
+    const storedImageMime =
+      photo.mime_type &&
+      /^image\/[\w.+-]+$/.test(photo.mime_type) &&
+      !/^image\/svg|xml/i.test(photo.mime_type)
+        ? photo.mime_type
+        : null;
     const isVideo = photo.media_type === 'video' ||
       Boolean(storedVideoMime) ||
       Boolean(extMime && extMime.startsWith('video/'));

--- a/backend/src/services/chunkedUploadService.js
+++ b/backend/src/services/chunkedUploadService.js
@@ -281,8 +281,12 @@ async function cleanupExpiredUploads() {
   return expiredIds.length;
 }
 
-// Run cleanup every hour
-setInterval(cleanupExpiredUploads, 60 * 60 * 1000);
+// Run cleanup every hour. unref so this module-level housekeeping timer
+// never holds the process open on its own — in production the HTTP
+// listener keeps the loop alive, and in Jest this exact handle kept the
+// runner from exiting for every suite that requires adminPhotos (#908;
+// it is why adminPhotos.reference sits on the CI ignore list).
+setInterval(cleanupExpiredUploads, 60 * 60 * 1000).unref();
 
 module.exports = {
   initializeUpload,


### PR DESCRIPTION
Stable port of #910 (issue #908 — reproduced on 3.45.x by the reporter).

## The bug (exactly as reported — excellent diagnosis by @natistir)

`adminPhotos.js` `GET /:eventId/photo/:photoId` set `Content-Type: image/${ext}` unconditionally, producing invalid types like `image/mp4`. `AdminAuthenticatedVideo` fetches the URL into a blob that inherits that type, and browsers refuse to play a `<video>` blob labeled `image/*` — blank/grey admin preview, while the download route (which already uses `photo.mime_type`) worked.

## The fix

Stored `photos.mime_type` wins; fallbacks mirror the download handler:
- video rows without a stored MIME → `video/mp4`
- images → extension-based as before
- extensionless files → `image/jpeg` (previously the equally invalid bare `image/`)

## Bonus: the reason no CI suite could cover this route

Requiring `adminPhotos` pulls in `chunkedUploadService`, whose module-level hourly `setInterval` held Jest open forever — it's why `integration/adminPhotos.reference` sits on the CI `testPathIgnorePatterns` list. The timer is now `unref()`ed (production unchanged; the HTTP listener keeps the process alive), which is what makes the new test suite possible. Un-ignoring the reference suite is a separate follow-up — its exclusion note mentions other mock/infra issues.

## Review hardening (3 Codex rounds)

The MIME resolution is now allowlist-based with the invariant that the header is **always `image/*` or `video/*`**:
- stored `photos.mime_type` is honored only when it is a strict header-safe `video/<token>` — the chunked-upload path stores the client-sent MIME unvalidated, so `text/html` (inline XSS) and `video/mp4\r\nX: y` (`setHeader` throws → permanent 500) must never reach the header
- MIME-less videos map from the shared `EXTENSION_TO_MIME` (`.mov` → `video/quicktime`), unknown extensions get `video/mp4`
- images ignore the stored MIME entirely (migration 039 backfilled `image/jpeg` onto every legacy row, PNGs included) and are map-only — no raw extension interpolation (`.svg+xml` would be scriptable inline), unmapped → `image/jpeg`

Test suite: 10 MIME cases, exits cleanly without `--forceExit`.

## Tests

`__tests__/routes/adminPhotoContentType.test.js` pins all ten MIME cases against the real route (real files on disk, admin-auth requests): stored `video/mp4` wins, video-without-mime fallback, image extension fallback, extensionless → `image/jpeg`. Suite passes and exits cleanly without `--forceExit`.

