### PR TITLE
fix(admin): stop marking events expired up to 24h early (#909)

### DIFF
--- a/frontend/src/pages/admin/AdminDashboard.tsx
+++ b/frontend/src/pages/admin/AdminDashboard.tsx
@@ -15,7 +15,7 @@ import {
   Check,
   X
 } from 'lucide-react';
-import { differenceInDays, parseISO } from 'date-fns';
+import { parseISO } from 'date-fns';
 import { useTranslation } from 'react-i18next';
 import { useLocalizedDate } from '../../hooks/useLocalizedDate';
 import { useMutationWithToast } from '../../hooks';
@@ -237,7 +237,8 @@ export const AdminDashboard: React.FC = () => {
             ) : (
               <div className="space-y-3">
                 {expiringEvents.map((event) => {
-                  const daysLeft = differenceInDays(parseISO(event.expires_at!), new Date());
+                  // Ceiling (#909): truncation showed "0 days" on the last day.
+                  const daysLeft = Math.max(1, Math.ceil((parseISO(event.expires_at!).getTime() - Date.now()) / 86400000));
 
                   return (
                     <div

--- a/frontend/src/pages/admin/EventDetailsPage.tsx
+++ b/frontend/src/pages/admin/EventDetailsPage.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { differenceInDays } from 'date-fns';
 import { toast } from 'react-toastify';
 import { useLocalizedDate } from '../../hooks/useLocalizedDate';
 
@@ -290,9 +289,14 @@ export const EventDetailsPage: React.FC = () => {
   }
 
   const expiresAtDate = safeParseDate(event.expires_at);
-  const daysUntilExpiration = expiresAtDate ? differenceInDays(expiresAtDate, new Date()) : null;
-  const isExpired = daysUntilExpiration !== null && daysUntilExpiration <= 0;
-  const isExpiring = daysUntilExpiration !== null && daysUntilExpiration > 0 && daysUntilExpiration <= 7;
+  // Timestamp comparison, not truncated whole days (#909): the old
+  // differenceInDays <= 0 marked events "expired" up to 24h early.
+  // Ceiling keeps the countdown at "1 day" through the final day.
+  const isExpired = expiresAtDate !== null && expiresAtDate.getTime() <= Date.now();
+  const daysUntilExpiration = expiresAtDate
+    ? Math.ceil((expiresAtDate.getTime() - Date.now()) / 86400000)
+    : null;
+  const isExpiring = !isExpired && daysUntilExpiration !== null && daysUntilExpiration > 0 && daysUntilExpiration <= 7;
 
   const handleStartEdit = () => {
     setEditForm({

--- a/frontend/src/pages/admin/EventsListPage.tsx
+++ b/frontend/src/pages/admin/EventsListPage.tsx
@@ -18,7 +18,7 @@ import {
   ChevronLeft,
   ChevronRight
 } from 'lucide-react';
-import { parseISO, differenceInDays } from 'date-fns';
+import { parseISO } from 'date-fns';
 import { toast } from 'react-toastify';
 import { useModal, useMutationWithToast } from '../../hooks';
 import { useLocalizedDate } from '../../hooks/useLocalizedDate';
@@ -258,8 +258,14 @@ export const EventsListPage: React.FC = () => {
 
     if (!event.expires_at) return { label: t('events.active'), color: 'text-green-600 dark:text-green-400 bg-green-100 dark:bg-green-900/40' };
 
-    const days = differenceInDays(parseISO(event.expires_at), new Date());
-    if (days <= 0) return { label: t('events.expired'), color: 'text-red-600 dark:text-red-400 bg-red-100 dark:bg-red-900/40' };
+    // Expired means the timestamp has actually passed (#909):
+    // differenceInDays truncates to whole days, so an event expiring in a
+    // few hours returned 0 and showed "Expired" while the public gallery
+    // (which compares real timestamps) correctly showed it active.
+    const expiresAt = parseISO(event.expires_at);
+    if (expiresAt.getTime() <= Date.now()) return { label: t('events.expired'), color: 'text-red-600 dark:text-red-400 bg-red-100 dark:bg-red-900/40' };
+    // Ceiling so the last day reads "1 day left", never "0 days".
+    const days = Math.ceil((expiresAt.getTime() - Date.now()) / 86400000);
     if (days <= 7) return { label: t('events.daysLeft', { count: days }), color: 'text-orange-600 dark:text-orange-400 bg-orange-100 dark:bg-orange-900/40' };
 
     return { label: t('events.active'), color: 'text-green-600 dark:text-green-400 bg-green-100 dark:bg-green-900/40' };


### PR DESCRIPTION
Fixes #909.

## Root cause — exactly the reporter's hypothesis, one level down

Not a timezone or date-string comparison, but the same effect: three admin surfaces classify expiry via `differenceInDays(expires_at, now)`, and date-fns **truncates to whole days**. An event expiring in 11 hours returns `0`:

- `EventsListPage` — `days <= 0` → status chip **"Expired"** while the event is live (the reported symptom)
- `EventDetailsPage` — identical `isExpired` math on the detail view
- `AdminDashboard` — the expiring-soon card shows "0 days left" on the final day

The public gallery route compares real timestamps, which is why it correctly shows "expires in 11 hours" — the two views genuinely used different logic.

## The fix

- **Expired** = `expires_at <= now` (timestamp comparison, matching the public gallery and the backend archival logic)
- **Countdown chips** use ceiling days: the final day reads "1 day left" instead of flipping to "Expired"/"0 days"

Frontend-only, three files; `differenceInDays` imports dropped where now unused.

## On the reporter's secondary observation

"1 day" expiring at midnight rather than `created_at + 24h` is intentional: `adminEvents/crud.js:308-312` anchors `expires_at` to midnight of the event date plus the expiration days. Answered on the issue; not changed here.

## Verification

`npm run build` clean, eslint clean on all three files. Manual check of the boundary math: `expires_at` 11h in the future → list chip "1 day left", details header not expired; `expires_at` 1min in the past → "Expired" everywhere.

Stable port follows (same code on 3.45.x).
