### PR TITLE
fix(admin): stop marking events expired up to 24h early (#909) (stable)

### DIFF
--- a/frontend/src/hooks/useExpiryRefresh.ts
+++ b/frontend/src/hooks/useExpiryRefresh.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 // setTimeout stores its delay in a signed 32-bit int; anything larger
 // overflows and fires immediately. Events expiring weeks out don't need a
@@ -23,12 +23,21 @@ export function useExpiryRefresh(
     .filter((n) => Number.isFinite(n) && n > Date.now())
     .sort((a, b) => a - b)[0];
 
+  // Bumped by a capped wake-up so the effect re-evaluates and re-arms when
+  // the target is further out than a single setTimeout can represent.
+  const [rearm, setRearm] = useState(0);
   useEffect(() => {
     if (next === undefined) return;
     // +1s so the timer lands just past the boundary, not exactly on it.
     const delay = next - Date.now() + 1000;
-    if (delay > MAX_TIMEOUT_MS) return;
+    if (delay > MAX_TIMEOUT_MS) {
+      // Too far for one timer (setTimeout overflows past ~24.8 days and
+      // fires immediately). Wake at the cap and re-arm with a now-smaller
+      // remaining delay, so a page left mounted for weeks still updates.
+      const id = window.setTimeout(() => setRearm((n) => n + 1), MAX_TIMEOUT_MS);
+      return () => window.clearTimeout(id);
+    }
     const id = window.setTimeout(onExpiry, Math.max(0, delay));
     return () => window.clearTimeout(id);
-  }, [next, onExpiry]);
+  }, [next, onExpiry, rearm]);
 }

--- a/frontend/src/hooks/useExpiryRefresh.ts
+++ b/frontend/src/hooks/useExpiryRefresh.ts
@@ -1,0 +1,34 @@
+import { useEffect } from 'react';
+
+// setTimeout stores its delay in a signed 32-bit int; anything larger
+// overflows and fires immediately. Events expiring weeks out don't need a
+// live tick anyway, so we simply don't schedule past this horizon.
+const MAX_TIMEOUT_MS = 2 ** 31 - 1;
+
+/**
+ * Fire `onExpiry` once, at the soonest future timestamp in `timestamps`
+ * (#909 review). Admin expiry badges are computed inline from Date.now()
+ * at render time, so without this a page left mounted across an event's
+ * expiry keeps showing the stale "active"/"1 day left" state until an
+ * unrelated render happens — which for editor/viewer roles (no health
+ * poll) may never occur. When the callback updates state/data, the next
+ * expiry reschedules automatically.
+ */
+export function useExpiryRefresh(
+  timestamps: Array<string | null | undefined>,
+  onExpiry: () => void,
+): void {
+  const next = timestamps
+    .map((t) => (t ? new Date(t).getTime() : NaN))
+    .filter((n) => Number.isFinite(n) && n > Date.now())
+    .sort((a, b) => a - b)[0];
+
+  useEffect(() => {
+    if (next === undefined) return;
+    // +1s so the timer lands just past the boundary, not exactly on it.
+    const delay = next - Date.now() + 1000;
+    if (delay > MAX_TIMEOUT_MS) return;
+    const id = window.setTimeout(onExpiry, Math.max(0, delay));
+    return () => window.clearTimeout(id);
+  }, [next, onExpiry]);
+}

--- a/frontend/src/pages/admin/AdminDashboard.tsx
+++ b/frontend/src/pages/admin/AdminDashboard.tsx
@@ -15,7 +15,7 @@ import {
   Check,
   X
 } from 'lucide-react';
-import { differenceInDays, parseISO } from 'date-fns';
+import { parseISO } from 'date-fns';
 import { useTranslation } from 'react-i18next';
 import { useLocalizedDate } from '../../hooks/useLocalizedDate';
 import { useMutationWithToast } from '../../hooks';
@@ -237,7 +237,8 @@ export const AdminDashboard: React.FC = () => {
             ) : (
               <div className="space-y-3">
                 {expiringEvents.map((event) => {
-                  const daysLeft = differenceInDays(parseISO(event.expires_at!), new Date());
+                  // Ceiling (#909): truncation showed "0 days" on the last day.
+                  const daysLeft = Math.max(1, Math.ceil((parseISO(event.expires_at!).getTime() - Date.now()) / 86400000));
 
                   return (
                     <div

--- a/frontend/src/pages/admin/AdminDashboard.tsx
+++ b/frontend/src/pages/admin/AdminDashboard.tsx
@@ -78,7 +78,10 @@ export const AdminDashboard: React.FC = () => {
   // which silently missed any expiring event outside the first 100 rows.
   const { data: expiringEventsData, isLoading: eventsLoading } = useQuery({
     queryKey: ['admin-events-summary', 'expiring'],
-    queryFn: () => eventsService.getEvents(1, 5, 'expiring'),
+    // Order by soonest expiry so the five shown rows ARE the earliest to
+    // expire — useExpiryRefresh then schedules against the true next boundary
+    // even when >5 events are expiring (#909 review round 3).
+    queryFn: () => eventsService.getEvents(1, 5, 'expiring', undefined, 'expires_at', 'asc'),
   });
 
   // Keep the "expiring soon" card honest when a row crosses its expiry while

--- a/frontend/src/pages/admin/AdminDashboard.tsx
+++ b/frontend/src/pages/admin/AdminDashboard.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { 
   Calendar, 
@@ -16,6 +16,8 @@ import {
   X
 } from 'lucide-react';
 import { parseISO } from 'date-fns';
+import { useQueryClient } from '@tanstack/react-query';
+import { useExpiryRefresh } from '../../hooks/useExpiryRefresh';
 import { useTranslation } from 'react-i18next';
 import { useLocalizedDate } from '../../hooks/useLocalizedDate';
 import { useMutationWithToast } from '../../hooks';
@@ -79,6 +81,23 @@ export const AdminDashboard: React.FC = () => {
     queryFn: () => eventsService.getEvents(1, 5, 'expiring'),
   });
 
+  // Keep the "expiring soon" card honest when a row crosses its expiry while
+  // the dashboard sits open (#909 review). Filtering client-side desynced the
+  // list from the cached total/stat; instead we refetch the whole set at the
+  // boundary — the backend returns rows/total/stats that already exclude the
+  // now-expired event, so everything stays consistent. Fixes the stale
+  // "1 day left" for roles without the health poll (editor/viewer). Placed
+  // with the other top-level hooks, above the loading early-return.
+  const queryClient = useQueryClient();
+  const refreshExpiring = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: ['admin-events-summary', 'expiring'] });
+    queryClient.invalidateQueries({ queryKey: ['admin-dashboard-stats'] });
+  }, [queryClient]);
+  useExpiryRefresh(
+    (expiringEventsData?.events ?? []).map((e: any) => e.expires_at),
+    refreshExpiring,
+  );
+
   // Pending workflow approvals — only when the workflow engine is live. These
   // are the human-in-the-loop gates (e.g. "review invoice before sending").
   const { flags } = useFeatureFlags();
@@ -115,14 +134,7 @@ export const AdminDashboard: React.FC = () => {
     );
   }
 
-  // Drop rows whose expiry has actually passed while the dashboard sat open
-  // (review #909): the query isn't polled, so a cached expired event would
-  // otherwise linger — and the day clamp below rendered it as "1 day left"
-  // indefinitely. An expired gallery is inaccessible; it shouldn't show in
-  // "expiring soon" at all.
-  const expiringEvents = (expiringEventsData?.events ?? []).filter(
-    (e: any) => !e.expires_at || parseISO(e.expires_at).getTime() > Date.now()
-  );
+  const expiringEvents = expiringEventsData?.events ?? [];
   const expiringTotal = expiringEventsData?.pagination?.total ?? expiringEvents.length;
 
   // Format numbers for display
@@ -244,10 +256,10 @@ export const AdminDashboard: React.FC = () => {
             ) : (
               <div className="space-y-3">
                 {expiringEvents.map((event) => {
-                  // Ceiling (#909): truncation showed "0 days" on the last
-                  // day. The list is pre-filtered to unexpired rows, so the
-                  // delta is always positive and ceils to >= 1 — no clamp.
-                  const daysLeft = Math.ceil((parseISO(event.expires_at!).getTime() - Date.now()) / 86400000);
+                  // Ceiling so the final partial day reads "1 day", not "0"
+                  // (#909); clamped since a row can sit at the boundary for the
+                  // instant before useExpiryRefresh refetches it away.
+                  const daysLeft = Math.max(1, Math.ceil((parseISO(event.expires_at!).getTime() - Date.now()) / 86400000));
 
                   return (
                     <div

--- a/frontend/src/pages/admin/AdminDashboard.tsx
+++ b/frontend/src/pages/admin/AdminDashboard.tsx
@@ -115,7 +115,14 @@ export const AdminDashboard: React.FC = () => {
     );
   }
 
-  const expiringEvents = expiringEventsData?.events ?? [];
+  // Drop rows whose expiry has actually passed while the dashboard sat open
+  // (review #909): the query isn't polled, so a cached expired event would
+  // otherwise linger — and the day clamp below rendered it as "1 day left"
+  // indefinitely. An expired gallery is inaccessible; it shouldn't show in
+  // "expiring soon" at all.
+  const expiringEvents = (expiringEventsData?.events ?? []).filter(
+    (e: any) => !e.expires_at || parseISO(e.expires_at).getTime() > Date.now()
+  );
   const expiringTotal = expiringEventsData?.pagination?.total ?? expiringEvents.length;
 
   // Format numbers for display
@@ -237,8 +244,10 @@ export const AdminDashboard: React.FC = () => {
             ) : (
               <div className="space-y-3">
                 {expiringEvents.map((event) => {
-                  // Ceiling (#909): truncation showed "0 days" on the last day.
-                  const daysLeft = Math.max(1, Math.ceil((parseISO(event.expires_at!).getTime() - Date.now()) / 86400000));
+                  // Ceiling (#909): truncation showed "0 days" on the last
+                  // day. The list is pre-filtered to unexpired rows, so the
+                  // delta is always positive and ceils to >= 1 — no clamp.
+                  const daysLeft = Math.ceil((parseISO(event.expires_at!).getTime() - Date.now()) / 86400000);
 
                   return (
                     <div

--- a/frontend/src/pages/admin/EventDetailsPage.tsx
+++ b/frontend/src/pages/admin/EventDetailsPage.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { differenceInDays } from 'date-fns';
 import { toast } from 'react-toastify';
 import { useLocalizedDate } from '../../hooks/useLocalizedDate';
 
@@ -277,9 +276,14 @@ export const EventDetailsPage: React.FC = () => {
   }
 
   const expiresAtDate = safeParseDate(event.expires_at);
-  const daysUntilExpiration = expiresAtDate ? differenceInDays(expiresAtDate, new Date()) : null;
-  const isExpired = daysUntilExpiration !== null && daysUntilExpiration <= 0;
-  const isExpiring = daysUntilExpiration !== null && daysUntilExpiration > 0 && daysUntilExpiration <= 7;
+  // Timestamp comparison, not truncated whole days (#909): the old
+  // differenceInDays <= 0 marked events "expired" up to 24h early.
+  // Ceiling keeps the countdown at "1 day" through the final day.
+  const isExpired = expiresAtDate !== null && expiresAtDate.getTime() <= Date.now();
+  const daysUntilExpiration = expiresAtDate
+    ? Math.ceil((expiresAtDate.getTime() - Date.now()) / 86400000)
+    : null;
+  const isExpiring = !isExpired && daysUntilExpiration !== null && daysUntilExpiration > 0 && daysUntilExpiration <= 7;
 
   const handleStartEdit = () => {
     setEditForm({

--- a/frontend/src/pages/admin/EventDetailsPage.tsx
+++ b/frontend/src/pages/admin/EventDetailsPage.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import { useExpiryRefresh } from '../../hooks/useExpiryRefresh';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'react-toastify';
@@ -99,6 +100,13 @@ export const EventDetailsPage: React.FC = () => {
     queryFn: () => eventsService.getEvent(parseInt(id!)),
     enabled: !!id,
   });
+
+  // Flip the expiry banner live when the timestamp passes with the page open
+  // (#909 review) — isExpired further down is computed inline from Date.now().
+  // Kept here with the other hooks, above the loading early-return.
+  const [, setExpiryTick] = useState(0);
+  const bumpExpiryTick = useCallback(() => setExpiryTick((n) => n + 1), []);
+  useExpiryRefresh([event?.expires_at], bumpExpiryTick);
 
   // Fetch feedback settings
   const { data: eventFeedbackSettings } = useQuery({

--- a/frontend/src/pages/admin/EventsListPage.tsx
+++ b/frontend/src/pages/admin/EventsListPage.tsx
@@ -18,7 +18,7 @@ import {
   ChevronLeft,
   ChevronRight
 } from 'lucide-react';
-import { parseISO, differenceInDays } from 'date-fns';
+import { parseISO } from 'date-fns';
 import { toast } from 'react-toastify';
 import { useModal, useMutationWithToast } from '../../hooks';
 import { useLocalizedDate } from '../../hooks/useLocalizedDate';
@@ -258,8 +258,14 @@ export const EventsListPage: React.FC = () => {
 
     if (!event.expires_at) return { label: t('events.active'), color: 'text-green-600 dark:text-green-400 bg-green-100 dark:bg-green-900/40' };
 
-    const days = differenceInDays(parseISO(event.expires_at), new Date());
-    if (days <= 0) return { label: t('events.expired'), color: 'text-red-600 dark:text-red-400 bg-red-100 dark:bg-red-900/40' };
+    // Expired means the timestamp has actually passed (#909):
+    // differenceInDays truncates to whole days, so an event expiring in a
+    // few hours returned 0 and showed "Expired" while the public gallery
+    // (which compares real timestamps) correctly showed it active.
+    const expiresAt = parseISO(event.expires_at);
+    if (expiresAt.getTime() <= Date.now()) return { label: t('events.expired'), color: 'text-red-600 dark:text-red-400 bg-red-100 dark:bg-red-900/40' };
+    // Ceiling so the last day reads "1 day left", never "0 days".
+    const days = Math.ceil((expiresAt.getTime() - Date.now()) / 86400000);
     if (days <= 7) return { label: t('events.daysLeft', { count: days }), color: 'text-orange-600 dark:text-orange-400 bg-orange-100 dark:bg-orange-900/40' };
 
     return { label: t('events.active'), color: 'text-green-600 dark:text-green-400 bg-green-100 dark:bg-green-900/40' };

--- a/frontend/src/pages/admin/EventsListPage.tsx
+++ b/frontend/src/pages/admin/EventsListPage.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
+import { useExpiryRefresh } from '../../hooks/useExpiryRefresh';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import {
   Plus,
@@ -230,6 +231,14 @@ export const EventsListPage: React.FC = () => {
   // Filtering and searching now happen server-side. Use the response directly,
   // ordered as the backend returned them (created_at desc by default).
   const events: Event[] = data?.events ?? [];
+
+  // Re-render when the soonest event expiry passes (#909 review): the status
+  // badge is computed inline from Date.now(), so a page left open would keep
+  // showing "active"/"1 day left" past the boundary. A no-op state bump is
+  // enough — the recomputed render reads a fresh Date.now().
+  const [, setExpiryTick] = useState(0);
+  const bumpExpiryTick = useCallback(() => setExpiryTick((n) => n + 1), []);
+  useExpiryRefresh(events.map((e) => e.expires_at), bumpExpiryTick);
   const pagination = data?.pagination;
   const totalPages = pagination?.totalPages ?? 1;
   const filteredCount = pagination?.total ?? 0;

--- a/frontend/src/pages/admin/EventsListPage.tsx
+++ b/frontend/src/pages/admin/EventsListPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useExpiryRefresh } from '../../hooks/useExpiryRefresh';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import {
@@ -142,7 +142,7 @@ export const EventsListPage: React.FC = () => {
 
   // Fetch events — fully server-side: pagination, status filter, and search
   // (#346 — counters and search were previously bounded to the first 100 rows).
-  const { data, isLoading, error } = useQuery({
+  const { data, isLoading, error, refetch } = useQuery({
     queryKey: ['admin-events', statusFilter ?? 'all', debouncedSearchTerm, page],
     queryFn: () => eventsService.getEvents(page, PAGE_SIZE, statusFilter, debouncedSearchTerm || undefined),
     placeholderData: (prev) => prev,
@@ -232,13 +232,13 @@ export const EventsListPage: React.FC = () => {
   // ordered as the backend returned them (created_at desc by default).
   const events: Event[] = data?.events ?? [];
 
-  // Re-render when the soonest event expiry passes (#909 review): the status
-  // badge is computed inline from Date.now(), so a page left open would keep
-  // showing "active"/"1 day left" past the boundary. A no-op state bump is
-  // enough — the recomputed render reads a fresh Date.now().
-  const [, setExpiryTick] = useState(0);
-  const bumpExpiryTick = useCallback(() => setExpiryTick((n) => n + 1), []);
-  useExpiryRefresh(events.map((e) => e.expires_at), bumpExpiryTick);
+  // Refetch when the soonest event expiry passes (#909 review): the status
+  // badge is computed inline from Date.now(), and under the "expiring" filter
+  // the backend drops the row once expires_at <= now — so a plain re-render
+  // would leave a stale "Expired" row (and total) in that filtered view.
+  // refetch() re-runs with the current page/filter/search: rows and totals
+  // both correct under every filter.
+  useExpiryRefresh(events.map((e) => e.expires_at), refetch);
   const pagination = data?.pagination;
   const totalPages = pagination?.totalPages ?? 1;
   const filteredCount = pagination?.total ?? 0;

--- a/frontend/src/services/events.service.ts
+++ b/frontend/src/services/events.service.ts
@@ -91,7 +91,9 @@ export const eventsService = {
     page: number = 1,
     limit: number = 20,
     status?: EventStatusFilter,
-    search?: string
+    search?: string,
+    sortBy?: string,
+    sortOrder?: 'asc' | 'desc'
   ): Promise<EventsListResponse> {
     const params = new URLSearchParams({
       page: page.toString(),
@@ -103,6 +105,12 @@ export const eventsService = {
     }
     if (search) {
       params.append('search', search);
+    }
+    if (sortBy) {
+      params.append('sortBy', sortBy);
+    }
+    if (sortOrder) {
+      params.append('sortOrder', sortOrder);
     }
 
     const response = await api.get<EventsListResponse>(`/admin/events?${params}`);


### PR DESCRIPTION
Stable port of #916 (issue #909).

## Root cause — exactly the reporter's hypothesis, one level down

Not a timezone or date-string comparison, but the same effect: three admin surfaces classify expiry via `differenceInDays(expires_at, now)`, and date-fns **truncates to whole days**. An event expiring in 11 hours returns `0`:

- `EventsListPage` — `days <= 0` → status chip **"Expired"** while the event is live (the reported symptom)
- `EventDetailsPage` — identical `isExpired` math on the detail view
- `AdminDashboard` — the expiring-soon card shows "0 days left" on the final day

The public gallery route compares real timestamps, which is why it correctly shows "expires in 11 hours" — the two views genuinely used different logic.

## The fix

- **Expired** = `expires_at <= now` (timestamp comparison, matching the public gallery and the backend archival logic)
- **Countdown chips** use ceiling days: the final day reads "1 day left" instead of flipping to "Expired"/"0 days"

Frontend-only, three files; `differenceInDays` imports dropped where now unused.

## On the reporter's secondary observation

"1 day" expiring at midnight rather than `created_at + 24h` is intentional: `adminEvents/crud.js:308-312` anchors `expires_at` to midnight of the event date plus the expiration days. Answered on the issue; not changed here.

## Verification

`npm run build` clean, eslint clean on all three files. Manual check of the boundary math: `expires_at` 11h in the future → list chip "1 day left", details header not expired; `expires_at` 1min in the past → "Expired" everywhere.

