### PR TITLE
ci: batch stable releases into one daily version (stable)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,32 +27,12 @@ jobs:
           manifest-file: .release-please-manifest.json
           target-branch: stable
 
-      # Auto-approve + auto-merge the open stable release PR. See the beta
-      # workflow for the full rationale. Skipped on the release-cutting run and
-      # whenever no PAT is configured.
-      - name: Auto-approve and enable auto-merge on the release PR
-        if: ${{ steps.release.outputs.release_created != 'true' }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_PAT: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-          # No checkout in this job — set the repo explicitly so gh works
-          # without a git remote (same pattern as whatsnew, 2a5f0a8).
-          GH_REPO: ${{ github.repository }}
-        run: |
-          if [ -z "$RELEASE_PAT" ]; then
-            echo "RELEASE_PLEASE_TOKEN not set — skipping auto-merge (manual review still required)."
-            exit 0
-          fi
-          pr=$(gh pr list --head release-please--branches--stable --state open --json number --jq '.[0].number // empty')
-          if [ -n "$pr" ]; then
-            # Approve as github-actions[bot] (GITHUB_TOKEN, ≠ the PAT author) so it
-            # is a valid review; enable auto-merge as the PAT so the merge commit is
-            # attributed to a real identity and triggers the tag-cutting run (#719).
-            gh pr review "$pr" --approve --body "Automated approval — release-please version bump + changelog (#719)." || true
-            GH_TOKEN="$RELEASE_PAT" gh pr merge "$pr" --squash --auto || true
-          else
-            echo "No open release PR to auto-merge."
-          fi
+      # NOTE: stable release PRs are intentionally NOT auto-merged here
+      # anymore. Fixes accumulate in the rolling release PR and are cut as
+      # ONE patch version per day by release-stable-daily.yml (18:00 UTC,
+      # or on demand via workflow_dispatch / a manual merge of the release
+      # PR). Beta keeps instant releases — see release-please-beta.yml —
+      # because same-day reporter verification depends on it.
 
       - name: Output Release Info
         if: ${{ steps.release.outputs.release_created }}

--- a/.github/workflows/release-stable-daily.yml
+++ b/.github/workflows/release-stable-daily.yml
@@ -70,10 +70,15 @@ jobs:
           # already merged OR an auto-merge request is now pending; only a PR
           # that is still open with no auto-merge request is a real failure
           # (expired/under-scoped PAT) worth failing the job on (review round 2).
-          state=$(gh pr view "$pr" --json state --jq '.state')
+          # One snapshot of both fields (review round 3): querying state and
+          # autoMergeRequest separately races — auto-merge can complete
+          # between the two calls, so the first sees OPEN and the second sees
+          # the request already cleared on the now-merged PR → false failure.
+          read -r state automerge < <(gh pr view "$pr" --json state,autoMergeRequest \
+            --jq '[.state, (.autoMergeRequest != null)] | @tsv')
           if [ "$state" = "MERGED" ]; then
             echo "Stable release PR #$pr merged immediately (checks were already green)."
-          elif [ "$(gh pr view "$pr" --json autoMergeRequest --jq '.autoMergeRequest != null')" = "true" ]; then
+          elif [ "$automerge" = "true" ]; then
             echo "Auto-merge enabled on stable release PR #$pr — merges when checks are green."
           else
             echo "::error::stable release PR #$pr is still open with no auto-merge — check RELEASE_PLEASE_TOKEN scope/expiry."

--- a/.github/workflows/release-stable-daily.yml
+++ b/.github/workflows/release-stable-daily.yml
@@ -1,0 +1,50 @@
+name: Cut Stable Release (daily batch)
+
+# Stable fixes accumulate in release-please's rolling release PR instead of
+# each cutting its own patch version (the old per-merge auto-merge produced
+# e.g. 3.45.8 AND 3.45.9 on the same day). This workflow merges the open
+# stable release PR once a day, so a day of N bugfixes ships as ONE version
+# with all N changelog entries — and one Docker build instead of N.
+#
+# - schedule only fires from the default branch (main); the stable copy of
+#   this file is inert and exists to keep the branches in sync.
+# - Need a release NOW? Run this via workflow_dispatch, or merge the
+#   release PR by hand — the schedule is a default, not a gate.
+# - Approval/merge mechanics mirror the old inline step (#719): approve as
+#   github-actions[bot] (GITHUB_TOKEN, a valid distinct reviewer), enable
+#   auto-merge as the PAT so the merge attributes to a real identity and
+#   triggers the tag-cutting run. --auto waits for green checks.
+
+on:
+  schedule:
+    - cron: '0 18 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  merge-stable-release-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Approve and enable auto-merge on the open stable release PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_PAT: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          # No checkout — set the repo explicitly so gh works without a
+          # git remote (same pattern as whatsnew, 2a5f0a8).
+          GH_REPO: ${{ github.repository }}
+        run: |
+          if [ -z "$RELEASE_PAT" ]; then
+            echo "RELEASE_PLEASE_TOKEN not set — skipping (manual review required)."
+            exit 0
+          fi
+          pr=$(gh pr list --head release-please--branches--stable --state open --json number --jq '.[0].number // empty')
+          if [ -z "$pr" ]; then
+            echo "No open stable release PR — nothing to cut today."
+            exit 0
+          fi
+          gh pr review "$pr" --approve --body "Automated approval — daily stable release batch (release-please version bump + changelog)." || true
+          GH_TOKEN="$RELEASE_PAT" gh pr merge "$pr" --squash --auto || true
+          echo "Enabled auto-merge on stable release PR #$pr — merges when checks are green."

--- a/.github/workflows/release-stable-daily.yml
+++ b/.github/workflows/release-stable-daily.yml
@@ -40,11 +40,32 @@ jobs:
             echo "RELEASE_PLEASE_TOKEN not set — skipping (manual review required)."
             exit 0
           fi
-          pr=$(gh pr list --head release-please--branches--stable --state open --json number --jq '.[0].number // empty')
+          # Strict selection (review P1): this job runs daily even without a
+          # stable push, and `gh pr list --head` matches the branch NAME only
+          # — a fork PR can spoof `release-please--branches--stable`. Pin the
+          # base to stable AND require a same-repo head (isCrossRepository
+          # == false); a fork PR is cross-repository, so it can never be
+          # picked and auto-merged with the privileged PAT.
+          pr=$(gh pr list \
+            --base stable \
+            --head release-please--branches--stable \
+            --state open \
+            --json number,isCrossRepository \
+            --jq '[.[] | select(.isCrossRepository == false)] | .[0].number // empty')
           if [ -z "$pr" ]; then
-            echo "No open stable release PR — nothing to cut today."
+            echo "No open same-repo stable release PR — nothing to cut today."
             exit 0
           fi
-          gh pr review "$pr" --approve --body "Automated approval — daily stable release batch (release-please version bump + changelog)." || true
-          GH_TOKEN="$RELEASE_PAT" gh pr merge "$pr" --squash --auto || true
-          echo "Enabled auto-merge on stable release PR #$pr — merges when checks are green."
+          # Approve is tolerant — a pre-existing approval already satisfies
+          # branch protection and re-approving can return non-zero.
+          gh pr review "$pr" --approve --body "Automated approval — daily stable release batch (release-please version bump + changelog)." || echo "::warning::approve returned non-zero (PR may already be approved)"
+          # But the auto-merge enable is the load-bearing step: this scheduled
+          # job is the ONLY automatic stable cut, so DON'T swallow its failure
+          # (review P2) — an expired/under-scoped PAT would otherwise stop
+          # releases while the workflow stays green.
+          GH_TOKEN="$RELEASE_PAT" gh pr merge "$pr" --squash --auto
+          if [ "$(gh pr view "$pr" --json autoMergeRequest --jq '.autoMergeRequest != null')" != "true" ]; then
+            echo "::error::auto-merge was not enabled on stable release PR #$pr — check RELEASE_PLEASE_TOKEN scope/expiry."
+            exit 1
+          fi
+          echo "Auto-merge enabled on stable release PR #$pr — merges when checks are green."

--- a/.github/workflows/release-stable-daily.yml
+++ b/.github/workflows/release-stable-daily.yml
@@ -64,8 +64,18 @@ jobs:
           # (review P2) — an expired/under-scoped PAT would otherwise stop
           # releases while the workflow stays green.
           GH_TOKEN="$RELEASE_PAT" gh pr merge "$pr" --squash --auto
-          if [ "$(gh pr view "$pr" --json autoMergeRequest --jq '.autoMergeRequest != null')" != "true" ]; then
-            echo "::error::auto-merge was not enabled on stable release PR #$pr — check RELEASE_PLEASE_TOKEN scope/expiry."
+          # `gh pr merge --auto` merges IMMEDIATELY when the required checks
+          # are already green — the normal case at 18:00, since the fixes
+          # merged hours earlier and CI passed. So success is EITHER the PR is
+          # already merged OR an auto-merge request is now pending; only a PR
+          # that is still open with no auto-merge request is a real failure
+          # (expired/under-scoped PAT) worth failing the job on (review round 2).
+          state=$(gh pr view "$pr" --json state --jq '.state')
+          if [ "$state" = "MERGED" ]; then
+            echo "Stable release PR #$pr merged immediately (checks were already green)."
+          elif [ "$(gh pr view "$pr" --json autoMergeRequest --jq '.autoMergeRequest != null')" = "true" ]; then
+            echo "Auto-merge enabled on stable release PR #$pr — merges when checks are green."
+          else
+            echo "::error::stable release PR #$pr is still open with no auto-merge — check RELEASE_PLEASE_TOKEN scope/expiry."
             exit 1
           fi
-          echo "Auto-merge enabled on stable release PR #$pr — merges when checks are green."


### PR DESCRIPTION
Stable port of #919 — this is the copy that actually disables the per-merge auto-merge (push-triggered workflows run the pushed branch's file).

## Why

The stable release PR auto-merges the moment it's green, so every bugfix merged into `stable` immediately becomes its own patch release — 2026-07-29 alone produced `3.45.8` *and* `3.45.9`. For the conservative channel that means N upgrade notifications per day and N full Docker build cycles (release-PR CI + branch build + tag build, each).

## What changes

release-please already batches by design — the rolling release PR accumulates every fix and regenerates its changelog; the version count is purely a function of when that PR merges. So:

- `release-please.yml` (stable): the instant auto-approve/auto-merge step is removed; a comment points to the new cadence.
- `release-stable-daily.yml` (new): cron at **18:00 UTC** (plus `workflow_dispatch`) approves + enables auto-merge on the open stable release PR — one version per day carrying the whole day's fixes. No open release PR → the job exits quietly.

Mechanics are identical to the old inline step (#719): approve as `github-actions[bot]` (valid distinct reviewer), enable auto-merge as the PAT so the merge attributes to a real identity and triggers the tag-cutting run; `--auto` waits for green checks. Fixes merged after 18:00 roll into the next day's version (branch protection dismisses the stale approval; the next cron re-approves).

## What does NOT change

- **Beta** keeps instant releases — same-day reporter verification (see #895/#909 turnaround) depends on it.
- **Urgent stable fix**: run the daily job via `workflow_dispatch` or merge the release PR by hand at any moment — the schedule is a default, not a gate.

Stable port carries the same two files; the `schedule` trigger only fires from the default branch, so stable's copy of the daily workflow is inert (kept for branch-sync consistency). The removal of the auto-merge step is the part that must live on `stable`, since push-triggered workflows run the pushed branch's copy.
