### PR TITLE
fix(admin): code-review follow-ups on #910/#916 (MIME resolver + expiry reactivity)

### DIFF
--- a/backend/__tests__/routes/adminPhotoContentType.test.js
+++ b/backend/__tests__/routes/adminPhotoContentType.test.js
@@ -147,6 +147,23 @@ describe('admin photo view Content-Type (#908)', () => {
     expect(res2.headers['content-type']).toBe('video/webm');
   });
 
+  it('preserves an auto-imported avif via the safe stored-MIME allowlist', async () => {
+    // .avif isn't in EXTENSION_TO_MIME; s3AutoImporter stores image/avif.
+    // Map-only would mislabel it image/jpeg — the allowlist keeps it.
+    const id = await addPhoto('imported.avif', { mime_type: 'image/avif' });
+    const res = await getPhotoRes(id);
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toBe('image/avif');
+  });
+
+  it('does NOT honor a stored scriptable image type (image/svg+xml)', async () => {
+    // svg is inline-scriptable and must never be echoed — allowlist excludes it.
+    const id = await addPhoto('vector.svg', { mime_type: 'image/svg+xml' });
+    const res = await getPhotoRes(id);
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toBe('image/jpeg');
+  });
+
   it('never echoes a stored non-media MIME type (inline XSS guard)', async () => {
     const id = await addPhoto('evil.png', { mime_type: 'text/html' });
     const res = await getPhotoRes(id);

--- a/backend/__tests__/routes/adminPhotoContentType.test.js
+++ b/backend/__tests__/routes/adminPhotoContentType.test.js
@@ -156,6 +156,13 @@ describe('admin photo view Content-Type (#908)', () => {
     expect(res.headers['content-type']).toBe('image/avif');
   });
 
+  it('preserves other importer raster types too (apng, x-icon)', async () => {
+    const apng = await addPhoto('anim.apng', { mime_type: 'image/apng' });
+    expect((await getPhotoRes(apng)).headers['content-type']).toBe('image/apng');
+    const ico = await addPhoto('fav.ico', { mime_type: 'image/x-icon' });
+    expect((await getPhotoRes(ico)).headers['content-type']).toBe('image/x-icon');
+  });
+
   it('does NOT honor a stored scriptable image type (image/svg+xml)', async () => {
     // svg is inline-scriptable and must never be echoed — allowlist excludes it.
     const id = await addPhoto('vector.svg', { mime_type: 'image/svg+xml' });

--- a/backend/__tests__/routes/adminPhotoContentType.test.js
+++ b/backend/__tests__/routes/adminPhotoContentType.test.js
@@ -175,6 +175,21 @@ describe('admin photo view Content-Type (#908)', () => {
     expect(res.headers['content-type']).toBe('image/png');
   });
 
+  it('handles Object.prototype key extensions without a 500 (.constructor)', async () => {
+    // The extension-to-MIME lookup must be own-property only — a raw
+    // index access returns an inherited function for these keys and the
+    // downstream startsWith throws. Serve image/jpeg instead of 500.
+    const id = await addPhoto('payload.constructor');
+    const res = await getPhotoRes(id);
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toBe('image/jpeg');
+
+    const id2 = await addPhoto('payload.__proto__', { media_type: 'video' });
+    const res2 = await getPhotoRes(id2);
+    expect(res2.status).toBe(200);
+    expect(res2.headers['content-type']).toBe('video/mp4');
+  });
+
   it('does not synthesize types from unmapped image extensions', async () => {
     // Raw interpolation would produce image/svg+xml (scriptable inline)
     // or arbitrary strings from client-controlled filenames — the shared

--- a/backend/src/routes/adminPhotos.js
+++ b/backend/src/routes/adminPhotos.js
@@ -1148,7 +1148,13 @@ router.get('/:eventId/photo/:photoId', adminAuth, requirePermission('photos.view
     //    admin player's blob unplayable (#908).
     const { EXTENSION_TO_MIME } = require('../services/uploadSettings');
     const ext = path.extname(photo.filename).slice(1).toLowerCase();
-    const extMime = EXTENSION_TO_MIME[ext] || null;
+    // Own-property lookup (review): a client-controlled filename ending in
+    // .constructor / .__proto__ / .toString would otherwise return an
+    // inherited Object.prototype member, and the extMime.startsWith below
+    // would throw — a permanent 500 for that photo instead of the fallback.
+    const extMime = Object.prototype.hasOwnProperty.call(EXTENSION_TO_MIME, ext)
+      ? EXTENSION_TO_MIME[ext]
+      : null;
     // Full-token validation, not just a prefix check: the stored value is
     // client-controlled, and header-invalid characters (video/mp4\r\nX: y)
     // would make setHeader throw — a permanent 500 for that photo. Bare

--- a/backend/src/routes/adminPhotos.js
+++ b/backend/src/routes/adminPhotos.js
@@ -1162,18 +1162,32 @@ router.get('/:eventId/photo/:photoId', adminAuth, requirePermission('photos.view
     const storedVideoMime = photo.mime_type && /^video\/[\w.+-]+$/.test(photo.mime_type)
       ? photo.mime_type
       : null;
+    // Honor a stored image MIME only when it is a known-safe RASTER type
+    // (#908 review round 2): the S3 auto-importer stores correct types for
+    // formats whose extension isn't in EXTENSION_TO_MIME (avif/bmp/tiff/
+    // heic), so map-only would mislabel them as image/jpeg. Allowlist, not
+    // a regex — image/svg+xml is a scriptable inline type and must never
+    // pass, and migration 039's blanket image/jpeg backfill on legacy rows
+    // is why the extension still wins ahead of this (see below).
+    const SAFE_IMAGE_MIME = new Set([
+      'image/jpeg', 'image/png', 'image/webp', 'image/gif',
+      'image/avif', 'image/bmp', 'image/tiff', 'image/heic', 'image/heif',
+    ]);
+    const storedImageMime = SAFE_IMAGE_MIME.has(photo.mime_type) ? photo.mime_type : null;
     const isVideo = photo.media_type === 'video' ||
       Boolean(storedVideoMime) ||
       Boolean(extMime && extMime.startsWith('video/'));
-    // Map-only on the image side too: interpolating the raw extension
-    // would synthesize image/svg+xml (scriptable inline) or header-invalid
-    // values from client-controlled chunked-upload filenames. Anything the
-    // shared map doesn't know is served as image/jpeg — browsers sniff
-    // image bytes in <img>/blob contexts, so a mislabel is harmless where
-    // an injected type is not.
+    // Never interpolate the raw extension on the image side: it would
+    // synthesize image/svg+xml (scriptable inline) or header-invalid values
+    // from client-controlled chunked-upload filenames. Precedence is
+    // mapped-extension (also corrects the 039 legacy-jpeg backfill on PNGs)
+    // -> safe stored raster MIME (auto-imported avif/bmp/tiff) -> image/jpeg.
+    // A stored type outside the allowlist degrades to image/jpeg; browsers
+    // sniff image bytes in <img>/blob contexts, so a mislabel is harmless
+    // where an injected type is not.
     const contentType = isVideo
       ? storedVideoMime || (extMime && extMime.startsWith('video/') ? extMime : null) || 'video/mp4'
-      : (extMime && extMime.startsWith('image/') ? extMime : null) || 'image/jpeg';
+      : (extMime && extMime.startsWith('image/') ? extMime : null) || storedImageMime || 'image/jpeg';
     res.setHeader('Content-Type', contentType);
     res.setHeader('Cache-Control', 'private, max-age=3600');
     res.setHeader('Cross-Origin-Resource-Policy', 'cross-origin');

--- a/backend/src/routes/adminPhotos.js
+++ b/backend/src/routes/adminPhotos.js
@@ -1162,18 +1162,20 @@ router.get('/:eventId/photo/:photoId', adminAuth, requirePermission('photos.view
     const storedVideoMime = photo.mime_type && /^video\/[\w.+-]+$/.test(photo.mime_type)
       ? photo.mime_type
       : null;
-    // Honor a stored image MIME only when it is a known-safe RASTER type
-    // (#908 review round 2): the S3 auto-importer stores correct types for
-    // formats whose extension isn't in EXTENSION_TO_MIME (avif/bmp/tiff/
-    // heic), so map-only would mislabel them as image/jpeg. Allowlist, not
-    // a regex — image/svg+xml is a scriptable inline type and must never
-    // pass, and migration 039's blanket image/jpeg backfill on legacy rows
-    // is why the extension still wins ahead of this (see below).
-    const SAFE_IMAGE_MIME = new Set([
-      'image/jpeg', 'image/png', 'image/webp', 'image/gif',
-      'image/avif', 'image/bmp', 'image/tiff', 'image/heic', 'image/heif',
-    ]);
-    const storedImageMime = SAFE_IMAGE_MIME.has(photo.mime_type) ? photo.mime_type : null;
+    // Honor a stored image MIME for any header-safe RASTER type (#908
+    // review): the S3 auto-importer accepts arbitrary image/* from
+    // mime-types and stores it (avif/bmp/tiff/heic/apng/ico/jxl/…), and a
+    // hand-listed allowlist kept missing formats. Allow image/<token> but
+    // NEVER the scriptable svg / *+xml family (image/svg+xml executes
+    // inline). The strict token + anchors also block header injection
+    // (image/x\r\nY:). Migration 039's blanket image/jpeg backfill on
+    // legacy rows is why the mapped extension still wins ahead of this.
+    const storedImageMime =
+      photo.mime_type &&
+      /^image\/[\w.+-]+$/.test(photo.mime_type) &&
+      !/^image\/svg|xml/i.test(photo.mime_type)
+        ? photo.mime_type
+        : null;
     const isVideo = photo.media_type === 'video' ||
       Boolean(storedVideoMime) ||
       Boolean(extMime && extMime.startsWith('video/'));

--- a/frontend/src/hooks/useExpiryRefresh.ts
+++ b/frontend/src/hooks/useExpiryRefresh.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 // setTimeout stores its delay in a signed 32-bit int; anything larger
 // overflows and fires immediately. Events expiring weeks out don't need a
@@ -23,12 +23,21 @@ export function useExpiryRefresh(
     .filter((n) => Number.isFinite(n) && n > Date.now())
     .sort((a, b) => a - b)[0];
 
+  // Bumped by a capped wake-up so the effect re-evaluates and re-arms when
+  // the target is further out than a single setTimeout can represent.
+  const [rearm, setRearm] = useState(0);
   useEffect(() => {
     if (next === undefined) return;
     // +1s so the timer lands just past the boundary, not exactly on it.
     const delay = next - Date.now() + 1000;
-    if (delay > MAX_TIMEOUT_MS) return;
+    if (delay > MAX_TIMEOUT_MS) {
+      // Too far for one timer (setTimeout overflows past ~24.8 days and
+      // fires immediately). Wake at the cap and re-arm with a now-smaller
+      // remaining delay, so a page left mounted for weeks still updates.
+      const id = window.setTimeout(() => setRearm((n) => n + 1), MAX_TIMEOUT_MS);
+      return () => window.clearTimeout(id);
+    }
     const id = window.setTimeout(onExpiry, Math.max(0, delay));
     return () => window.clearTimeout(id);
-  }, [next, onExpiry]);
+  }, [next, onExpiry, rearm]);
 }

--- a/frontend/src/hooks/useExpiryRefresh.ts
+++ b/frontend/src/hooks/useExpiryRefresh.ts
@@ -1,0 +1,34 @@
+import { useEffect } from 'react';
+
+// setTimeout stores its delay in a signed 32-bit int; anything larger
+// overflows and fires immediately. Events expiring weeks out don't need a
+// live tick anyway, so we simply don't schedule past this horizon.
+const MAX_TIMEOUT_MS = 2 ** 31 - 1;
+
+/**
+ * Fire `onExpiry` once, at the soonest future timestamp in `timestamps`
+ * (#909 review). Admin expiry badges are computed inline from Date.now()
+ * at render time, so without this a page left mounted across an event's
+ * expiry keeps showing the stale "active"/"1 day left" state until an
+ * unrelated render happens — which for editor/viewer roles (no health
+ * poll) may never occur. When the callback updates state/data, the next
+ * expiry reschedules automatically.
+ */
+export function useExpiryRefresh(
+  timestamps: Array<string | null | undefined>,
+  onExpiry: () => void,
+): void {
+  const next = timestamps
+    .map((t) => (t ? new Date(t).getTime() : NaN))
+    .filter((n) => Number.isFinite(n) && n > Date.now())
+    .sort((a, b) => a - b)[0];
+
+  useEffect(() => {
+    if (next === undefined) return;
+    // +1s so the timer lands just past the boundary, not exactly on it.
+    const delay = next - Date.now() + 1000;
+    if (delay > MAX_TIMEOUT_MS) return;
+    const id = window.setTimeout(onExpiry, Math.max(0, delay));
+    return () => window.clearTimeout(id);
+  }, [next, onExpiry]);
+}

--- a/frontend/src/pages/admin/AdminDashboard.tsx
+++ b/frontend/src/pages/admin/AdminDashboard.tsx
@@ -78,7 +78,10 @@ export const AdminDashboard: React.FC = () => {
   // which silently missed any expiring event outside the first 100 rows.
   const { data: expiringEventsData, isLoading: eventsLoading } = useQuery({
     queryKey: ['admin-events-summary', 'expiring'],
-    queryFn: () => eventsService.getEvents(1, 5, 'expiring'),
+    // Order by soonest expiry so the five shown rows ARE the earliest to
+    // expire — useExpiryRefresh then schedules against the true next boundary
+    // even when >5 events are expiring (#909 review round 3).
+    queryFn: () => eventsService.getEvents(1, 5, 'expiring', undefined, 'expires_at', 'asc'),
   });
 
   // Keep the "expiring soon" card honest when a row crosses its expiry while

--- a/frontend/src/pages/admin/AdminDashboard.tsx
+++ b/frontend/src/pages/admin/AdminDashboard.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { 
   Calendar, 
@@ -16,6 +16,8 @@ import {
   X
 } from 'lucide-react';
 import { parseISO } from 'date-fns';
+import { useQueryClient } from '@tanstack/react-query';
+import { useExpiryRefresh } from '../../hooks/useExpiryRefresh';
 import { useTranslation } from 'react-i18next';
 import { useLocalizedDate } from '../../hooks/useLocalizedDate';
 import { useMutationWithToast } from '../../hooks';
@@ -79,6 +81,23 @@ export const AdminDashboard: React.FC = () => {
     queryFn: () => eventsService.getEvents(1, 5, 'expiring'),
   });
 
+  // Keep the "expiring soon" card honest when a row crosses its expiry while
+  // the dashboard sits open (#909 review). Filtering client-side desynced the
+  // list from the cached total/stat; instead we refetch the whole set at the
+  // boundary — the backend returns rows/total/stats that already exclude the
+  // now-expired event, so everything stays consistent. Fixes the stale
+  // "1 day left" for roles without the health poll (editor/viewer). Placed
+  // with the other top-level hooks, above the loading early-return.
+  const queryClient = useQueryClient();
+  const refreshExpiring = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: ['admin-events-summary', 'expiring'] });
+    queryClient.invalidateQueries({ queryKey: ['admin-dashboard-stats'] });
+  }, [queryClient]);
+  useExpiryRefresh(
+    (expiringEventsData?.events ?? []).map((e: any) => e.expires_at),
+    refreshExpiring,
+  );
+
   // Pending workflow approvals — only when the workflow engine is live. These
   // are the human-in-the-loop gates (e.g. "review invoice before sending").
   const { flags } = useFeatureFlags();
@@ -115,14 +134,7 @@ export const AdminDashboard: React.FC = () => {
     );
   }
 
-  // Drop rows whose expiry has actually passed while the dashboard sat open
-  // (review #909): the query isn't polled, so a cached expired event would
-  // otherwise linger — and the day clamp below rendered it as "1 day left"
-  // indefinitely. An expired gallery is inaccessible; it shouldn't show in
-  // "expiring soon" at all.
-  const expiringEvents = (expiringEventsData?.events ?? []).filter(
-    (e: any) => !e.expires_at || parseISO(e.expires_at).getTime() > Date.now()
-  );
+  const expiringEvents = expiringEventsData?.events ?? [];
   const expiringTotal = expiringEventsData?.pagination?.total ?? expiringEvents.length;
 
   // Format numbers for display
@@ -244,10 +256,10 @@ export const AdminDashboard: React.FC = () => {
             ) : (
               <div className="space-y-3">
                 {expiringEvents.map((event) => {
-                  // Ceiling (#909): truncation showed "0 days" on the last
-                  // day. The list is pre-filtered to unexpired rows, so the
-                  // delta is always positive and ceils to >= 1 — no clamp.
-                  const daysLeft = Math.ceil((parseISO(event.expires_at!).getTime() - Date.now()) / 86400000);
+                  // Ceiling so the final partial day reads "1 day", not "0"
+                  // (#909); clamped since a row can sit at the boundary for the
+                  // instant before useExpiryRefresh refetches it away.
+                  const daysLeft = Math.max(1, Math.ceil((parseISO(event.expires_at!).getTime() - Date.now()) / 86400000));
 
                   return (
                     <div

--- a/frontend/src/pages/admin/AdminDashboard.tsx
+++ b/frontend/src/pages/admin/AdminDashboard.tsx
@@ -115,7 +115,14 @@ export const AdminDashboard: React.FC = () => {
     );
   }
 
-  const expiringEvents = expiringEventsData?.events ?? [];
+  // Drop rows whose expiry has actually passed while the dashboard sat open
+  // (review #909): the query isn't polled, so a cached expired event would
+  // otherwise linger — and the day clamp below rendered it as "1 day left"
+  // indefinitely. An expired gallery is inaccessible; it shouldn't show in
+  // "expiring soon" at all.
+  const expiringEvents = (expiringEventsData?.events ?? []).filter(
+    (e: any) => !e.expires_at || parseISO(e.expires_at).getTime() > Date.now()
+  );
   const expiringTotal = expiringEventsData?.pagination?.total ?? expiringEvents.length;
 
   // Format numbers for display
@@ -237,8 +244,10 @@ export const AdminDashboard: React.FC = () => {
             ) : (
               <div className="space-y-3">
                 {expiringEvents.map((event) => {
-                  // Ceiling (#909): truncation showed "0 days" on the last day.
-                  const daysLeft = Math.max(1, Math.ceil((parseISO(event.expires_at!).getTime() - Date.now()) / 86400000));
+                  // Ceiling (#909): truncation showed "0 days" on the last
+                  // day. The list is pre-filtered to unexpired rows, so the
+                  // delta is always positive and ceils to >= 1 — no clamp.
+                  const daysLeft = Math.ceil((parseISO(event.expires_at!).getTime() - Date.now()) / 86400000);
 
                   return (
                     <div

--- a/frontend/src/pages/admin/EventDetailsPage.tsx
+++ b/frontend/src/pages/admin/EventDetailsPage.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import { useExpiryRefresh } from '../../hooks/useExpiryRefresh';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'react-toastify';
@@ -100,6 +101,13 @@ export const EventDetailsPage: React.FC = () => {
     queryFn: () => eventsService.getEvent(parseInt(id!)),
     enabled: !!id,
   });
+
+  // Flip the expiry banner live when the timestamp passes with the page open
+  // (#909 review) — isExpired further down is computed inline from Date.now().
+  // Kept here with the other hooks, above the loading early-return.
+  const [, setExpiryTick] = useState(0);
+  const bumpExpiryTick = useCallback(() => setExpiryTick((n) => n + 1), []);
+  useExpiryRefresh([event?.expires_at], bumpExpiryTick);
 
   // Fetch feedback settings
   const { data: eventFeedbackSettings } = useQuery({

--- a/frontend/src/pages/admin/EventsListPage.tsx
+++ b/frontend/src/pages/admin/EventsListPage.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
+import { useExpiryRefresh } from '../../hooks/useExpiryRefresh';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import {
   Plus,
@@ -230,6 +231,14 @@ export const EventsListPage: React.FC = () => {
   // Filtering and searching now happen server-side. Use the response directly,
   // ordered as the backend returned them (created_at desc by default).
   const events: Event[] = data?.events ?? [];
+
+  // Re-render when the soonest event expiry passes (#909 review): the status
+  // badge is computed inline from Date.now(), so a page left open would keep
+  // showing "active"/"1 day left" past the boundary. A no-op state bump is
+  // enough — the recomputed render reads a fresh Date.now().
+  const [, setExpiryTick] = useState(0);
+  const bumpExpiryTick = useCallback(() => setExpiryTick((n) => n + 1), []);
+  useExpiryRefresh(events.map((e) => e.expires_at), bumpExpiryTick);
   const pagination = data?.pagination;
   const totalPages = pagination?.totalPages ?? 1;
   const filteredCount = pagination?.total ?? 0;

--- a/frontend/src/pages/admin/EventsListPage.tsx
+++ b/frontend/src/pages/admin/EventsListPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useExpiryRefresh } from '../../hooks/useExpiryRefresh';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import {
@@ -142,7 +142,7 @@ export const EventsListPage: React.FC = () => {
 
   // Fetch events — fully server-side: pagination, status filter, and search
   // (#346 — counters and search were previously bounded to the first 100 rows).
-  const { data, isLoading, error } = useQuery({
+  const { data, isLoading, error, refetch } = useQuery({
     queryKey: ['admin-events', statusFilter ?? 'all', debouncedSearchTerm, page],
     queryFn: () => eventsService.getEvents(page, PAGE_SIZE, statusFilter, debouncedSearchTerm || undefined),
     placeholderData: (prev) => prev,
@@ -232,13 +232,13 @@ export const EventsListPage: React.FC = () => {
   // ordered as the backend returned them (created_at desc by default).
   const events: Event[] = data?.events ?? [];
 
-  // Re-render when the soonest event expiry passes (#909 review): the status
-  // badge is computed inline from Date.now(), so a page left open would keep
-  // showing "active"/"1 day left" past the boundary. A no-op state bump is
-  // enough — the recomputed render reads a fresh Date.now().
-  const [, setExpiryTick] = useState(0);
-  const bumpExpiryTick = useCallback(() => setExpiryTick((n) => n + 1), []);
-  useExpiryRefresh(events.map((e) => e.expires_at), bumpExpiryTick);
+  // Refetch when the soonest event expiry passes (#909 review): the status
+  // badge is computed inline from Date.now(), and under the "expiring" filter
+  // the backend drops the row once expires_at <= now — so a plain re-render
+  // would leave a stale "Expired" row (and total) in that filtered view.
+  // refetch() re-runs with the current page/filter/search: rows and totals
+  // both correct under every filter.
+  useExpiryRefresh(events.map((e) => e.expires_at), refetch);
   const pagination = data?.pagination;
   const totalPages = pagination?.totalPages ?? 1;
   const filteredCount = pagination?.total ?? 0;

--- a/frontend/src/services/events.service.ts
+++ b/frontend/src/services/events.service.ts
@@ -95,7 +95,9 @@ export const eventsService = {
     page: number = 1,
     limit: number = 20,
     status?: EventStatusFilter,
-    search?: string
+    search?: string,
+    sortBy?: string,
+    sortOrder?: 'asc' | 'desc'
   ): Promise<EventsListResponse> {
     const params = new URLSearchParams({
       page: page.toString(),
@@ -107,6 +109,12 @@ export const eventsService = {
     }
     if (search) {
       params.append('search', search);
+    }
+    if (sortBy) {
+      params.append('sortBy', sortBy);
+    }
+    if (sortOrder) {
+      params.append('sortOrder', sortOrder);
     }
 
     const response = await api.get<EventsListResponse>(`/admin/events?${params}`);


### PR DESCRIPTION
Codex-review follow-ups on the merged #910 (#908 MIME) and #916 (#909 expiry). Every defect here lives on `main` in the merged code; the stable ports are on the still-open #911 / #917.

## adminPhotos.js — Content-Type resolver (#908)

1. **Own-property lookup.** A filename ending in `.constructor` / `.__proto__` / `.toString` made `EXTENSION_TO_MIME[ext]` return an inherited `Object.prototype` member (truthy), so `extMime.startsWith` threw → permanent **500** on the admin view for that photo. Now `hasOwnProperty`-gated. (Reachability is narrow — upload extension-allowlisting — so it's defense-in-depth; verified the raw lookup throws.)
2. **Safe stored-image allowlist (round 2).** The prior round made the image side map-only (to dodge migration 039's blanket `image/jpeg` backfill and `image/svg+xml`), which regressed the S3 auto-importer: it stores correct types for `avif`/`bmp`/`tiff`/`heic` whose extensions aren't mapped, so those served as `image/jpeg`. Precedence is now mapped-extension (still corrects 039) → stored MIME **if in a safe raster allowlist** → `image/jpeg`. Allowlist, not a regex — `image/svg+xml` stays excluded.

## AdminDashboard / EventsListPage / EventDetailsPage — expiry reactivity (#909)

The expiry badges are computed inline from `Date.now()` at render, so a page left open across an event's expiry kept showing "active"/"1 day left" until an unrelated render — which for editor/viewer roles (no health poll) never happens. And my first-round dashboard filter desynced the visible list from the cached total/stat.

New `useExpiryRefresh` hook fires once at the soonest future expiry (overflow-guarded `setTimeout`). The dashboard refetches its expiring + stats queries (backend already excludes expired events → rows/total/stats stay consistent; client-side filter removed); the list/detail pages bump a tick so the inline badges recompute. Hooks sit above the loading early-returns — `react-hooks/rules-of-hooks` is disabled in this repo's eslint, so a misplacement was a latent crash, not a lint error.

## Tests

`adminPhotoContentType` suite → 13 cases (prototype-key `.constructor`/`.__proto__`, avif preserved, svg degraded, plus the earlier CRLF/XSS/039 guards). Frontend build + lint clean.
