### PR TITLE
feat(gallery): mouse-wheel zoom at cursor in the lightbox (#885)

### DIFF
--- a/frontend/src/components/gallery/PhotoLightbox.tsx
+++ b/frontend/src/components/gallery/PhotoLightbox.tsx
@@ -457,6 +457,46 @@ export const PhotoLightbox: React.FC<PhotoLightboxProps> = ({
     }
   };
 
+  // Mouse-wheel zoom centered on the cursor (#885). Multiplicative steps
+  // feel uniform across the 1–3 range and are finer than the 0.5-step
+  // toolbar buttons. Attached as a native non-passive listener because
+  // the event must be preventDefault()ed to keep the page behind the
+  // lightbox from scrolling, and React's onWheel can't guarantee that.
+  const wheelStateRef = useRef({ zoom, dragOffset });
+  wheelStateRef.current = { zoom, dragOffset };
+  useEffect(() => {
+    const el = trackContainerRef.current;
+    if (!el || currentPhoto?.media_type === 'video') return;
+    const handleWheel = (e: WheelEvent) => {
+      e.preventDefault();
+      const { zoom: prevZoom, dragOffset: prevOffset } = wheelStateRef.current;
+      // deltaMode 1 = line-based scrolling (Firefox); normalise to pixels.
+      const deltaPx = e.deltaMode === 1 ? e.deltaY * 33 : e.deltaY;
+      const nextZoom = Math.min(3, Math.max(1, prevZoom * Math.exp(-deltaPx * 0.002)));
+      if (nextZoom === prevZoom) return;
+      if (nextZoom <= 1) {
+        setZoom(1);
+        setDragOffset({ x: 0, y: 0 });
+        return;
+      }
+      // Keep the image point under the cursor fixed while the scale
+      // changes: take the cursor's offset from the container centre (the
+      // image's natural centre) and rescale its distance to the current
+      // pan offset by the zoom ratio.
+      const rect = el.getBoundingClientRect();
+      const cx = e.clientX - (rect.left + rect.width / 2);
+      const cy = e.clientY - (rect.top + rect.height / 2);
+      const ratio = nextZoom / prevZoom;
+      setZoom(nextZoom);
+      setDragOffset({
+        x: cx - (cx - prevOffset.x) * ratio,
+        y: cy - (cy - prevOffset.y) * ratio,
+      });
+    };
+    el.addEventListener('wheel', handleWheel, { passive: false });
+    return () => el.removeEventListener('wheel', handleWheel);
+  }, [currentPhoto]);
+
   // Touch event handlers: pinch-to-zoom (2 fingers) + single-finger
   // carousel-style swipe nav. Swipe is suppressed while zoomed in so the
   // user can pan instead. The carousel is also disabled mid-animation.

--- a/frontend/src/components/gallery/PhotoLightbox.tsx
+++ b/frontend/src/components/gallery/PhotoLightbox.tsx
@@ -470,11 +470,18 @@ export const PhotoLightbox: React.FC<PhotoLightboxProps> = ({
     const handleWheel = (e: WheelEvent) => {
       e.preventDefault();
       const { zoom: prevZoom, dragOffset: prevOffset } = wheelStateRef.current;
-      // deltaMode 1 = line-based scrolling (Firefox); normalise to pixels.
-      const deltaPx = e.deltaMode === 1 ? e.deltaY * 33 : e.deltaY;
+      // Normalise deltaY to pixels: deltaMode 1 = lines (Firefox),
+      // deltaMode 2 = pages (rare; deltaY is ±1 per notch there).
+      const deltaPx = e.deltaMode === 1 ? e.deltaY * 33
+        : e.deltaMode === 2 ? e.deltaY * 300
+        : e.deltaY;
       const nextZoom = Math.min(3, Math.max(1, prevZoom * Math.exp(-deltaPx * 0.002)));
       if (nextZoom === prevZoom) return;
       if (nextZoom <= 1) {
+        // Sync the ref before the async setState so a burst of wheel
+        // events landing within one render frame chains each step off
+        // the previous one instead of all reading the same stale zoom.
+        wheelStateRef.current = { zoom: 1, dragOffset: { x: 0, y: 0 } };
         setZoom(1);
         setDragOffset({ x: 0, y: 0 });
         return;
@@ -487,11 +494,13 @@ export const PhotoLightbox: React.FC<PhotoLightboxProps> = ({
       const cx = e.clientX - (rect.left + rect.width / 2);
       const cy = e.clientY - (rect.top + rect.height / 2);
       const ratio = nextZoom / prevZoom;
-      setZoom(nextZoom);
-      setDragOffset({
+      const nextOffset = {
         x: cx - (cx - prevOffset.x) * ratio,
         y: cy - (cy - prevOffset.y) * ratio,
-      });
+      };
+      wheelStateRef.current = { zoom: nextZoom, dragOffset: nextOffset };
+      setZoom(nextZoom);
+      setDragOffset(nextOffset);
     };
     el.addEventListener('wheel', handleWheel, { passive: false });
     return () => el.removeEventListener('wheel', handleWheel);


### PR DESCRIPTION
Closes #885.

## What

Mouse-wheel zoom in the gallery lightbox, centered on the cursor position, as requested by @jodrmx.

- **Wheel up/down zooms in/out** between 100% and the existing 300% cap.
- **Zoom is pinned to the cursor**: the image point under the pointer stays fixed while the scale changes (classic zoom-at-point math reusing the existing `dragOffset` pan state, so panning/drag continue to work unchanged).
- **Finer granularity**: multiplicative ~27%-per-notch steps instead of the toolbar buttons' fixed 50%, and trackpads get proportionally smaller increments (`deltaY`-scaled). Firefox's line-based `deltaMode` is normalised to pixels.
- Zooming out below 100% snaps back to fit and re-centres (clears the pan offset), matching the +/- button behaviour.

## Implementation notes

`PhotoLightbox.tsx` only. The listener is attached natively with `{ passive: false }` (not React `onWheel`) because the event must be `preventDefault()`ed to stop the page behind the lightbox from scrolling — verified `window.scrollY` stays 0 while wheeling. Videos keep default wheel behaviour, mirroring the other pointer handlers. Latest zoom/offset are read through a ref so the single listener never acts on stale state.

## Verification

Dev server against a local gallery (Playwright): wheeled at a point in the upper-left quadrant → zoom label showed 127%/162%/205%… (finer than the 50% steps), and the applied transform matched the zoom-at-point math exactly (`translate = (cursor − offset·ratio)/zoom`). Hit the 300% cap cleanly, wheel-down below 100% reset offset, +/-/fit buttons and drag-pan unaffected.

_Screenshot (lightbox at 162% after two wheel notches, zoomed toward the cursor) follows in a comment._
