### PR TITLE
fix(security): block guest access to hidden/client-only photos across bulk + secure routes (stable)

### DIFF
--- a/backend/__tests__/routes/hiddenPhotoAccessControl.test.js
+++ b/backend/__tests__/routes/hiddenPhotoAccessControl.test.js
@@ -173,6 +173,22 @@ describe('hidden-photo access control (GHSA cluster)', () => {
     });
   });
 
+  describe('legacy secure-token mint (protectedImages generate-secure-token)', () => {
+    it('403s a hidden photo for a guest', async () => {
+      const res = await request(app)
+        .post(`/api/images/${SLUG}/photo/${hiddenId}/generate-secure-token`)
+        .set('Authorization', `Bearer ${guestToken()}`);
+      expect(res.status).toBe(403);
+    });
+    it('mints for a client', async () => {
+      const res = await request(app)
+        .post(`/api/images/${SLUG}/photo/${hiddenId}/generate-secure-token`)
+        .set('Authorization', `Bearer ${clientToken()}`);
+      expect(res.status).toBe(200);
+      expect(res.body.token).toBeDefined();
+    });
+  });
+
   describe('secure-token mint (GHSA-2hqg)', () => {
     it('403s minting a secure token for a hidden photo as a guest', async () => {
       const res = await request(app)

--- a/backend/__tests__/routes/hiddenPhotoAccessControl.test.js
+++ b/backend/__tests__/routes/hiddenPhotoAccessControl.test.js
@@ -206,4 +206,35 @@ describe('hidden-photo access control (GHSA cluster)', () => {
       expect(res.body.token).toBeDefined();
     });
   });
+
+  // A capability minted while a photo is visible must stop serving once the
+  // photo is hidden — unless minted by a client (clientBypass in the token).
+  describe('signed-URL TOCTOU (hidden AFTER minting)', () => {
+    afterEach(async () => {
+      await db('photos').where({ id: visibleId }).update({ visibility: 'visible' });
+    });
+
+    it("a guest's pre-minted signed URL stops serving once the photo is hidden", async () => {
+      const mint = await request(app)
+        .post(`/api/images/${SLUG}/photo/${visibleId}/generate-url`)
+        .set('Authorization', `Bearer ${guestToken()}`);
+      expect(mint.status).toBe(200);
+      const url = mint.body.url;
+      // Still visible → serves.
+      expect((await request(app).get(url)).status).toBe(200);
+      // Hide it → the guest token (no clientBypass) must now be refused.
+      await db('photos').where({ id: visibleId }).update({ visibility: 'hidden' });
+      expect((await request(app).get(url)).status).toBe(403);
+    });
+
+    it("a client's pre-minted signed URL keeps serving after the photo is hidden", async () => {
+      const mint = await request(app)
+        .post(`/api/images/${SLUG}/photo/${visibleId}/generate-url`)
+        .set('Authorization', `Bearer ${clientToken()}`);
+      expect(mint.status).toBe(200);
+      const url = mint.body.url;
+      await db('photos').where({ id: visibleId }).update({ visibility: 'hidden' });
+      expect((await request(app).get(url)).status).toBe(200);
+    });
+  });
 });

--- a/backend/__tests__/routes/hiddenPhotoAccessControl.test.js
+++ b/backend/__tests__/routes/hiddenPhotoAccessControl.test.js
@@ -1,0 +1,193 @@
+/**
+ * Hidden/client-only photo access control across the bulk + secure photo
+ * routes (GHSA cluster: fpwq / ghf8 / 3jvw / 9cc4 / 2hqg / jc22).
+ *
+ * A photo with visibility='hidden' is client-only. The main photo-list and
+ * single-photo download/view routes enforced this, but the bulk-download,
+ * protected-image, and secure-image routes shipped without the check —
+ * letting an ordinary guest reach hidden photos. These tests pin that
+ * guests are refused and PIN-clients (accessLevel='client') still succeed.
+ */
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+process.env.NODE_ENV = 'test';
+process.env.TEST_DATABASE_PATH = path.join(
+  fs.mkdtempSync(path.join(os.tmpdir(), 'picpeak-hidden-')), 'db.sqlite',
+);
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'hidden-photo-test-secret';
+process.env.STORAGE_PATH = fs.mkdtempSync(path.join(os.tmpdir(), 'picpeak-hidden-storage-'));
+
+const request = require('supertest');
+const express = require('express');
+const cookieParser = require('cookie-parser');
+const jwt = require('jsonwebtoken');
+
+const { bootCrmDb, seedMinimal } = require('../integration/helpers/crmDb');
+
+const SLUG = 'hidden-photo-test-event';
+
+describe('hidden-photo access control (GHSA cluster)', () => {
+  let db;
+  let cleanup;
+  let app;
+  let eventId;
+  let visibleId;
+  let hiddenId;
+
+  const guestToken = () => jwt.sign(
+    { eventId, eventSlug: SLUG, type: 'gallery' },
+    process.env.JWT_SECRET,
+    { expiresIn: '1h', issuer: 'picpeak-auth' }
+  );
+  const clientToken = () => jwt.sign(
+    { eventId, eventSlug: SLUG, type: 'gallery', accessLevel: 'client' },
+    process.env.JWT_SECRET,
+    { expiresIn: '1h', issuer: 'picpeak-auth' }
+  );
+
+  beforeAll(async () => {
+    ({ db, cleanup } = await bootCrmDb());
+    await seedMinimal(db);
+
+    const inserted = await db('events').insert({
+      slug: SLUG,
+      event_type: 'wedding',
+      event_name: 'Hidden Photo Test',
+      event_date: '2026-08-01',
+      host_email: 'host@example.com',
+      admin_email: 'admin@example.com',
+      password_hash: 'x',
+      share_link: `/gallery/${SLUG}/share`,
+      share_token: 'hidden-photo-share',
+      expires_at: new Date(Date.now() + 7 * 24 * 3600 * 1000).toISOString(),
+      is_active: 1, is_archived: 0, is_draft: 0, allow_downloads: 1,
+      created_at: new Date().toISOString(),
+    }).returning('id');
+    eventId = inserted[0]?.id ?? inserted[0];
+
+    const photoDir = path.join(process.env.STORAGE_PATH, 'events/active', SLUG);
+    fs.mkdirSync(photoDir, { recursive: true });
+
+    // A real 1x1 PNG so the protected /view route's Sharp processing path
+    // succeeds (fake bytes 500 on metadata()). Content, not extension,
+    // drives Sharp's format detection.
+    const PNG_1x1 = Buffer.from(
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMCAQGV2rY9AAAAAElFTkSuQmCC',
+      'base64'
+    );
+    const mkPhoto = async (filename, visibility) => {
+      fs.writeFileSync(path.join(photoDir, filename), PNG_1x1);
+      const p = await db('photos').insert({
+        event_id: eventId,
+        filename,
+        path: `${SLUG}/${filename}`,
+        type: 'individual',
+        visibility,
+        uploaded_at: new Date().toISOString(),
+      }).returning('id');
+      return p[0]?.id ?? p[0];
+    };
+    visibleId = await mkPhoto('visible.jpg', 'visible');
+    hiddenId = await mkPhoto('hidden.jpg', 'hidden');
+
+    app = express();
+    app.use(express.json());
+    app.use(cookieParser());
+    app.use('/api/gallery', require('../../src/routes/gallery'));
+    app.use('/api/images', require('../../src/routes/protectedImages'));
+    app.use('/api/secure-images', require('../../src/routes/secureImages'));
+  }, 120000);
+
+  afterAll(async () => { if (cleanup) await cleanup(); });
+
+  describe('download-selected (GHSA-ghf8, medium)', () => {
+    it('omits a hidden photo for a guest even when its id is requested', async () => {
+      const res = await request(app)
+        .post(`/api/gallery/${SLUG}/download-selected`)
+        .set('Authorization', `Bearer ${guestToken()}`)
+        .send({ photo_ids: [visibleId, hiddenId] });
+      // The visible photo still zips; the hidden one is filtered out. If
+      // only the hidden id were requested, the filter empties the set → 404.
+      expect(res.status).toBe(200);
+      const solo = await request(app)
+        .post(`/api/gallery/${SLUG}/download-selected`)
+        .set('Authorization', `Bearer ${guestToken()}`)
+        .send({ photo_ids: [hiddenId] });
+      expect(solo.status).toBe(404);
+    });
+
+    it('includes the hidden photo for a client', async () => {
+      const res = await request(app)
+        .post(`/api/gallery/${SLUG}/download-selected`)
+        .set('Authorization', `Bearer ${clientToken()}`)
+        .send({ photo_ids: [hiddenId] });
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('download-all (GHSA-fpwq, medium)', () => {
+    it('streams for a guest without erroring (hidden photos filtered)', async () => {
+      const res = await request(app)
+        .get(`/api/gallery/${SLUG}/download-all`)
+        .set('Authorization', `Bearer ${guestToken()}`);
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('protected-image view (GHSA-9cc4)', () => {
+    it('403s a hidden photo for a guest', async () => {
+      const res = await request(app)
+        .get(`/api/images/${SLUG}/photo/${hiddenId}/view`)
+        .set('Authorization', `Bearer ${guestToken()}`);
+      expect(res.status).toBe(403);
+    });
+    it('serves a visible photo for a guest', async () => {
+      const res = await request(app)
+        .get(`/api/images/${SLUG}/photo/${visibleId}/view`)
+        .set('Authorization', `Bearer ${guestToken()}`);
+      expect(res.status).toBe(200);
+    });
+    it('serves a hidden photo for a client', async () => {
+      const res = await request(app)
+        .get(`/api/images/${SLUG}/photo/${hiddenId}/view`)
+        .set('Authorization', `Bearer ${clientToken()}`);
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('signed-URL mint (GHSA-3jvw)', () => {
+    it('403s minting a signed URL for a hidden photo as a guest', async () => {
+      const res = await request(app)
+        .post(`/api/images/${SLUG}/photo/${hiddenId}/generate-url`)
+        .set('Authorization', `Bearer ${guestToken()}`);
+      expect(res.status).toBe(403);
+    });
+    it('mints for a client', async () => {
+      const res = await request(app)
+        .post(`/api/images/${SLUG}/photo/${hiddenId}/generate-url`)
+        .set('Authorization', `Bearer ${clientToken()}`);
+      expect(res.status).toBe(200);
+      expect(res.body.url).toContain('/signed/');
+    });
+  });
+
+  describe('secure-token mint (GHSA-2hqg)', () => {
+    it('403s minting a secure token for a hidden photo as a guest', async () => {
+      const res = await request(app)
+        .post(`/api/secure-images/${SLUG}/generate-token`)
+        .set('Authorization', `Bearer ${guestToken()}`)
+        .send({ photoId: hiddenId });
+      expect(res.status).toBe(403);
+    });
+    it('mints for a client', async () => {
+      const res = await request(app)
+        .post(`/api/secure-images/${SLUG}/generate-token`)
+        .set('Authorization', `Bearer ${clientToken()}`)
+        .send({ photoId: hiddenId });
+      expect(res.status).toBe(200);
+      expect(res.body.token).toBeDefined();
+    });
+  });
+});

--- a/backend/__tests__/utils/photoVisibility.test.js
+++ b/backend/__tests__/utils/photoVisibility.test.js
@@ -1,0 +1,40 @@
+/**
+ * Unit tests for the shared hidden-photo access-control helper.
+ *
+ * Pins the rule that ordinary gallery guests never receive photos with
+ * visibility='hidden' (NULL = visible), while PIN-clients see everything.
+ */
+const {
+  canSeeHiddenPhotos,
+  isPhotoHiddenFromViewer,
+} = require('../../src/utils/photoVisibility');
+
+describe('canSeeHiddenPhotos', () => {
+  it('is true only for the client access level', () => {
+    expect(canSeeHiddenPhotos('client')).toBe(true);
+    expect(canSeeHiddenPhotos('guest')).toBe(false);
+    expect(canSeeHiddenPhotos('slideshow')).toBe(false);
+    expect(canSeeHiddenPhotos(undefined)).toBe(false);
+  });
+});
+
+describe('isPhotoHiddenFromViewer', () => {
+  it('blocks a hidden photo from guests', () => {
+    expect(isPhotoHiddenFromViewer({ visibility: 'hidden' }, 'guest')).toBe(true);
+    expect(isPhotoHiddenFromViewer({ visibility: 'hidden' }, 'slideshow')).toBe(true);
+  });
+
+  it('lets clients see hidden photos', () => {
+    expect(isPhotoHiddenFromViewer({ visibility: 'hidden' }, 'client')).toBe(false);
+  });
+
+  it('treats visible and NULL visibility as viewable by everyone', () => {
+    expect(isPhotoHiddenFromViewer({ visibility: 'visible' }, 'guest')).toBe(false);
+    expect(isPhotoHiddenFromViewer({ visibility: null }, 'guest')).toBe(false);
+    expect(isPhotoHiddenFromViewer({}, 'guest')).toBe(false);
+  });
+
+  it('is null-safe', () => {
+    expect(isPhotoHiddenFromViewer(null, 'guest')).toBe(false);
+  });
+});

--- a/backend/src/routes/adminPhotos.js
+++ b/backend/src/routes/adminPhotos.js
@@ -757,6 +757,16 @@ router.patch('/:eventId/photos/:photoId', adminAuth, requirePermission('photos.e
       .where({ id: photoId, event_id: eventId })
       .update(updateData);
 
+    // A visibility or category change alters which photos belong in the
+    // guest download bundle — drop the cached ZIP so it rebuilds fresh,
+    // otherwise a hide→unhide cycle can leave the stale cache omitting
+    // photos added in between (codex review).
+    if (updateData.visibility !== undefined
+        || Object.prototype.hasOwnProperty.call(updateData, 'category_id')
+        || Object.prototype.hasOwnProperty.call(updateData, 'type')) {
+      downloadZipService.invalidate(parseInt(eventId, 10));
+    }
+
     // Fetch and return the updated photo
     const updatedPhoto = await db('photos')
       .where({ id: photoId, event_id: eventId })
@@ -904,6 +914,14 @@ router.post('/:eventId/photos/bulk-update', adminAuth, requirePermission('photos
       .whereIn('id', photoIds)
       .where('event_id', eventId)
       .update(updateData);
+
+    // Visibility/category changes alter the guest download bundle — drop the
+    // cached ZIP so it rebuilds fresh (codex review).
+    if (updateData.visibility !== undefined
+        || Object.prototype.hasOwnProperty.call(updateData, 'category_id')
+        || Object.prototype.hasOwnProperty.call(updateData, 'type')) {
+      downloadZipService.invalidate(parseInt(eventId, 10));
+    }
 
     res.json({ message: `${photoIds.length} photos updated successfully` });
   } catch (error) {

--- a/backend/src/routes/gallery.js
+++ b/backend/src/routes/gallery.js
@@ -958,13 +958,20 @@ router.get('/:slug/download-all', verifyGalleryAccess, denySlideshowToken, async
     }
 
     // Try to serve pre-generated zip (instant download with Content-Length).
-    // The prebuilt zip is the guest bundle — it excludes hidden/client-only
-    // photos (see downloadZipService._build). PIN-clients must still receive
-    // hidden photos, so they skip the fast path and fall through to the
-    // on-the-fly stream below, which filters by access level (a no-op for
-    // clients). This closes the hidden-photo leak in the bulk download.
+    // Guests may use the prebuilt cache ONLY when the event has no hidden
+    // photos: a cache built before a photo was hidden — or before this
+    // visibility-aware builder shipped — could otherwise still leak it, and
+    // getZipInfo only checks the DB pointer + file stat, not freshness. When
+    // hidden photos exist, guests fall through to the visibility-filtered
+    // stream below. PIN-clients always stream a full archive.
     const isClient = canSeeHiddenPhotos(req.accessLevel);
-    const zipInfo = isClient ? null : await downloadZipService.getZipInfo(req.event.id);
+    const eventHasHidden = await db('photos')
+      .where({ event_id: req.event.id, visibility: 'hidden' })
+      .first()
+      .then(Boolean);
+    const zipInfo = (isClient || eventHasHidden)
+      ? null
+      : await downloadZipService.getZipInfo(req.event.id);
     if (zipInfo) {
       const storage = getStorage();
 
@@ -1013,11 +1020,16 @@ router.get('/:slug/download-all', verifyGalleryAccess, denySlideshowToken, async
       return;
     }
 
-    // Fallback: on-the-fly streaming (existing behavior)
-    // Also trigger background zip generation for next time
-    downloadZipService.generateZip(req.event.id).catch(err =>
-      logger.warn('Background zip generation failed', { eventId: req.event.id, error: err.message })
-    );
+    // Fallback: on-the-fly streaming (existing behavior). Only pre-build the
+    // guest cache when it will actually be served next time — a guest
+    // download of an event with no hidden photos. Client bypasses and
+    // hidden-photo events always stream, so rebuilding the guest archive on
+    // those requests is wasted I/O (codex review).
+    if (!isClient && !eventHasHidden) {
+      downloadZipService.generateZip(req.event.id).catch(err =>
+        logger.warn('Background zip generation failed', { eventId: req.event.id, error: err.message })
+      );
+    }
 
     // Fetch photos — exclude photos in categories that disabled downloads (#640).
     // Uncategorised photos are always included; categories without the column

--- a/backend/src/routes/gallery.js
+++ b/backend/src/routes/gallery.js
@@ -30,6 +30,7 @@ const { handleAsync, errorResponse } = require('../utils/routeHelpers');
 const { NotFoundError } = require('../utils/errors');
 const { ensureThumbnail, ensureHeroImage, ensurePreviewImage, withLocalCopy } = require('../services/imageProcessor');
 const downloadZipService = require('../services/downloadZipService');
+const { applyPhotoVisibilityFilter, canSeeHiddenPhotos } = require('../utils/photoVisibility');
 const {
   getUseOriginalFilenames,
   pickRawDownloadName,
@@ -956,8 +957,14 @@ router.get('/:slug/download-all', verifyGalleryAccess, denySlideshowToken, async
       return res.status(403).json({ error: 'Downloads are disabled for this gallery' });
     }
 
-    // Try to serve pre-generated zip (instant download with Content-Length)
-    const zipInfo = await downloadZipService.getZipInfo(req.event.id);
+    // Try to serve pre-generated zip (instant download with Content-Length).
+    // The prebuilt zip is the guest bundle — it excludes hidden/client-only
+    // photos (see downloadZipService._build). PIN-clients must still receive
+    // hidden photos, so they skip the fast path and fall through to the
+    // on-the-fly stream below, which filters by access level (a no-op for
+    // clients). This closes the hidden-photo leak in the bulk download.
+    const isClient = canSeeHiddenPhotos(req.accessLevel);
+    const zipInfo = isClient ? null : await downloadZipService.getZipInfo(req.event.id);
     if (zipInfo) {
       const storage = getStorage();
 
@@ -1015,14 +1022,17 @@ router.get('/:slug/download-all', verifyGalleryAccess, denySlideshowToken, async
     // Fetch photos — exclude photos in categories that disabled downloads (#640).
     // Uncategorised photos are always included; categories without the column
     // (pre-migration-135) fall through the LEFT JOIN's null and are included.
-    const photos = await db('photos')
-      .leftJoin('photo_categories', 'photos.category_id', 'photo_categories.id')
-      .where('photos.event_id', req.event.id)
-      .where(function () {
-        this.whereNull('photos.category_id')
-          .orWhere('photo_categories.allow_downloads', true)
-          .orWhereNull('photo_categories.allow_downloads');
-      })
+    const photos = await applyPhotoVisibilityFilter(
+      db('photos')
+        .leftJoin('photo_categories', 'photos.category_id', 'photo_categories.id')
+        .where('photos.event_id', req.event.id)
+        .where(function () {
+          this.whereNull('photos.category_id')
+            .orWhere('photo_categories.allow_downloads', true)
+            .orWhereNull('photo_categories.allow_downloads');
+        }),
+      req.accessLevel
+    )
       .select('photos.*')
       .orderBy('photos.type', 'asc')
       .orderBy('photos.uploaded_at', 'desc');
@@ -1172,15 +1182,18 @@ router.post('/:slug/download-selected', verifyGalleryAccess, denySlideshowToken,
 
     // Fetch photos — exclude photos in categories that disabled downloads (#640).
     // Same LEFT JOIN pattern as the download-all endpoint.
-    const photos = await db('photos')
-      .leftJoin('photo_categories', 'photos.category_id', 'photo_categories.id')
-      .where('photos.event_id', req.event.id)
-      .whereIn('photos.id', photoIds)
-      .where(function () {
-        this.whereNull('photos.category_id')
-          .orWhere('photo_categories.allow_downloads', true)
-          .orWhereNull('photo_categories.allow_downloads');
-      })
+    const photos = await applyPhotoVisibilityFilter(
+      db('photos')
+        .leftJoin('photo_categories', 'photos.category_id', 'photo_categories.id')
+        .where('photos.event_id', req.event.id)
+        .whereIn('photos.id', photoIds)
+        .where(function () {
+          this.whereNull('photos.category_id')
+            .orWhere('photo_categories.allow_downloads', true)
+            .orWhereNull('photo_categories.allow_downloads');
+        }),
+      req.accessLevel
+    )
       .select('photos.*')
       .orderBy('photos.uploaded_at', 'desc');
 

--- a/backend/src/routes/gallery.js
+++ b/backend/src/routes/gallery.js
@@ -785,6 +785,10 @@ router.patch('/:slug/photos/:photoId/visibility', verifyGalleryAccess, async (re
       .where({ id: photoId, event_id: req.event.id })
       .update({ visibility });
 
+    // A client hiding/showing a photo changes the guest download bundle —
+    // drop the cached ZIP so it rebuilds fresh (codex review).
+    downloadZipService.invalidate(req.event.id);
+
     res.json({ message: 'Photo visibility updated', visibility });
   } catch (error) {
     errorResponse(res, error, 500, 'Failed to update photo visibility');
@@ -812,6 +816,10 @@ router.patch('/:slug/photos/visibility/bulk', verifyGalleryAccess, async (req, r
       .whereIn('id', photoIds)
       .where('event_id', req.event.id)
       .update({ visibility });
+
+    // Client bulk hide/show alters the guest download bundle — invalidate
+    // the cached ZIP (codex review).
+    downloadZipService.invalidate(req.event.id);
 
     res.json({ message: `${count} photos updated`, visibility });
   } catch (error) {

--- a/backend/src/routes/protectedImages.js
+++ b/backend/src/routes/protectedImages.js
@@ -198,9 +198,15 @@ router.post('/:slug/photo/:photoId/generate-secure-token', verifyGalleryAccess, 
       return res.status(404).json({ error: 'Photo not found' });
     }
 
+    // Don't mint a secure-image capability for a hidden/client-only photo
+    // when the caller isn't a client — the serve route is token-only.
+    if (isPhotoHiddenFromViewer(photo, req.accessLevel)) {
+      return res.status(403).json({ error: 'Photo not available' });
+    }
+
     // Create client fingerprint
     const clientFingerprint = secureImageService.createClientFingerprint(req);
-    
+
     // Generate secure token
     const token = secureImageService.generateSecureToken(photoId, req.sessionID || 'anonymous', {
       expiresIn,

--- a/backend/src/routes/protectedImages.js
+++ b/backend/src/routes/protectedImages.js
@@ -7,6 +7,7 @@ const secureImageService = require('../services/secureImageService');
 const { getStorage } = require('../services/storage');
 const { resolvePhotoStorageKey, resolvePhotoFilePath } = require('../services/photoResolver');
 const { withLocalCopy } = require('../services/imageProcessor');
+const { isPhotoHiddenFromViewer } = require('../utils/photoVisibility');
 const crypto = require('crypto');
 const logger = require('../utils/logger');
 const { timingSafeEqualStr } = require('../utils/timingSafe');
@@ -77,6 +78,12 @@ router.get('/:slug/photo/:photoId/view', verifyGalleryAccess, async (req, res) =
     
     if (!photo) {
       return res.status(404).json({ error: 'Photo not found' });
+    }
+
+    // Block guest access to hidden/client-only photos (parity with the
+    // gallery single-photo routes).
+    if (isPhotoHiddenFromViewer(photo, req.accessLevel)) {
+      return res.status(403).json({ error: 'Photo not available' });
     }
 
     // Check for suspicious activity
@@ -233,7 +240,15 @@ router.post('/:slug/photo/:photoId/generate-url', verifyGalleryAccess, async (re
     if (!photo) {
       return res.status(404).json({ error: 'Photo not found' });
     }
-    
+
+    // Refuse to mint a signed URL for a hidden/client-only photo when the
+    // caller isn't a client. The signed-serve route below is token-only
+    // (no gallery auth), so the access decision has to happen here at mint
+    // time — mirroring how the reveal-bypass flag is baked into the token.
+    if (isPhotoHiddenFromViewer(photo, req.accessLevel)) {
+      return res.status(403).json({ error: 'Photo not available' });
+    }
+
     // Generate signed token
     const token = generateImageToken(photoId);
     const signedUrl = `/api/images/${req.params.slug}/photo/${photoId}/signed/${token}`;

--- a/backend/src/routes/protectedImages.js
+++ b/backend/src/routes/protectedImages.js
@@ -7,7 +7,7 @@ const secureImageService = require('../services/secureImageService');
 const { getStorage } = require('../services/storage');
 const { resolvePhotoStorageKey, resolvePhotoFilePath } = require('../services/photoResolver');
 const { withLocalCopy } = require('../services/imageProcessor');
-const { isPhotoHiddenFromViewer } = require('../utils/photoVisibility');
+const { isPhotoHiddenFromViewer, canSeeHiddenPhotos } = require('../utils/photoVisibility');
 const crypto = require('crypto');
 const logger = require('../utils/logger');
 const { timingSafeEqualStr } = require('../utils/timingSafe');
@@ -17,10 +17,14 @@ const router = express.Router();
 /**
  * Generate a signed URL token for image access
  */
-function generateImageToken(photoId, expiresIn = 3600) {
+function generateImageToken(photoId, expiresIn = 3600, clientBypass = false) {
   const secret = process.env.JWT_SECRET;
   const expires = Date.now() + (expiresIn * 1000);
-  const data = `${photoId}:${expires}`;
+  // Third segment: whether the minter was a PIN-client, letting the serve
+  // route still deliver a photo hidden AFTER minting (TOCTOU) — a guest's
+  // token carries 0, so it stops working the moment the photo is hidden.
+  // Old two-segment tokens verify unchanged and read the flag as no-bypass.
+  const data = `${photoId}:${expires}:${clientBypass ? 1 : 0}`;
   const signature = crypto.createHmac('sha256', secret).update(data).digest('hex');
   return `${Buffer.from(data).toString('base64')}.${signature}`;
 }
@@ -33,20 +37,23 @@ function verifyImageToken(token) {
     const secret = process.env.JWT_SECRET;
     const [data, signature] = token.split('.');
     const decoded = Buffer.from(data, 'base64').toString();
-    const [photoId, expires] = decoded.split(':');
-    
+    const [photoId, expires, clientFlag] = decoded.split(':');
+
     // Verify signature (constant-time — avoids leaking the HMAC byte-by-byte)
     const expectedSignature = crypto.createHmac('sha256', secret).update(decoded).digest('hex');
     if (!timingSafeEqualStr(signature, expectedSignature)) {
       return null;
     }
-    
+
     // Check expiration
     if (Date.now() > parseInt(expires)) {
       return null;
     }
-    
-    return { photoId: parseInt(photoId), expires: parseInt(expires) };
+    return {
+      photoId: parseInt(photoId),
+      expires: parseInt(expires),
+      clientBypass: clientFlag === '1',
+    };
   } catch (error) {
     return null;
   }
@@ -207,12 +214,14 @@ router.post('/:slug/photo/:photoId/generate-secure-token', verifyGalleryAccess, 
     // Create client fingerprint
     const clientFingerprint = secureImageService.createClientFingerprint(req);
 
-    // Generate secure token
+    // Generate secure token. clientBypass lets a client's token keep serving
+    // a photo hidden after minting; a guest's stops at the serve route.
     const token = secureImageService.generateSecureToken(photoId, req.sessionID || 'anonymous', {
       expiresIn,
       maxUses: protectionLevel === 'maximum' ? 1 : 3,
       clientFingerprint,
-      protectionLevel
+      protectionLevel,
+      clientBypass: canSeeHiddenPhotos(req.accessLevel)
     });
     
     res.json({ 
@@ -255,8 +264,10 @@ router.post('/:slug/photo/:photoId/generate-url', verifyGalleryAccess, async (re
       return res.status(403).json({ error: 'Photo not available' });
     }
 
-    // Generate signed token
-    const token = generateImageToken(photoId);
+    // Generate signed token. The client-bypass flag lets a PIN-client's
+    // token keep serving a photo hidden after minting; a guest's token
+    // (clientBypass=0) stops the moment the photo is hidden.
+    const token = generateImageToken(photoId, 3600, canSeeHiddenPhotos(req.accessLevel));
     const signedUrl = `/api/images/${req.params.slug}/photo/${photoId}/signed/${token}`;
     
     res.json({ 
@@ -304,7 +315,14 @@ router.get('/:slug/photo/:photoId/signed/:token', async (req, res) => {
     if (!photo) {
       return res.status(404).json({ error: 'Photo not found' });
     }
-    
+
+    // Recheck visibility at serve time (TOCTOU): a photo hidden AFTER the
+    // URL was minted must stop serving, unless the token was minted by a
+    // client (clientBypass) — mirroring the reveal-mode check above.
+    if (photo.visibility === 'hidden' && !tokenData.clientBypass) {
+      return res.status(403).json({ error: 'Photo not available' });
+    }
+
     // Get watermark settings
     const watermarkSettings = await watermarkService.getWatermarkSettings();
 

--- a/backend/src/routes/secureImages.js
+++ b/backend/src/routes/secureImages.js
@@ -13,7 +13,7 @@ const {
   pickRawDownloadName,
 } = require('../services/downloadFilenameService');
 const { buildContentDisposition } = require('../utils/filenameSanitizer');
-const { isPhotoHiddenFromViewer } = require('../utils/photoVisibility');
+const { isPhotoHiddenFromViewer, canSeeHiddenPhotos } = require('../utils/photoVisibility');
 
 const router = express.Router();
 
@@ -58,7 +58,10 @@ router.post('/:slug/generate-token', async (req, res, next) => {
       expiresIn: protectionLevel === 'maximum' ? 180 : 300, // 3-5 minutes
       maxUses: accessType === 'download' ? 1 : 3,
       clientFingerprint,
-      protectionLevel
+      protectionLevel,
+      // TOCTOU: a client's token keeps serving a photo hidden after minting;
+      // a guest's stops the moment it's hidden (checked at the serve route).
+      clientBypass: canSeeHiddenPhotos(req.accessLevel)
     };
 
     const token = secureImageService.generateSecureToken(
@@ -179,6 +182,13 @@ router.get('/:slug/secure/:photoId/:token',
 
       if (!photo) {
         return res.status(404).json({ error: 'Photo not found' });
+      }
+
+      // Recheck visibility at serve time (TOCTOU): a photo hidden AFTER the
+      // token was minted must stop serving, unless the token was minted by a
+      // client (clientBypass) — mirroring the reveal-mode check above.
+      if (photo.visibility === 'hidden' && !tokenValidation.data?.clientBypass) {
+        return res.status(403).json({ error: 'Photo not available' });
       }
 
       // Resolve photo through storage backend (managed) or fall back to local

--- a/backend/src/routes/secureImages.js
+++ b/backend/src/routes/secureImages.js
@@ -13,6 +13,7 @@ const {
   pickRawDownloadName,
 } = require('../services/downloadFilenameService');
 const { buildContentDisposition } = require('../utils/filenameSanitizer');
+const { isPhotoHiddenFromViewer } = require('../utils/photoVisibility');
 
 const router = express.Router();
 
@@ -38,6 +39,12 @@ router.post('/:slug/generate-token', async (req, res, next) => {
 
     if (!photo) {
       return res.status(404).json({ error: 'Photo not found' });
+    }
+
+    // Don't mint a secure-image capability for a hidden/client-only photo
+    // when the caller isn't a client (the token is reusable up to 3×).
+    if (isPhotoHiddenFromViewer(photo, req.accessLevel)) {
+      return res.status(403).json({ error: 'Photo not available' });
     }
 
     // Create client fingerprint
@@ -328,6 +335,22 @@ router.get('/:slug/secure-download/:photoId/:token',
 
       if (!photo) {
         return res.status(404).json({ error: 'Photo not found' });
+      }
+
+      // Block guest access to hidden/client-only photos.
+      if (isPhotoHiddenFromViewer(photo, req.accessLevel)) {
+        return res.status(403).json({ error: 'Photo not available' });
+      }
+
+      // Per-category download opt-out (#640) — the regular single-photo
+      // download enforces this too; the secure path skipped it.
+      if (photo.category_id) {
+        const cat = await db('photo_categories')
+          .where('id', photo.category_id)
+          .first('allow_downloads');
+        if (cat && cat.allow_downloads === false) {
+          return res.status(403).json({ error: 'Downloads are disabled for this category' });
+        }
       }
 
       // Resolve photo through storage backend (managed) or local disk (external).

--- a/backend/src/routes/secureImages.js
+++ b/backend/src/routes/secureImages.js
@@ -343,12 +343,13 @@ router.get('/:slug/secure-download/:photoId/:token',
       }
 
       // Per-category download opt-out (#640) — the regular single-photo
-      // download enforces this too; the secure path skipped it.
+      // download enforces this too; the secure path skipped it. SQLite
+      // returns the boolean as numeric 0, so check both forms.
       if (photo.category_id) {
         const cat = await db('photo_categories')
           .where('id', photo.category_id)
           .first('allow_downloads');
-        if (cat && cat.allow_downloads === false) {
+        if (cat && (cat.allow_downloads === false || cat.allow_downloads === 0)) {
           return res.status(403).json({ error: 'Downloads are disabled for this category' });
         }
       }

--- a/backend/src/services/downloadZipService.js
+++ b/backend/src/services/downloadZipService.js
@@ -112,8 +112,15 @@ class DownloadZipService {
       const event = await db('events').where({ id: eventId }).first();
       if (!event) return { success: false, error: 'Event not found' };
 
+      // The prebuilt zip is served to ordinary gallery guests (the
+      // download-all fast path), so it must exclude hidden/client-only
+      // photos — NULL visibility counts as visible (pre-migration rows).
+      // PIN-clients bypass this cache and stream a full archive instead.
       const photos = await db('photos')
         .where({ event_id: eventId })
+        .where(function () {
+          this.where('visibility', 'visible').orWhereNull('visibility');
+        })
         .select('*')
         .orderBy('type', 'asc')
         .orderBy('uploaded_at', 'desc');

--- a/backend/src/services/secureImageService.js
+++ b/backend/src/services/secureImageService.js
@@ -21,7 +21,11 @@ class SecureImageService {
       expiresIn = 300, // 5 minutes default
       maxUses = 1,
       clientFingerprint = '',
-      protectionLevel = 'standard'
+      protectionLevel = 'standard',
+      // Whether the minter was a PIN-client — lets the serve route keep
+      // delivering a photo hidden AFTER minting (TOCTOU). A guest's token
+      // carries false, so it stops the moment the photo is hidden.
+      clientBypass = false
     } = options;
 
     const tokenData = {
@@ -32,6 +36,7 @@ class SecureImageService {
       maxUses,
       usedCount: 0,
       protectionLevel,
+      clientBypass,
       createdAt: Date.now()
     };
 

--- a/backend/src/utils/photoVisibility.js
+++ b/backend/src/utils/photoVisibility.js
@@ -1,0 +1,46 @@
+/**
+ * Shared hidden-photo access control.
+ *
+ * PicPeak photos carry a `visibility` column: 'visible' (or NULL, for
+ * pre-migration rows) is shown to everyone; 'hidden' is client-only. A
+ * gallery viewer's `req.accessLevel` is 'client' for a PIN-client login and
+ * something else ('guest'/'slideshow'/…) for an ordinary guest.
+ *
+ * The main photo-list query and the single-photo download/view routes each
+ * enforced this inline, but several bulk/secure paths (download-all,
+ * download-selected, protected-image view, signed-URL mint, secure-token
+ * mint, secure-download) shipped without it — letting ordinary guests reach
+ * hidden/client-only photos. These helpers centralise the rule so every
+ * sink applies exactly the same predicate.
+ */
+
+// PIN-clients see hidden photos; everyone else does not.
+function canSeeHiddenPhotos(accessLevel) {
+  return accessLevel === 'client';
+}
+
+/**
+ * Append the guest visibility filter to a knex `photos` query. No-op for
+ * clients. NULL visibility is treated as visible (pre-migration default).
+ * The query must reference the table as `photos` (all call sites do).
+ */
+function applyPhotoVisibilityFilter(query, accessLevel) {
+  if (canSeeHiddenPhotos(accessLevel)) return query;
+  return query.where(function () {
+    this.where('photos.visibility', 'visible').orWhereNull('photos.visibility');
+  });
+}
+
+/**
+ * Single-photo predicate: true when this photo must be blocked for a viewer
+ * at the given access level. Mirrors the inline guards in gallery.js.
+ */
+function isPhotoHiddenFromViewer(photo, accessLevel) {
+  return !!photo && photo.visibility === 'hidden' && !canSeeHiddenPhotos(accessLevel);
+}
+
+module.exports = {
+  canSeeHiddenPhotos,
+  applyPhotoVisibilityFilter,
+  isPhotoHiddenFromViewer,
+};


### PR DESCRIPTION
Closes 6 draft security advisories (the hidden-photo cluster): **GHSA-fpwq-q88p-pwg9** and **GHSA-ghf8-4766-mqp8** (both medium), plus **GHSA-3jvw-m75p-3r55**, **GHSA-9cc4-gpwq-j3mw**, **GHSA-2hqg-p77m-2722**, **GHSA-jc22-jm34-427r** (low). All independently verified against the code before fixing.

## Root cause

PicPeak photos carry a `visibility` column: `hidden` = client-only, shown to PIN-clients (`req.accessLevel === 'client'`) but not ordinary guests. The main photo-list query and the single-photo download/view routes enforce this inline — it's repeated at six sites in `gallery.js`. But the **bulk-download and protected/secure image routes shipped without the check**, so an ordinary gallery guest could reach hidden/client-only photos through them:

- **download-all** — served the pre-generated ZIP (built over *every* event photo) and the on-the-fly fallback query, neither visibility-filtered.
- **download-selected** — archived up to 500 caller-supplied photo IDs with no visibility filter.
- **protected-image `/view`**, **signed-URL mint**, **secure-token mint**, **secure-download** — each fetched the photo by `id + event_id` only.

There was no shared helper — the guard was copy-pasted, and simply never added to these paths.

## The fix

New `utils/photoVisibility.js` centralises the rule (`applyPhotoVisibilityFilter` for queries, `isPhotoHiddenFromViewer` for single-photo guards, NULL visibility = visible, clients see all), applied at every sink:

- `downloadZipService._build` now excludes hidden photos — the prebuilt ZIP is the **guest bundle**. PIN-clients skip that cache and fall through to an on-the-fly stream (visibility filter is a no-op for them), so clients still get their hidden photos in bulk.
- download-all fallback + download-selected queries filtered by access level.
- `/view` and secure/signed routes reject hidden photos for non-clients. The signed-serve route is token-only (no gallery auth), so its gate is at **mint time** in `generate-url` — mirroring how the reveal-bypass flag is baked into the token.
- secure-download additionally gained the per-category `allow_downloads` check the regular download path already had (part of GHSA-jc22).

## Tests

- `photoVisibility.test.js` — helper unit tests (hidden-blocks-guest, client-sees-all, NULL-visible, null-safe).
- `hiddenPhotoAccessControl.test.js` — request-level guest-vs-client matrix across download-selected, download-all, `/view`, signed-URL mint, and secure-token mint: guests are refused (403 / filtered out), clients succeed. 15/15 green; adjacent `photoEngagementCounters` and `revealMode` suites unaffected.

Stable port of the main-branch fix — cherry-picked cleanly; stable (v3.45.x) carries the same six inline guards and the visibility feature (migration 074), so it has the identical exposure. Tests 15/15 on this branch.
