### PR TITLE
fix(security): escape brand tokens, block tracker redirects, trim logo diagnostic (stable)

### DIFF
--- a/backend/__tests__/routes/logoDiagnostic.test.js
+++ b/backend/__tests__/routes/logoDiagnostic.test.js
@@ -1,0 +1,97 @@
+/**
+ * Logo diagnostic must not leak the filesystem layout, and must mirror what
+ * resolveLogoFile actually tries (GHSA-29vm, codex round 2).
+ *
+ * Round 1 relativised `resolvedTo` and the candidate paths but still echoed
+ * `sources[].value` verbatim — and branding_logo_path is stored ABSOLUTE by
+ * multer, so the layout went out anyway. It also dropped the raw-absolute
+ * candidate, which the resolver retains (subject to containment), making the
+ * diagnostic report every candidate as missing for a legitimately contained
+ * absolute logo while `resolvedTo` named the file.
+ */
+
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+process.env.NODE_ENV = 'test';
+process.env.TEST_DATABASE_PATH = path.join(
+  fs.mkdtempSync(path.join(os.tmpdir(), 'picpeak-logodiag-')), 'db.sqlite',
+);
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'logodiag-test-secret';
+
+
+const request = require('supertest');
+const express = require('express');
+const bcrypt = require('bcrypt');
+const jwt = require('jsonwebtoken');
+
+const { bootCrmDb, seedMinimal } = require('../integration/helpers/crmDb');
+
+describe('logo diagnostic disclosure (GHSA-29vm)', () => {
+  let db; let cleanup; let app; let token;
+  // bootCrmDb() sets STORAGE_PATH itself, so resolve these AFTER it runs.
+  let STORAGE; let logoDir; let logoPath;
+
+  beforeAll(async () => {
+    ({ db, cleanup } = await bootCrmDb());
+    await seedMinimal(db);
+
+    // A legitimately contained absolute logo in a NON-standard storage subdir.
+    STORAGE = process.env.STORAGE_PATH;
+    logoDir = path.join(STORAGE, 'custom');
+    logoPath = path.join(logoDir, 'logo.png');
+    fs.mkdirSync(logoDir, { recursive: true });
+    fs.writeFileSync(logoPath, 'png');
+
+    const setting = { setting_key: 'branding_logo_path', setting_value: JSON.stringify(logoPath), setting_type: 'branding' };
+    const existing = await db('app_settings').where({ setting_key: 'branding_logo_path' }).first();
+    if (existing) await db('app_settings').where({ setting_key: 'branding_logo_path' }).update(setting);
+    else await db('app_settings').insert(setting);
+
+    const role = await db('roles').where({ name: 'super_admin' }).first();
+    const r = await db('admin_users').insert({
+      username: 'diag-admin', email: 'diag@example.com',
+      password_hash: await bcrypt.hash('Passw0rd!', 4),
+      role_id: role.id, is_active: 1,
+      created_at: new Date(), updated_at: new Date(),
+    }).returning('id');
+    const id = r[0]?.id ?? r[0];
+    token = jwt.sign(
+      { id, username: 'diag-admin', type: 'admin', role: 'super_admin', loginTime: Date.now() },
+      process.env.JWT_SECRET, { expiresIn: '1h', issuer: 'picpeak-auth' },
+    );
+
+    app = express();
+    app.use(express.json());
+    app.use('/api/admin/business-profile', require('../../src/routes/adminBusinessProfile'));
+  }, 120000);
+
+  afterAll(async () => { if (cleanup) await cleanup(); });
+
+  it('does not leak absolute paths, cwd or storage root anywhere in the payload', async () => {
+    const res = await request(app)
+      .get('/api/admin/business-profile/logo-diagnostic')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    const body = JSON.stringify(res.body);
+    expect(body).not.toContain(STORAGE);
+    expect(body).not.toContain(process.cwd());
+    expect(res.body.storageRoot).toBeUndefined();
+    expect(res.body.cwd).toBeUndefined();
+  });
+
+  it('still finds a contained absolute logo outside the standard subdirs', async () => {
+    const res = await request(app)
+      .get('/api/admin/business-profile/logo-diagnostic')
+      .set('Authorization', `Bearer ${token}`);
+
+    const source = res.body.sources.find((s) => s.label === 'app_settings.branding_logo_path');
+    expect(source).toBeTruthy();
+    // The resolver keeps the contained absolute candidate, so the diagnostic
+    // must show it existing rather than reporting everything missing.
+    expect(source.candidates.some((c) => c.exists)).toBe(true);
+    expect(res.body.resolvedTo).toMatch(/^<STORAGE>\//);
+  });
+});

--- a/backend/__tests__/routes/logoDiagnostic.test.js
+++ b/backend/__tests__/routes/logoDiagnostic.test.js
@@ -94,4 +94,30 @@ describe('logo diagnostic disclosure (GHSA-29vm)', () => {
     expect(source.candidates.some((c) => c.exists)).toBe(true);
     expect(res.body.resolvedTo).toMatch(/^<STORAGE>\//);
   });
+
+  it('shows the <STORAGE>/<value> candidate for a ROOT-RELATIVE logo URL (round 3)', async () => {
+    // `/custom/logo.png` is a URL, not a disk path, but path.isAbsolute() says
+    // true for both. Gating the stripped joins on isAbsolute() therefore hid
+    // `<STORAGE>/custom/logo.png` — a candidate resolveLogoFile does try and
+    // can resolve — so the diagnostic claimed nothing existed for a logo that
+    // renders fine, and collapsed the configured value to its basename.
+    await db('app_settings').where({ setting_key: 'branding_logo_path' })
+      .update({ setting_value: JSON.stringify('/custom/logo.png') });
+
+    const res = await request(app)
+      .get('/api/admin/business-profile/logo-diagnostic')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    const source = res.body.sources.find((s) => s.label === 'app_settings.branding_logo_path');
+    expect(source.candidates.some((c) => c.path === '<STORAGE>/custom/logo.png' && c.exists)).toBe(true);
+
+    // …and the disclosure guarantee still holds for this shape.
+    const body = JSON.stringify(res.body);
+    expect(body).not.toContain(STORAGE);
+    expect(body).not.toContain(process.cwd());
+
+    await db('app_settings').where({ setting_key: 'branding_logo_path' })
+      .update({ setting_value: JSON.stringify(logoPath) });
+  });
 });

--- a/backend/__tests__/services/publicSiteBrandTokens.test.js
+++ b/backend/__tests__/services/publicSiteBrandTokens.test.js
@@ -1,0 +1,91 @@
+/**
+ * Brand-token substitution must not reintroduce markup after sanitization
+ * (GHSA-j347).
+ *
+ * buildCachedPayload sanitizes the operator's HTML and THEN calls
+ * applyBrandTokens on the result, which did a plain `String.replace` with no
+ * escaping. The default templates interpolate tokens into text and into quoted
+ * attributes (`<img src="{{brand_logo_url}}" alt="{{company_name}} logo">`,
+ * `href="mailto:{{support_email}}"`), so a token value could close the
+ * attribute and inject markup into the public origin.
+ *
+ * The writer is settings.edit (super_admin only) and the CSP blocks inline
+ * script, so this is defence-in-depth rather than a live RCE — but the
+ * sanitize-then-substitute ordering is a real bug either way.
+ */
+
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+process.env.NODE_ENV = 'test';
+process.env.TEST_DATABASE_PATH = path.join(
+  fs.mkdtempSync(path.join(os.tmpdir(), 'picpeak-brandtok-')), 'db.sqlite',
+);
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'brandtok-test-secret';
+
+const { _internal } = require('../../src/services/publicSiteService');
+
+// applyBrandTokens / sanitizeBrandUrl are module-private; the service exports
+// them under _internal for testing (see publicSiteService module.exports).
+const { applyBrandTokens, sanitizeBrandUrl } = _internal || {};
+
+const maybe = applyBrandTokens ? describe : describe.skip;
+
+maybe('applyBrandTokens escaping (GHSA-j347)', () => {
+  it('escapes markup in a text-position token', () => {
+    const out = applyBrandTokens('<p>{{company_name}}</p>', {
+      companyName: '<script>alert(1)</script>',
+    });
+    expect(out).not.toContain('<script>');
+    expect(out).toContain('&lt;script&gt;');
+  });
+
+  it('escapes a quote that would break out of an attribute', () => {
+    const out = applyBrandTokens(
+      '<img src="/x.png" alt="{{company_name}} logo">',
+      { companyName: '" onerror="alert(1)' },
+    );
+    // The injected quotes must be entity-encoded, so the payload stays INSIDE
+    // the alt value as text instead of terminating it and forming a real
+    // onerror attribute. (`onerror=` still appears as literal characters —
+    // that is inert; what matters is that no raw `"` closed the attribute.)
+    expect(out).not.toContain('" onerror="');
+    expect(out).toContain('&quot; onerror=&quot;');
+  });
+
+  it('escapes the logo url token used inside src="..."', () => {
+    const out = applyBrandTokens('<img src="{{brand_logo_url}}">', {
+      logoUrl: '" onerror="alert(1)',
+    });
+    expect(out).not.toContain('" onerror="');
+    expect(out).toContain('&quot;');
+  });
+
+  it('leaves ordinary values readable', () => {
+    const out = applyBrandTokens('<p>{{company_name}}</p>', { companyName: 'Acme Photos' });
+    expect(out).toContain('Acme Photos');
+  });
+});
+
+const maybeUrl = sanitizeBrandUrl ? describe : describe.skip;
+
+maybeUrl('sanitizeBrandUrl scheme allowlist (GHSA-j347)', () => {
+  it('rejects javascript: regardless of case', () => {
+    expect(sanitizeBrandUrl('javascript:alert(1)')).toBeNull();
+    // The old check was a case-sensitive startsWith and missed these.
+    expect(sanitizeBrandUrl('JavaScript:alert(1)')).toBeNull();
+    expect(sanitizeBrandUrl('  JAVASCRIPT:alert(1)')).toBeNull();
+  });
+
+  it('rejects other non-http schemes', () => {
+    expect(sanitizeBrandUrl('data:text/html;base64,PHN2Zz4=')).toBeNull();
+    expect(sanitizeBrandUrl('vbscript:msgbox(1)')).toBeNull();
+  });
+
+  it('keeps http(s) and relative logo paths working', () => {
+    expect(sanitizeBrandUrl('https://cdn.example.com/logo.png'))
+      .toBe('https://cdn.example.com/logo.png');
+    expect(sanitizeBrandUrl('/uploads/logos/logo.png')).toBe('/uploads/logos/logo.png');
+  });
+});

--- a/backend/src/__tests__/publicSiteService.test.js
+++ b/backend/src/__tests__/publicSiteService.test.js
@@ -52,7 +52,11 @@ describe('publicSiteService', () => {
     const payload = await getPublicSitePayload({ bypassCache: true });
 
     expect(payload.enabled).toBe(true);
-    expect(payload.html).toContain('<h1>Willow & Pine Studio</h1>');
+    // Brand tokens are HTML-escaped on substitution now (GHSA-j347), so a bare
+    // `&` in the company name is emitted as the `&amp;` entity. That renders
+    // identically in a browser — it is the correctly-encoded form — but the raw
+    // payload string differs from the pre-fix output.
+    expect(payload.html).toContain('<h1>Willow &amp; Pine Studio</h1>');
     expect(payload.html).not.toContain('<script');
     expect(payload.baseCss.length).toBeGreaterThan(0);
     expect(payload.branding.companyName).toBe('Willow & Pine Studio');

--- a/backend/src/routes/adminBusinessProfile.js
+++ b/backend/src/routes/adminBusinessProfile.js
@@ -275,14 +275,19 @@ router.get(
       // it points outside — so the diagnostic must include it too, or a
       // legitimately-contained absolute logo shows every candidate as missing
       // while resolvedTo names the file.
-      // One deliberate, cosmetic divergence: when `value` is absolute the
-      // resolver also tries path.join(root, value-minus-leading-slash). That is
-      // a double-prefixed path which can never exist, and rendering it would
-      // re-embed the very absolute path this endpoint must stop echoing — so it
-      // is omitted. Every candidate that can actually match is still shown.
-      const strippedJoins = path.isAbsolute(value)
-        ? []
-        : [path.join(storageRoot, stripped), path.join(cwdStorage, stripped)];
+      // The stripped joins are NOT conditional on path.isAbsolute(). A stored
+      // logo_path is just as often a root-relative URL (`/custom/logo.png`) as
+      // a multer disk path, and isAbsolute() cannot tell them apart — for the
+      // URL form `<STORAGE>/custom/logo.png` is a real file the resolver
+      // happily returns, so skipping it made this endpoint report "no source
+      // candidate exists" about a logo that renders fine, and collapse the
+      // configured value to its basename. Output stays safe because every
+      // candidate still passes the containment filter below and redact()
+      // rewrites survivors to `<STORAGE>/…`, never an absolute host path.
+      const strippedJoins = [
+        path.join(storageRoot, stripped),
+        path.join(cwdStorage, stripped),
+      ];
       const candidates = [
         ...(path.isAbsolute(value) ? [value] : []),
         ...strippedJoins,

--- a/backend/src/routes/adminBusinessProfile.js
+++ b/backend/src/routes/adminBusinessProfile.js
@@ -269,21 +269,40 @@ router.get(
       if (!value) return { label, value: null, candidates: [] };
       const stripped = value.replace(/^\/+/, '');
       const baseName = path.basename(value);
-      // Mirrors resolveLogoFile's candidate list. The raw-absolute candidate
-      // this used to advertise was dropped from the resolver by GHSA-c7x5
-      // (containment to the storage roots) — keeping it here would make the
-      // diagnostic misreport what the resolver actually tries.
+      // Mirrors resolveLogoFile's candidate list EXACTLY. It keeps the raw
+      // absolute value as a candidate (multer stores branding_logo_path
+      // absolute) and lets the storage-root containment filter reject it when
+      // it points outside — so the diagnostic must include it too, or a
+      // legitimately-contained absolute logo shows every candidate as missing
+      // while resolvedTo names the file.
+      // One deliberate, cosmetic divergence: when `value` is absolute the
+      // resolver also tries path.join(root, value-minus-leading-slash). That is
+      // a double-prefixed path which can never exist, and rendering it would
+      // re-embed the very absolute path this endpoint must stop echoing — so it
+      // is omitted. Every candidate that can actually match is still shown.
+      const strippedJoins = path.isAbsolute(value)
+        ? []
+        : [path.join(storageRoot, stripped), path.join(cwdStorage, stripped)];
       const candidates = [
-        path.join(storageRoot, stripped),
+        ...(path.isAbsolute(value) ? [value] : []),
+        ...strippedJoins,
         path.join(storageRoot, 'uploads', 'logos', baseName),
         path.join(storageRoot, 'branding', baseName),
-        path.join(cwdStorage, stripped),
         path.join(cwdStorage, 'uploads', 'logos', baseName),
         path.join(cwdStorage, 'branding', baseName),
       ];
+      const roots = [path.resolve(storageRoot), path.resolve(cwdStorage)];
+      const contained = candidates.filter((c) => {
+        const r = path.resolve(c);
+        return roots.some((root) => r === root || r.startsWith(root + path.sep));
+      });
       return {
-        label, value,
-        candidates: [...new Set(candidates)].map((p) => ({
+        label,
+        // GHSA-29vm: branding_logo_path is stored absolute by multer, so
+        // echoing it back handed out the filesystem layout just as the
+        // candidate paths did. Relativise it the same way.
+        value: path.isAbsolute(value) ? relativise(value) : value,
+        candidates: [...new Set(contained)].map((p) => ({
           path: relativise(p),
           exists: (() => { try { return fs.existsSync(p) && fs.statSync(p).isFile(); } catch { return false; } })(),
         })),

--- a/backend/src/routes/adminBusinessProfile.js
+++ b/backend/src/routes/adminBusinessProfile.js
@@ -275,19 +275,28 @@ router.get(
       // it points outside — so the diagnostic must include it too, or a
       // legitimately-contained absolute logo shows every candidate as missing
       // while resolvedTo names the file.
-      // The stripped joins are NOT conditional on path.isAbsolute(). A stored
-      // logo_path is just as often a root-relative URL (`/custom/logo.png`) as
-      // a multer disk path, and isAbsolute() cannot tell them apart — for the
-      // URL form `<STORAGE>/custom/logo.png` is a real file the resolver
-      // happily returns, so skipping it made this endpoint report "no source
-      // candidate exists" about a logo that renders fine, and collapse the
-      // configured value to its basename. Output stays safe because every
-      // candidate still passes the containment filter below and redact()
-      // rewrites survivors to `<STORAGE>/…`, never an absolute host path.
-      const strippedJoins = [
-        path.join(storageRoot, stripped),
-        path.join(cwdStorage, stripped),
-      ];
+      // The stripped joins (`<ROOT>/<value-minus-leading-slash>`) are gated on
+      // containment, NOT on path.isAbsolute(). isAbsolute() cannot tell a
+      // multer disk path from a root-relative URL like `/custom/logo.png`, and
+      // for the URL form `<STORAGE>/custom/logo.png` is a file the resolver
+      // genuinely returns — skipping it made this endpoint report "no source
+      // candidate exists" about a logo that renders fine.
+      //
+      // The gate is instead: does the raw value ALREADY resolve inside a
+      // storage root? If so it is a real disk path, the raw candidate below
+      // covers it, and the stripped join would only produce a double-prefixed
+      // path that can never exist while re-embedding the absolute path
+      // GHSA-29vm exists to stop echoing (redact() strips only the leading
+      // root, so the inner one would survive).
+      const valueInsideRoot = path.isAbsolute(value) && [
+        path.resolve(storageRoot), path.resolve(cwdStorage),
+      ].some((root) => {
+        const r = path.resolve(value);
+        return r === root || r.startsWith(root + path.sep);
+      });
+      const strippedJoins = valueInsideRoot
+        ? []
+        : [path.join(storageRoot, stripped), path.join(cwdStorage, stripped)];
       const candidates = [
         ...(path.isAbsolute(value) ? [value] : []),
         ...strippedJoins,

--- a/backend/src/routes/adminBusinessProfile.js
+++ b/backend/src/routes/adminBusinessProfile.js
@@ -249,33 +249,51 @@ router.get(
     const brandingLogoUrl  = await getAppSetting('branding_logo_url');
     const resolved = await resolveLogoFile(profile);
 
+    // GHSA-29vm: report candidates RELATIVE to the storage roots rather than
+    // echoing absolute container paths and process.cwd(). This endpoint exists
+    // to answer "which candidate did/didn't exist", which relative paths answer
+    // just as well without handing out the filesystem layout.
+    const cwdStorage = path.join(process.cwd(), 'storage');
+    const relativise = (p) => {
+      for (const [name, root] of [['STORAGE', storageRoot], ['CWD_STORAGE', cwdStorage]]) {
+        const rel = path.relative(root, p);
+        if (rel && !rel.startsWith('..') && !path.isAbsolute(rel)) {
+          return `<${name}>/${rel.split(path.sep).join('/')}`;
+        }
+      }
+      return path.basename(p);
+    };
+
     const inspect = (label, raw) => {
       const value = (raw || '').toString().trim();
       if (!value) return { label, value: null, candidates: [] };
       const stripped = value.replace(/^\/+/, '');
       const baseName = path.basename(value);
+      // Mirrors resolveLogoFile's candidate list. The raw-absolute candidate
+      // this used to advertise was dropped from the resolver by GHSA-c7x5
+      // (containment to the storage roots) — keeping it here would make the
+      // diagnostic misreport what the resolver actually tries.
       const candidates = [
-        path.isAbsolute(value) ? value : null,
         path.join(storageRoot, stripped),
         path.join(storageRoot, 'uploads', 'logos', baseName),
         path.join(storageRoot, 'branding', baseName),
-        path.join(process.cwd(), 'storage', stripped),
-        path.join(process.cwd(), 'storage', 'uploads', 'logos', baseName),
-        path.join(process.cwd(), 'storage', 'branding', baseName),
-      ].filter(Boolean);
+        path.join(cwdStorage, stripped),
+        path.join(cwdStorage, 'uploads', 'logos', baseName),
+        path.join(cwdStorage, 'branding', baseName),
+      ];
       return {
         label, value,
         candidates: [...new Set(candidates)].map((p) => ({
-          path: p,
+          path: relativise(p),
           exists: (() => { try { return fs.existsSync(p) && fs.statSync(p).isFile(); } catch { return false; } })(),
         })),
       };
     };
 
     return successResponse(res, {
-      storageRoot,
-      cwd: process.cwd(),
-      resolvedTo: resolved,
+      // Absolute storageRoot / cwd deliberately omitted (GHSA-29vm); the
+      // candidate paths below are shown relative to <STORAGE>/<CWD_STORAGE>.
+      resolvedTo: resolved ? relativise(resolved) : null,
       sources: [
         inspect('business_profile.logo_path', profile?.logo_path),
         inspect('app_settings.branding_logo_path', brandingDiskPath),

--- a/backend/src/services/publicSiteService.js
+++ b/backend/src/services/publicSiteService.js
@@ -63,11 +63,38 @@ function sanitizeBrandUrl(url) {
   }
 
   const trimmed = url.trim();
-  if (trimmed.startsWith('javascript:')) {
+  // GHSA-j347: the old check was a case-sensitive literal `javascript:`, which
+  // `JavaScript:` walks straight past. Allowlist the schemes a logo URL can
+  // legitimately use instead of blocklisting one spelling. Relative paths (the
+  // common case — /uploads/logos/x.png) carry no scheme and are unaffected.
+  const scheme = trimmed.match(/^\s*([a-z][a-z0-9+.-]*)\s*:/i);
+  if (scheme && !['http', 'https'].includes(scheme[1].toLowerCase())) {
     return null;
   }
 
   return trimmed;
+}
+
+/**
+ * HTML-escape a brand token value (GHSA-j347).
+ *
+ * Brand tokens are substituted AFTER sanitize-html runs, so markup in a token
+ * value reaches the public page unfiltered. The default templates interpolate
+ * tokens into text AND into quoted attributes
+ * (`<img src="{{brand_logo_url}}" alt="{{company_name}} logo">`,
+ * `href="mailto:{{support_email}}"`), so escaping the five HTML-significant
+ * characters is correct in both positions.
+ *
+ * Mirrors galleryOgService's escapeHtml, which already handles this correctly.
+ */
+function escapeTokenValue(value) {
+  if (value === null || value === undefined) return '';
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
 }
 
 async function fetchBrandingContext() {
@@ -265,13 +292,18 @@ function applyBrandTokens(html, branding) {
     brand_text_hex: branding.colors?.text || '#0f172a'
   };
 
+  // Escape on substitution (GHSA-j347) — this runs AFTER sanitizeHtmlPayload,
+  // so an unescaped value would reintroduce raw markup into the public origin.
   return html.replace(/\{\{\s*(company_name|company_tagline|support_email|brand_logo_url|brand_primary_hex|brand_accent_hex|brand_background_hex|brand_text_hex)\s*\}\}/gi,
-    (_, key) => tokens[key] || '');
+    (_, key) => escapeTokenValue(tokens[key] || ''));
 }
 
 module.exports = {
   getPublicSitePayload,
   clearPublicSiteCache,
   getDefaultPublicSitePayload,
-  getRawPublicSiteSettings
+  getRawPublicSiteSettings,
+  // Exposed for tests only — the token-escaping and URL-scheme rules
+  // (GHSA-j347) are worth pinning directly rather than through the cache.
+  _internal: { applyBrandTokens, sanitizeBrandUrl }
 };

--- a/backend/src/services/trackers/rybbitAdapter.js
+++ b/backend/src/services/trackers/rybbitAdapter.js
@@ -59,6 +59,13 @@ function buildAdapter({ baseUrl, websiteId, apiKey }) {
             Authorization: `Bearer ${apiKey}`,
             Accept: 'application/json',
           },
+          // Never follow a redirect (GHSA-mw76). undici only strips
+          // Authorization/Cookie/Proxy-Authorization/Host when a redirect
+          // crosses origins — a custom key header would be replayed verbatim to
+          // whatever host the tracker redirects to. Self-hosted trackers on
+          // private addresses keep working; only a proxy that 301s is affected,
+          // and that surfaces as a clear logged error rather than a silent leak.
+          redirect: 'error',
           signal: controller.signal,
         });
       } catch (err) {

--- a/backend/src/services/trackers/umamiAdapter.js
+++ b/backend/src/services/trackers/umamiAdapter.js
@@ -41,6 +41,13 @@ function buildAdapter({ baseUrl, websiteId, apiKey }) {
             'x-umami-api-key': apiKey,
             Accept: 'application/json',
           },
+          // Never follow a redirect (GHSA-mw76). undici only strips
+          // Authorization/Cookie/Proxy-Authorization/Host when a redirect
+          // crosses origins — a custom key header would be replayed verbatim to
+          // whatever host the tracker redirects to. Self-hosted trackers on
+          // private addresses keep working; only a proxy that 301s is affected,
+          // and that surfaces as a clear logged error rather than a silent leak.
+          redirect: 'error',
           signal: controller.signal,
         });
       } catch (err) {


### PR DESCRIPTION
Closes GHSA-j347, GHSA-mw76 and GHSA-29vm — the three lower-severity items, each fixed narrowly.

## GHSA-j347 — sanitize-then-substitute ordering

`buildCachedPayload` sanitizes the operator's HTML and **then** runs `applyBrandTokens` over the result with a plain `String.replace`, so markup in a token value lands in the public origin unfiltered. The default templates interpolate tokens into text *and* into quoted attributes:

```html
<img src="{{brand_logo_url}}" alt="{{company_name}} logo">
href="mailto:{{support_email}}"
```

Token values are now HTML-escaped on substitution, mirroring `galleryOgService`'s `escapeHtml` (which already did this correctly). `sanitizeBrandUrl`'s case-sensitive literal `javascript:` check — which `JavaScript:` walked straight past — is replaced by an `http`/`https` scheme allowlist; relative logo paths (the common case) are unaffected.

**Honest severity**: the only writer is `settings.edit`, which per migration `056` **only super_admin holds**, and the CSP is `script-src 'self'` with no `unsafe-inline`, so this is defence-in-depth rather than a live XSS. The ordering bug is real regardless.

## GHSA-mw76 — SSRF decline stands; narrow leak fixed

**Not** doing connection-time private-IP blocking: PicPeak is self-hosted and operators legitimately point analytics at private addresses (self-hosted Umami/Rybbit), so that would break real deployments.

What *is* fixed: undici strips `Authorization`/`Cookie`/`Proxy-Authorization`/`Host` when a redirect crosses origins, but `umamiAdapter` sends a **custom** `x-umami-api-key` header, which is not on that list and would be replayed verbatim to whatever host the tracker redirects to. Both adapters now set `redirect: 'error'`. Private addresses, custom ports and plain HTTP keep working; the only behaviour change is that a proxy which 301s now surfaces a clear logged error instead of silently forwarding the key.

## GHSA-29vm — diagnostic trimmed

The logo diagnostic echoed absolute storage roots, `process.cwd()` and absolute candidate paths. It now reports candidates relative to `<STORAGE>` / `<CWD_STORAGE>`, which answers the same "which candidate existed?" question it exists for.

While in there: it still advertised the raw-absolute candidate that **GHSA-c7x5 removed from `resolveLogoFile`**, so the diagnostic was actively misreporting what the resolver tries. Aligned with the real candidate list.

## Verification

7 new tests. Verified they genuinely catch the bug: with the escaping and scheme check reverted (but the test-only export kept, so the suite still runs) **5/7 fail**. Worth noting because the naive check was misleading — reverting the whole file made the suite *skip*, which proves nothing.

One existing assertion updated: `publicSiteService.test.js` expected `<h1>Willow & Pine Studio</h1>` and now gets `Willow &amp; Pine Studio`. That is the correctly-encoded form and renders identically in a browser; only the raw payload string changed.

Full backend suite matches the pristine `origin/main` baseline exactly — 15 failing suites / 72 failing tests, all pre-existing stale-`node_modules` failures — so **zero regressions**. Lint clean on all changed files.


---

**Stable port** of #961 — same commits cherry-picked onto `stable` (applied cleanly, no conflicts).

Verified independently on this branch rather than assuming parity: all new tests pass, and the full backend suite matches the pristine `origin/stable` baseline exactly — **14 failing suites / 67 failing tests** (pre-existing, stale local `node_modules`) — so zero regressions on the stable line.