### PR TITLE
fix(auth): fail closed when the adminAuth roles join errors (stable) (#968)

### DIFF
--- a/backend/__tests__/middleware/adminAuthRoleFallback.test.js
+++ b/backend/__tests__/middleware/adminAuthRoleFallback.test.js
@@ -1,0 +1,111 @@
+/**
+ * The roles-join fallback in adminAuth fabricates `role_name = 'super_admin'`
+ * to keep existing sessions working across the RBAC upgrade window. The catch
+ * around it used to be unconditional, so ANY transient database failure —
+ * connection reset, deadlock, statement timeout, pool exhaustion — took the
+ * same branch and handed the caller super_admin for the duration of the fault.
+ *
+ * `roleName` is the sole discriminator for every ownership check (ownership.js,
+ * adminProjects, adminUsers, adminApiTokens, projectService, ...), so that
+ * inverted the whole authorization model rather than failing the request.
+ * Issue #968. Same treatment apiTokenAuth already got for the v1 surface.
+ */
+
+const jwt = require('jsonwebtoken');
+
+jest.mock('../../src/utils/tokenRevocation', () => ({ isTokenRevoked: jest.fn().mockResolvedValue(false) }));
+jest.mock('../../src/utils/logger', () => ({ warn: jest.fn(), error: jest.fn(), debug: jest.fn(), info: jest.fn() }));
+
+// The joined query throws whatever the test stages; the role-less fallback
+// query (no .leftJoin) always succeeds, which is what made the original bug
+// reachable — it is the cheaper single-table read.
+// `mock`-prefixed so jest's module-factory hoisting allows the reference.
+let mockJoinError = null;
+const mockAdminRow = { id: 7, username: 'scoped', email: 's@example.com', password_changed_at: null };
+
+jest.mock('../../src/database/db', () => ({
+  db: () => ({
+    _joined: false,
+    leftJoin() { this._joined = true; return this; },
+    where() { return this; },
+    select() { return this; },
+    first() {
+      if (this._joined && mockJoinError) return Promise.reject(mockJoinError);
+      return Promise.resolve({ ...mockAdminRow });
+    },
+  }),
+}));
+
+const { adminAuth } = require('../../src/middleware/auth');
+
+const SECRET = 'test-secret-for-admin-auth-fallback';
+
+function makeReq() {
+  const token = jwt.sign(
+    { id: mockAdminRow.id, type: 'admin' },
+    SECRET,
+    { algorithm: 'HS256', issuer: 'picpeak-auth' },
+  );
+  return { headers: { authorization: `Bearer ${token}` }, ip: '127.0.0.1', connection: {} };
+}
+
+function makeRes() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) { this.statusCode = code; return this; },
+    json(payload) { this.body = payload; return this; },
+  };
+}
+
+describe('adminAuth roles-join fallback (#968)', () => {
+  const OLD_SECRET = process.env.JWT_SECRET;
+  beforeAll(() => { process.env.JWT_SECRET = SECRET; });
+  afterAll(() => { process.env.JWT_SECRET = OLD_SECRET; });
+  beforeEach(() => { mockJoinError = null; });
+
+  it('grants the upgrade-window fallback only for a genuinely missing roles table', async () => {
+    mockJoinError = new Error('SQLITE_ERROR: no such table: roles');
+    const req = makeReq();
+    const res = makeRes();
+    const next = jest.fn();
+
+    await adminAuth(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.admin.roleName).toBe('super_admin');
+  });
+
+  it.each([
+    ['connection reset', new Error('Connection terminated unexpectedly')],
+    ['deadlock', new Error('deadlock detected')],
+    ['pool exhaustion', new Error('Knex: Timeout acquiring a connection')],
+    ['statement timeout', new Error('canceling statement due to statement timeout')],
+  ])('does NOT fabricate super_admin on a transient failure (%s)', async (_label, err) => {
+    mockJoinError = err;
+    const req = makeReq();
+    const res = makeRes();
+    const next = jest.fn();
+
+    await adminAuth(req, res, next);
+
+    // Fails closed: request rejected, req.admin never populated. The specific
+    // status is 401 (adminAuth's blanket outer catch) — what matters is that
+    // the caller is not elevated and does not reach the route.
+    expect(next).not.toHaveBeenCalled();
+    expect(req.admin).toBeUndefined();
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('does NOT fabricate super_admin when an unrelated table is missing', async () => {
+    mockJoinError = new Error('SQLITE_ERROR: no such table: admin_sessions');
+    const req = makeReq();
+    const res = makeRes();
+    const next = jest.fn();
+
+    await adminAuth(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(req.admin).toBeUndefined();
+  });
+});

--- a/backend/__tests__/middleware/apiTokenRoleFallback.test.js
+++ b/backend/__tests__/middleware/apiTokenRoleFallback.test.js
@@ -29,4 +29,44 @@ describe('apiTokenAuth roles-schema fallback predicate (GHSA-9697)', () => {
   it('rejects a missing-table error for an unrelated table', () => {
     expect(isMissingRolesSchema(new Error('SQLITE_ERROR: no such table: api_tokens'))).toBe(false);
   });
+
+  // knex prefixes the failing SQL to err.message, and that SQL always names
+  // `roles` on this join — so the message substring proves nothing about the
+  // error, and only an exact driver phrase (or a SQLSTATE) may be trusted.
+  // These are real knex message shapes, captured from the actual query.
+  describe('with knex\'s SQL prefix on the message (#968)', () => {
+    const withSql = (driverMessage) => new Error(
+      'select `roles`.`name` as `role_name` from `admin_users` '
+      + 'left join `roles` on `roles`.`id` = `admin_users`.`role_id` '
+      + `where \`admin_users\`.\`id\` = 1 limit 1 - ${driverMessage}`,
+    );
+
+    it('accepts both legitimate upgrade-window states', () => {
+      // pre-054: the roles table does not exist yet
+      expect(isMissingRolesSchema(
+        Object.assign(withSql('SQLITE_ERROR: no such table: roles'), { code: 'SQLITE_ERROR' }),
+      )).toBe(true);
+      // post-054, pre-057: roles exists, admin_users.role_id not added yet
+      expect(isMissingRolesSchema(
+        Object.assign(withSql('SQLITE_ERROR: no such column: admin_users.role_id'), { code: 'SQLITE_ERROR' }),
+      )).toBe(true);
+    });
+
+    it('rejects an unrelated "does not exist" fault despite the SQL naming roles', () => {
+      // pgbouncer transaction pooling loses a named prepared statement
+      // (SQLSTATE 26000). Transient — the fallback query would succeed on a
+      // fresh connection, so accepting this would fabricate super_admin.
+      expect(isMissingRolesSchema(
+        Object.assign(withSql('prepared statement "S_1" does not exist'), { code: '26000' }),
+      )).toBe(false);
+      // The DB role/user, not the roles table.
+      expect(isMissingRolesSchema(
+        Object.assign(withSql('role "picpeak" does not exist'), { code: '28000' }),
+      )).toBe(false);
+      expect(isMissingRolesSchema(
+        Object.assign(withSql('database "picpeak" does not exist'), { code: '3D000' }),
+      )).toBe(false);
+      expect(isMissingRolesSchema(withSql('Connection terminated unexpectedly'))).toBe(false);
+    });
+  });
 });

--- a/backend/src/middleware/apiTokenAuth.js
+++ b/backend/src/middleware/apiTokenAuth.js
@@ -1,6 +1,7 @@
 const crypto = require('crypto');
 const { db } = require('../database/db');
 const { formatBoolean } = require('../utils/dbCompat');
+const { isMissingRolesSchema } = require('../utils/dbErrors');
 const logger = require('../utils/logger');
 
 const TOKEN_PREFIX = 'pp_live_';
@@ -30,24 +31,6 @@ function parseScopes(raw) {
     .split(',')
     .map((s) => s.trim().toLowerCase())
     .filter((s) => VALID_SCOPES.includes(s));
-}
-
-/**
- * Does this error mean the `roles` table/column genuinely isn't there yet
- * (mid-upgrade), as opposed to the database being briefly unhappy?
- *
- * The distinction matters because the fallback below grants super_admin: a
- * catch-all would turn any transient failure — connection reset, deadlock,
- * statement timeout — into a privilege escalation that hands a demoted viewer
- * exactly the access GHSA-9697 closes.
- */
-function isMissingRolesSchema(err) {
-  const message = String(err?.message || '');
-  if (!/roles/i.test(message)) return false;
-  // PG: 42P01 undefined_table / 42703 undefined_column. SQLite carries no
-  // codes, so match its wording too.
-  return err?.code === '42P01' || err?.code === '42703'
-    || /no such table|no such column|does not exist|unknown column/i.test(message);
 }
 
 /**

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -1,6 +1,7 @@
 const jwt = require('jsonwebtoken');
 const { db } = require('../database/db');
 const { formatBoolean } = require('../utils/dbCompat');
+const { isMissingRolesSchema } = require('../utils/dbErrors');
 const { isTokenRevoked } = require('../utils/tokenRevocation');
 const logger = require('../utils/logger');
 const { getAdminTokenFromRequest, getGalleryTokenFromRequest } = require('../utils/tokenUtils');
@@ -75,6 +76,14 @@ async function adminAuth(req, res, next) {
         )
         .first();
     } catch (joinError) {
+      // Fail CLOSED on anything that isn't a genuinely missing roles schema:
+      // the fallback below fabricates super_admin, so a transient query failure
+      // (connection reset, deadlock, statement timeout, pool exhaustion) must
+      // not become a free privilege upgrade for every scoped admin. Rethrow →
+      // outer catch → 401, which is already how a transient DB fault in this
+      // try block behaves (isTokenRevoked hits the DB here). apiTokenAuth takes
+      // the same posture on the v1 surface, differing only in its 500.
+      if (!isMissingRolesSchema(joinError)) throw joinError;
       // Fallback: roles table may not exist yet during upgrade
       // Query without role join - user will have no role info but can still authenticate
       logger.debug('Roles table not available, falling back to basic auth', { error: joinError.message });

--- a/backend/src/utils/dbErrors.js
+++ b/backend/src/utils/dbErrors.js
@@ -23,12 +23,26 @@ function isUniqueViolation(err) {
  * GHSA-9697 closes. Callers must rethrow anything this returns false for.
  */
 function isMissingRolesSchema(err) {
-  const message = String(err?.message || '');
-  if (!/roles/i.test(message)) return false;
-  // PG: 42P01 undefined_table / 42703 undefined_column. SQLite carries no
-  // codes, so match its wording too.
-  return err?.code === '42P01' || err?.code === '42703'
-    || /no such table|no such column|does not exist|unknown column/i.test(message);
+  if (!err) return false;
+  const message = String(err.message || '');
+
+  // Postgres is authoritative via SQLSTATE: 42P01 undefined_table, 42703
+  // undefined_column. Both are schema conditions, never transient.
+  if (err.code === '42P01' || err.code === '42703') return true;
+
+  // SQLite carries no SQLSTATE, so the driver's wording is all there is — but
+  // it must be matched EXACTLY, naming the object the roles join needs. A
+  // generic /does not exist/ test would be unsound here: knex prefixes the
+  // failing SQL to err.message, and that SQL always names `roles` on this
+  // join, so any "... does not exist" fault on the connection (e.g. pgbouncer
+  // losing a named prepared statement, SQLSTATE 26000) would read as a missing
+  // roles schema and fabricate super_admin.
+  //
+  // Two states are legitimate, per the migration order:
+  //   pre-054           → roles table absent
+  //   post-054, pre-057 → roles exists, admin_users.role_id not added yet
+  return /no such table: roles\b/i.test(message)
+    || /no such column: (roles\.|admin_users\.role_id\b)/i.test(message);
 }
 
 module.exports = { isUniqueViolation, isMissingRolesSchema };

--- a/backend/src/utils/dbErrors.js
+++ b/backend/src/utils/dbErrors.js
@@ -12,4 +12,23 @@ function isUniqueViolation(err) {
   return /unique/i.test(msg) || /sqlite_constraint/i.test(msg);
 }
 
-module.exports = { isUniqueViolation };
+/**
+ * Does this error mean the `roles` table/column genuinely isn't there yet
+ * (mid-upgrade), as opposed to the database being briefly unhappy?
+ *
+ * The distinction matters because both auth paths fall back to granting
+ * super_admin when the roles join fails: a catch-all would turn any transient
+ * failure — connection reset, deadlock, statement timeout, pool exhaustion —
+ * into a privilege escalation that hands a demoted viewer exactly the access
+ * GHSA-9697 closes. Callers must rethrow anything this returns false for.
+ */
+function isMissingRolesSchema(err) {
+  const message = String(err?.message || '');
+  if (!/roles/i.test(message)) return false;
+  // PG: 42P01 undefined_table / 42703 undefined_column. SQLite carries no
+  // codes, so match its wording too.
+  return err?.code === '42P01' || err?.code === '42703'
+    || /no such table|no such column|does not exist|unknown column/i.test(message);
+}
+
+module.exports = { isUniqueViolation, isMissingRolesSchema };


### PR DESCRIPTION
Closes #968 on `stable`. Backport of #974 — same shape, adapted where `stable` diverges.

## Root cause

`backend/src/middleware/auth.js:77` (line 85 on `main`) wraps the roles-join query in a `try/catch` whose fallback fabricates a role:

```js
} catch (joinError) {
  admin = await db('admin_users').where({ id: decoded.id, ... }).first();
  if (admin) {
    admin.role_id = null;
    admin.role_name = 'super_admin'; // Assume super_admin for existing users during upgrade
  }
}
```

The catch is unconditional, so any *transient* failure of the joined query — connection reset, deadlock, statement timeout, pool exhaustion — takes the same branch. The fallback query is a cheaper single-table read, so it usually succeeds and the request proceeds as `super_admin`.

`roleName` is the sole discriminator for every ownership check (`middleware/ownership.js`, `adminProjects`, `adminUsers`, `adminApiTokens`, `adminCategories`, `adminCustomers`, `adminFeedback`, `adminPhotos`, `projectService`), so a brief DB fault silently inverts the authorization model rather than failing the request.

## Fix

`apiTokenAuth.js` already carries `isMissingRolesSchema()` on this branch too. Moved it to `utils/dbErrors.js` (identical file on both branches) and applied it in `auth.js`:

```js
if (!isMissingRolesSchema(joinError)) throw joinError;
```

`apiTokenAuth.js` imports from the new location, so `apiTokenRoleFallback.test.js` is untouched and still passes.

## Differences from the `main` PR

Two, both accounted for:

1. `stable`'s `auth.js` has no `isTokenBeforeCutoff` import — the code comment references only `isTokenRevoked` here, and the test drops that `jest.mock`.
2. `stable`'s `apiTokenAuth.js` differs from `main` only at line 120 (`last_used_at: new Date()` vs `.toISOString()`), which this PR does not touch.

The rethrow lands on `adminAuth`'s outer catch → **401** (not 500 as the issue text assumed), matching how every other transient DB fault in that `try` already behaves.

## Tests

New `__tests__/middleware/adminAuthRoleFallback.test.js`: missing `roles` table still takes the upgrade fallback; the four transient-failure classes fail closed with no `req.admin` and a 401; an unrelated missing table does not elevate.

Verified it reproduces the bug on this branch — reverting the guard fails 5 of 6, restoring passes 6/6. Full `__tests__/middleware/`: 22 passed. ESLint clean. No UI surface touched, so no screenshot.

---

## Follow-up commit: tightening the predicate (external review)

An external Codex review pass initially reported no findings; challenged with empirical evidence, it retracted that and confirmed the predicate was overbroad. Second commit fixes it.

**knex prefixes the failing SQL to `err.message`.** Reproduced against the real query:

```
"select `roles`.`name` ... from `admin_users` left join `roles` on ... - SQLITE_ERROR: no such table: roles"
```

That SQL always names `roles` on this join, so the leading gate

```js
if (!/roles/i.test(message)) return false;
```

was testing the *SQL text*, not the error — it passed unconditionally on this code path. The whole security decision therefore rested on the remaining clause, which included a generic `/does not exist/i`.

**Consequence:** any "… does not exist" fault on the connection would read as a missing roles schema. The sharpest case is pgbouncer transaction pooling losing a named prepared statement (`prepared statement "S_1" does not exist`, SQLSTATE 26000) — genuinely transient, so the cheaper fallback query then succeeds on a fresh connection and `super_admin` gets fabricated. Same for `role "…" does not exist` (28000) and `database "…" does not exist` (3D000). That is the exact escalation this PR exists to close, surviving the first fix.

**Tightened to:**

```js
if (err.code === '42P01' || err.code === '42703') return true;   // PG: authoritative SQLSTATE
return /no such table: roles\b/i.test(message)                   // SQLite: exact driver phrasing
  || /no such column: (roles\.|admin_users\.role_id\b)/i.test(message);
```

**The `admin_users.role_id` arm matters** — Codex caught a regression the obvious tightening would have caused. Migration `054` creates `roles`; migration `057` adds `admin_users.role_id`. In between, `roles` exists but the column does not, and SQLite reports `no such column: admin_users.role_id` — a driver message containing no `roles` at all. Requiring "roles" in the driver message would have broken that legitimate upgrade window. Verified by reproducing both schema states against real knex:

```
A pre-054 (roles table absent)       -> predicate: true
B post-054 pre-057 (role_id absent)  -> predicate: true
```

Also dropped the MySQL-only `unknown column` arm — this project runs Postgres and SQLite only.

**Residual checked and closed:** whether a restore could transiently drop `roles` while `admin_users` survives, hitting `42P01` and elevating. It cannot — `restoreService.js:1089-1101` restores at *database* granularity (`DROP DATABASE` / `CREATE DATABASE`), which surfaces as connection/database-level errors that the tightened predicate rejects.

Four new predicate cases cover the SQL-prefixed shapes: both upgrade states accepted, the 26000/28000/3D000 class rejected. `__tests__/middleware/`: 24 passed. ESLint clean.
