### PR TITLE
fix(accounting): gate cross-add counters on the permission their endpoint checks (#983)

### DIFF
--- a/frontend/src/components/admin/CustomerCrmPanels.tsx
+++ b/frontend/src/components/admin/CustomerCrmPanels.tsx
@@ -252,6 +252,10 @@ const RebillsPanel: React.FC<Props> = ({ customerAccountId }) => {
   const canView = usePermission('accounting.view');
   const canManage = usePermission('accounting.manage');
   const canCombine = usePermission('customers.edit');
+  // The open-hours counter below reads GET /customers/:id/hour-entries, which
+  // requires customers.view — a different permission from the customers.edit
+  // that authorises the combined billing itself (#983).
+  const canViewCustomers = usePermission('customers.view');
   const [crossAddOpen, setCrossAddOpen] = useState(false);
   const [busy, setBusy] = useState(false);
 
@@ -262,12 +266,15 @@ const RebillsPanel: React.FC<Props> = ({ customerAccountId }) => {
     staleTime: 30_000,
   });
 
-  // Open hours count for the cross-add offer — only when hours logging is on
-  // AND the admin can actually create the combined invoice.
+  // Open hours count for the cross-add offer — only when hours logging is on,
+  // the admin can actually create the combined invoice (customers.edit) AND can
+  // read the hour entries the count comes from (customers.view). Both are
+  // required: without the read permission the request just 403s on every
+  // render (#983).
   const { data: openHours = 0 } = useQuery({
     queryKey: ['customer-open-hours-count', customerAccountId],
     queryFn: async () => (await customerAdminService.listHourEntries(customerAccountId, 'unbilled')).length,
-    enabled: !!flags.hoursLogging && canCombine,
+    enabled: !!flags.hoursLogging && canCombine && canViewCustomers,
     staleTime: 30_000,
   });
 

--- a/frontend/src/components/admin/HoursSection.tsx
+++ b/frontend/src/components/admin/HoursSection.tsx
@@ -56,6 +56,10 @@ export const HoursSection: React.FC<HoursSectionProps> = ({
   const { flags } = useFeatureFlags();
   // Billing hours (and the combined path) go through customers.edit (#866 review).
   const canBill = usePermission('customers.edit');
+  // The open-re-bills counter below reads GET /expenses/inbound/by-customer/:id,
+  // which requires accounting.view — a different permission from the one that
+  // authorises the billing itself (#983).
+  const canViewAccounting = usePermission('accounting.view');
   const { format: fmtDate, formatTime: fmtTime } = useLocalizedDate();
   const [entryDate, setEntryDate] = useState(() => new Date().toISOString().slice(0, 10));
   const [startTime, setStartTime] = useState('09:00');
@@ -167,11 +171,14 @@ export const HoursSection: React.FC<HoursSectionProps> = ({
   });
 
   // Open re-bills count for the cross-add offer (#866) — only when the
-  // incoming-invoices feature is on and the admin can create the invoice.
+  // incoming-invoices feature is on, the admin can create the invoice
+  // (customers.edit) AND can read the re-bills the count comes from
+  // (accounting.view). Both are required: without the read permission the
+  // request just 403s on every render (#983).
   const { data: openRebills = 0 } = useQuery({
     queryKey: ['customer-open-rebills-count', customerId],
     queryFn: async () => (await accountingService.listCustomerRebills(customerId)).filter((r) => r.status === 'open').length,
-    enabled: !!flags.incomingInvoices && canBill,
+    enabled: !!flags.incomingInvoices && canBill && canViewAccounting,
     staleTime: 30_000,
   });
   const [crossAddOpen, setCrossAddOpen] = useState(false);


### PR DESCRIPTION
Closes #983. Follow-up from the #979 review — not a regression, introduced by the permission-gating fix in that PR.

## Root cause

Both cross-add counter queries were `enabled:` on `customers.edit`, but neither endpoint checks that permission:

| Query | Endpoint | Actually requires |
|---|---|---|
| `HoursSection.tsx:174` | `GET /expenses/inbound/by-customer/:id` | `accounting.view` (`adminExpenses.js:118`) |
| `CustomerCrmPanels.tsx:270` | `GET /customers/:id/hour-entries` | `customers.view` (`adminCustomers.js:126`) |

So an admin holding `customers.edit` but not the matching read permission — a plausible "manages customers and hours, not the books" role — fired a guaranteed 403 on every customer-detail render.

## Impact

Low. It degraded safely: the query errors, the count stays at its `0` default, so the cross-add dialog is simply never offered — which is the correct outcome for that role. This is avoidable request noise and a permanently-failing query in devtools, not a dead control or wrong behaviour.

## Fix

Each guard now requires **both** permissions — the read one to fetch the count, and the write one because there is no point offering the cross-add to someone who cannot create the combined invoice:

```ts
enabled: !!flags.incomingInvoices && canBill && canViewAccounting,   // HoursSection
enabled: !!flags.hoursLogging && canCombine && canViewCustomers,     // CustomerCrmPanels
```

## Verification

`tsc --noEmit` clean, ESLint clean, frontend suite 119 passed.

**No new test.** The change is two boolean conjunctions on `useQuery({ enabled })`, and covering it would mean standing up the full render surface of both components (feature flags, permissions, business profile, project select, mutation toasts) to assert a service call *doesn't* happen. That is disproportionate to a two-line guard fix, so I verified it by inspection against the route definitions instead. Saying so explicitly rather than implying coverage.

No UI change — controls render exactly as before for every role; only the fetch is suppressed for one that could not read the data anyway. So no screenshot.
