### PR TITLE
fix(security): vet the destination project when linking a deal

### DIFF
--- a/backend/__tests__/services/projectDealLineageOwnership.test.js
+++ b/backend/__tests__/services/projectDealLineageOwnership.test.js
@@ -135,4 +135,56 @@ describe('linkDealToProject enforces lineage ownership (GHSA-wrg5, round 3)', ()
       projectService.assignQuote(project, quoteId, { id: editorA }),
     ).rejects.toMatchObject({ code: 'DEAL_EVENT_FORBIDDEN' });
   });
+
+  // The lineage guard above only fires once a deal has produced an event. The
+  // quote/contract create+update paths call linkDealToProject with a
+  // body-supplied projectId and NO route-level ownership guard, so a brand-new
+  // deal (eventIds empty) skipped every check and wrote into a foreign project.
+  describe('destination ownership (codex review follow-up)', () => {
+    it('refuses a foreign project even when the deal has no events yet', async () => {
+      const victimProject = await mkProject('victim-destination', editorB);
+      const quoteId = await mkQuote('deal-no-events', null);
+
+      await expect(
+        projectService.linkDealToProject('deal-no-events', victimProject, db, { id: editorA }),
+      ).rejects.toMatchObject({ code: 'PROJECT_NOT_FOUND' });
+
+      const q = await db('quotes').where({ id: quoteId }).first('project_id');
+      expect(q.project_id == null).toBe(true);
+    });
+
+    it('refuses an OWNERLESS project with no events (the escalation path)', async () => {
+      // created_by NULL + no linked events is exactly the shape that would let
+      // the caller claim the project via ownedProjectsSubquery's second branch
+      // once their quote converts to an event.
+      const orphan = await mkProject('orphan-destination', null);
+      await mkQuote('deal-orphan', null);
+
+      await expect(
+        projectService.linkDealToProject('deal-orphan', orphan, db, { id: editorA }),
+      ).rejects.toMatchObject({ code: 'PROJECT_NOT_FOUND' });
+    });
+
+    it("still allows the caller's own project with no events", async () => {
+      const own = await mkProject('own-destination', editorA);
+      const quoteId = await mkQuote('deal-own-dest', null);
+
+      await projectService.linkDealToProject('deal-own-dest', own, db, { id: editorA });
+
+      const q = await db('quotes').where({ id: quoteId }).first('project_id');
+      expect(Number(q.project_id)).toBe(Number(own));
+    });
+
+    it('leaves super_admin unrestricted on a foreign destination', async () => {
+      const victimProject = await mkProject('root-destination', editorB);
+      const quoteId = await mkQuote('deal-root-dest', null);
+
+      await projectService.linkDealToProject('deal-root-dest', victimProject, db, {
+        id: superAdmin, roleName: 'super_admin',
+      });
+
+      const q = await db('quotes').where({ id: quoteId }).first('project_id');
+      expect(Number(q.project_id)).toBe(Number(victimProject));
+    });
+  });
 });

--- a/backend/__tests__/services/projectDealLineageOwnership.test.js
+++ b/backend/__tests__/services/projectDealLineageOwnership.test.js
@@ -175,6 +175,45 @@ describe('linkDealToProject enforces lineage ownership (GHSA-wrg5, round 3)', ()
       expect(Number(q.project_id)).toBe(Number(own));
     });
 
+    it('refuses a foreign project when the deal_uuid is NULL (codex round 1)', async () => {
+      // deal_uuid is nullable (migration 107) and quoteService.update passes the
+      // EXISTING row's value, so a legacy quote reaches linkDealToProject with
+      // null. The old `if (!dealUuid || !projectId) return` bailed before the
+      // guard — while the caller had already written project_id onto its row.
+      const victimProject = await mkProject('victim-nulldeal', editorB);
+
+      await expect(
+        projectService.linkDealToProject(null, victimProject, db, { id: editorA }),
+      ).rejects.toMatchObject({ code: 'PROJECT_NOT_FOUND' });
+    });
+
+    it('still no-ops on a NULL deal_uuid pointed at the caller-s own project', async () => {
+      // The destination is vetted, then it returns without cascading — there is
+      // no lineage to move.
+      const own = await mkProject('own-nulldeal', editorA);
+      await expect(
+        projectService.linkDealToProject(null, own, db, { id: editorA }),
+      ).resolves.toBeUndefined();
+    });
+
+    it('does not leak customer association through the error code', async () => {
+      // The customer check used to run first, so a foreign project whose
+      // customer differed answered 422 PROJECT_CUSTOMER_MISMATCH while an
+      // unknown id answered 404 — enough to enumerate projects and infer their
+      // customer. Both must now be indistinguishable to a scoped caller.
+      const foreignWithCustomer = await mkProject('victim-customer', editorB);
+      await db('projects').where({ id: foreignWithCustomer }).update({ customer_account_id: customerId });
+      await mkQuote('deal-oracle', null);
+
+      await expect(
+        projectService.linkDealToProject('deal-oracle', foreignWithCustomer, db, { id: editorA }),
+      ).rejects.toMatchObject({ code: 'PROJECT_NOT_FOUND' });
+
+      await expect(
+        projectService.linkDealToProject('deal-oracle', 999999, db, { id: editorA }),
+      ).rejects.toMatchObject({ code: 'PROJECT_NOT_FOUND' });
+    });
+
     it('leaves super_admin unrestricted on a foreign destination', async () => {
       const victimProject = await mkProject('root-destination', editorB);
       const quoteId = await mkQuote('deal-root-dest', null);

--- a/backend/src/services/projectService.js
+++ b/backend/src/services/projectService.js
@@ -268,47 +268,7 @@ async function isSuperAdmin(actor, conn = db) {
  * destination, while this function re-points the deal's events into it.
  */
 async function linkDealToProject(dealUuid, projectId, conn = db, actor = null) {
-  if (!dealUuid || !projectId) return;
-
-  // Collect ALL the deal's customers across its quote/contract/invoice lineage
-  // AND every event it converted into — BEFORE mutating anything, so a link
-  // with no matching customer is rejected before we re-point data across tenants.
-  const eventIds = new Set();
-  const dealCustomerIds = new Set();
-  const quotesHaveDeal = await hasColumnCached('quotes', 'deal_uuid');
-  if (quotesHaveDeal) {
-    for (const q of await conn('quotes').where({ deal_uuid: dealUuid }).select('converted_event_id', 'customer_account_id')) {
-      if (q.converted_event_id) eventIds.add(q.converted_event_id);
-      if (q.customer_account_id != null) dealCustomerIds.add(Number(q.customer_account_id));
-    }
-  }
-  const contractsHaveDeal = await hasColumnCached('contracts', 'deal_uuid');
-  if (contractsHaveDeal && await hasColumnCached('contracts', 'converted_event_id')) {
-    for (const c of await conn('contracts').where({ deal_uuid: dealUuid }).select('converted_event_id', 'customer_account_id')) {
-      if (c.converted_event_id) eventIds.add(c.converted_event_id);
-      if (c.customer_account_id != null) dealCustomerIds.add(Number(c.customer_account_id));
-    }
-  }
-  if (await hasColumnCached('invoices', 'deal_uuid')) {
-    for (const inv of await conn('invoices').where({ deal_uuid: dealUuid }).select('event_id', 'customer_account_id')) {
-      if (inv.event_id) eventIds.add(inv.event_id);
-      if (inv.customer_account_id != null) dealCustomerIds.add(Number(inv.customer_account_id));
-    }
-  }
-
-  // Single-customer projects, "one customer matches" rule: a customer-assigned
-  // project rejects the deal only when NONE of the deal's customers is the
-  // project's customer. An *unassigned* project (customer_account_id null)
-  // ADOPTS the deal's customer below — "drop the first deal on an empty project".
-  const project = await conn('projects').where({ id: projectId }).select('customer_account_id').first();
-  if (!project) throw new AppError('Project not found', 404, 'PROJECT_NOT_FOUND');
-  if (
-    project.customer_account_id != null &&
-    dealCustomerIds.size &&
-    !dealCustomerIds.has(Number(project.customer_account_id))
-  ) {
-    throw new AppError('That belongs to a different customer than this project', 422, 'PROJECT_CUSTOMER_MISMATCH');
-  }
+  if (!projectId) return;
 
   // Ownership of the DESTINATION. `attachDocumentToProject` reaches here behind
   // requireProjectOwnership, but the quote/contract create+update paths do not:
@@ -355,6 +315,53 @@ async function linkDealToProject(dealUuid, projectId, conn = db, actor = null) {
     if (!owned) {
       throw new AppError('Project not found', 404, 'PROJECT_NOT_FOUND');
     }
+  }
+
+  // Nothing to cascade without a deal, but the destination above still had
+  // to be vetted: every caller writes `project_id` onto its own row BEFORE
+  // calling us, and `deal_uuid` is nullable (migration 107). A legacy quote
+  // with no deal would otherwise return here having bypassed the check while
+  // its foreign project link stood.
+  if (!dealUuid) return;
+
+  // Collect ALL the deal's customers across its quote/contract/invoice lineage
+  // AND every event it converted into — BEFORE mutating anything, so a link
+  // with no matching customer is rejected before we re-point data across tenants.
+  const eventIds = new Set();
+  const dealCustomerIds = new Set();
+  const quotesHaveDeal = await hasColumnCached('quotes', 'deal_uuid');
+  if (quotesHaveDeal) {
+    for (const q of await conn('quotes').where({ deal_uuid: dealUuid }).select('converted_event_id', 'customer_account_id')) {
+      if (q.converted_event_id) eventIds.add(q.converted_event_id);
+      if (q.customer_account_id != null) dealCustomerIds.add(Number(q.customer_account_id));
+    }
+  }
+  const contractsHaveDeal = await hasColumnCached('contracts', 'deal_uuid');
+  if (contractsHaveDeal && await hasColumnCached('contracts', 'converted_event_id')) {
+    for (const c of await conn('contracts').where({ deal_uuid: dealUuid }).select('converted_event_id', 'customer_account_id')) {
+      if (c.converted_event_id) eventIds.add(c.converted_event_id);
+      if (c.customer_account_id != null) dealCustomerIds.add(Number(c.customer_account_id));
+    }
+  }
+  if (await hasColumnCached('invoices', 'deal_uuid')) {
+    for (const inv of await conn('invoices').where({ deal_uuid: dealUuid }).select('event_id', 'customer_account_id')) {
+      if (inv.event_id) eventIds.add(inv.event_id);
+      if (inv.customer_account_id != null) dealCustomerIds.add(Number(inv.customer_account_id));
+    }
+  }
+
+  // Single-customer projects, "one customer matches" rule: a customer-assigned
+  // project rejects the deal only when NONE of the deal's customers is the
+  // project's customer. An *unassigned* project (customer_account_id null)
+  // ADOPTS the deal's customer below — "drop the first deal on an empty project".
+  const project = await conn('projects').where({ id: projectId }).select('customer_account_id').first();
+  if (!project) throw new AppError('Project not found', 404, 'PROJECT_NOT_FOUND');
+  if (
+    project.customer_account_id != null &&
+    dealCustomerIds.size &&
+    !dealCustomerIds.has(Number(project.customer_account_id))
+  ) {
+    throw new AppError('That belongs to a different customer than this project', 422, 'PROJECT_CUSTOMER_MISMATCH');
   }
 
   // Ownership of the LINEAGE, not just the destination (GHSA-wrg5). The writes

--- a/backend/src/services/projectService.js
+++ b/backend/src/services/projectService.js
@@ -310,9 +310,55 @@ async function linkDealToProject(dealUuid, projectId, conn = db, actor = null) {
     throw new AppError('That belongs to a different customer than this project', 422, 'PROJECT_CUSTOMER_MISMATCH');
   }
 
-  // Ownership of the LINEAGE, not just the destination (GHSA-wrg5). The route
-  // guard (requireProjectOwnership) only vets `projectId`; the writes below
-  // re-point every event this deal produced into it. Without this check an
+  // Ownership of the DESTINATION. `attachDocumentToProject` reaches here behind
+  // requireProjectOwnership, but the quote/contract create+update paths do not:
+  // adminQuotes.js / adminContracts.js take `projectId` straight from the body
+  // behind `quotes.manage` / `contracts.manage`, which are permissions, not
+  // ownership. So the destination has to be vetted here, at the one choke point
+  // every caller shares, rather than relying on a route guard three of the four
+  // callers never had.
+  //
+  // Without it a scoped admin could point a new quote at a project they do not
+  // own: the lineage check below is skipped when the deal has produced no event
+  // yet (`eventIds.size` is 0), and an unassigned project ADOPTS the deal's
+  // customer instead of rejecting it. That writes their document into another
+  // admin's cockpit, and on an OWNERLESS project (created_by IS NULL — legacy
+  // rows migration 167's backfill could not attribute) it escalates: once the
+  // quote converts to an event, that event becomes the project's only linked
+  // event, which is exactly the condition ownedProjectsSubquery's second branch
+  // grants ownership on — handing the caller read access to whatever documents
+  // were already attached there.
+  //
+  // Mirrors ownedProjectsSubquery (middleware/ownership.js) rather than calling
+  // it, because that helper binds the module-level `db` and this runs inside the
+  // caller's transaction.
+  if (actor?.id && !(await isSuperAdmin(actor, conn))) {
+    const owned = await conn('projects')
+      .where({ id: projectId })
+      .where((w) => {
+        w.where('created_by', actor.id)
+          .orWhere((noOwner) => {
+            noOwner
+              .where((c) => c
+                .whereNull('created_by')
+                .orWhereNotIn('created_by', conn('admin_users').select('id')))
+              .whereExists(
+                conn('events').select(conn.raw('1')).whereRaw('events.project_id = projects.id'),
+              )
+              .whereNotExists(
+                conn('events').select(conn.raw('1')).whereRaw('events.project_id = projects.id')
+                  .whereNotNull('events.created_by').whereNot('events.created_by', actor.id),
+              );
+          });
+      })
+      .first('id');
+    if (!owned) {
+      throw new AppError('Project not found', 404, 'PROJECT_NOT_FOUND');
+    }
+  }
+
+  // Ownership of the LINEAGE, not just the destination (GHSA-wrg5). The writes
+  // below re-point every event this deal produced into it. Without this check an
   // editor could create an empty project, attach another admin's quote, and
   // pull that admin's events — plus the invoices, emails and gallery that roll
   // up with them — into a project they own and can read via /:id/overview.


### PR DESCRIPTION
Follow-up from the Codex pass on #979, which flagged the destination scoping of `linkDealToProject` as a separate concern. I verified it — it is real.

## Root cause

`linkDealToProject` (`projectService.js:270`) re-points a deal's quotes, contracts and **events** into `projectId`. It has a lineage guard for the *source* events, and its comment states the assumption behind it:

> Ownership of the LINEAGE, not just the destination (GHSA-wrg5). The route guard (requireProjectOwnership) only vets `projectId` […]

That precondition holds for exactly one of its four callers. `attachDocumentToProject` sits behind `requireProjectOwnership`. The other three do not:

| Caller | Destination guard |
|---|---|
| `projectService.attachDocumentToProject` | `requireProjectOwnership` ✅ |
| `quoteService.create` (`:597`) | none |
| `quoteService.update` (`:736`) | none |
| `contract/crud.create` (`:214`), `.update` (`:316`) | none |

`adminQuotes.js` carries only `adminAuth` + `requireQuotesFlag` at router level and `requirePermission('quotes.manage')` per route — a permission, not ownership. `adminContracts.js` has no ownership guard at all. Both take `projectId` straight from the request body.

The lineage guard does not cover the gap, because it is skipped when the deal has produced no event yet:

```js
if (actor?.id && eventIds.size && !(await isSuperAdmin(actor, conn))) {
```

`eventIds.size` is 0 for a newly created quote. An unassigned destination offers no resistance either — it *adopts* the deal's customer rather than rejecting it.

## Impact

For a scoped (non-super_admin) caller:

1. **Write into a foreign project.** Their document lands in another admin's project and surfaces in that admin's cockpit.
2. **Escalation to read on an ownerless project.** `created_by IS NULL` rows — legacy projects migration 167's backfill could not attribute — are the sharp case. Once the attached quote converts to an event, that event becomes the project's *only* linked event, which is precisely the condition `ownedProjectsSubquery`'s second branch grants ownership on. The caller then owns the project and can read whatever documents were already attached to it.

Distinct error codes (`404 PROJECT_NOT_FOUND` vs `422 PROJECT_CUSTOMER_MISMATCH` vs success) also made project ids enumerable.

## Fix

Vet the destination in `linkDealToProject` itself — the one choke point all four callers share — rather than bolting a guard onto routes three of them never had. Future callers inherit it.

The predicate mirrors `ownedProjectsSubquery` rather than calling it, because that helper binds the module-level `db` and this runs inside the caller's transaction. Rejects with `404 PROJECT_NOT_FOUND`, matching `requireProjectOwnership`'s existing not-an-existence-oracle posture, which also closes the enumeration channel.

`super_admin` is unaffected.

## Tests

Four cases added to `projectDealLineageOwnership.test.js`:

- foreign project rejected even with an empty deal (the bypass)
- **ownerless** project with no events rejected (the escalation path)
- caller's own project with no events still allowed (no regression to the legitimate "drop the first deal on an empty project" flow)
- super_admin still unrestricted on a foreign destination

Verified they reproduce the vulnerability: stubbing the guard out fails exactly the two attack cases and leaves the two legitimate ones passing.

Suites green: `projectDealLineageOwnership`, `projectOwnership`, `projectOverviewEmailCanAct`, `quoteService.locks`, `quoteService.hierarchy`, `contractService`, `invoiceService.hierarchy` — 62 tests. ESLint clean on the changed source.

## Note

No advisory has been filed for this. Worth deciding whether it warrants a GHSA alongside GHSA-wrg5, since it is the same class and reopens part of what that closed.
