### PR TITLE
docs: the retired registry path freezes, it does not stop serving (#985)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 > [!IMPORTANT]
 > **PicPeak has moved to its own GitHub organization.**
 >
-> - **Docker images** are now published at `ghcr.io/picpeak/picpeak/{backend,frontend}`. The old path (`ghcr.io/the-luap/picpeak/...`) is no longer served — update your `docker-compose.yml`.
+> - **Docker images** are now published at `ghcr.io/picpeak/picpeak/{backend,frontend}`. Update your `docker-compose.yml`.
+> - ⚠️ The old path (`ghcr.io/the-luap/picpeak/...`) **still responds, but its tags are frozen** at 2026-05-27. `docker compose pull` succeeds and hands back the same build every time, so an out-of-date install looks like a broken download rather than a dead path. If PicPeak keeps reporting an update that never arrives, check your image path first.
 > - **Branches**: active development is now on `main` (was `beta`); the curated stable channel is now `stable` (was `main`). Existing PRs and clones auto-redirect via GitHub.
 >
 > See **[`docs/migration-to-org.md`](docs/migration-to-org.md)** for the one-line `docker-compose.yml` edit and full details.

--- a/docs/migration-to-org.md
+++ b/docs/migration-to-org.md
@@ -14,8 +14,37 @@ itself is unchanged; only the URLs you pull images from have moved.
 | **Branches (stable channel)** | `main` | `stable` |
 
 **Action required**: update your `docker-compose.yml` to pull from
-`ghcr.io/picpeak/picpeak/{backend,frontend}`. The old path no longer serves
-images.
+`ghcr.io/picpeak/picpeak/{backend,frontend}`.
+
+## The old path does not fail — it freezes
+
+This is the part that catches people out. `ghcr.io/the-luap/picpeak/*` **still
+serves**; it simply stopped receiving new images on 2026-05-27. So:
+
+- `docker compose pull` succeeds.
+- `docker rmi <image>` followed by a fresh pull succeeds.
+- You get byte-identical layers every time, because the tag never moves again.
+
+Nothing anywhere reports an error. The only visible symptom is that PicPeak keeps
+telling you an update is available and the update never arrives — which reads
+like a broken download rather than a retired registry path.
+
+### Am I affected?
+
+```bash
+docker image inspect ghcr.io/the-luap/picpeak/backend:latest \
+  --format '{{.Created}} {{index .Config.Labels "org.opencontainers.image.version"}}'
+```
+
+A `Created` date of `2026-05-27` (or a `version` of `main` rather than a `v3.x.y`
+tag) means you are on the retired path. Compare against the current image:
+
+```bash
+docker image inspect ghcr.io/picpeak/picpeak/backend:latest --format '{{.Created}}'
+```
+
+If your compose file still references `the-luap`, the fix below is all you need —
+there is nothing wrong with your install.
 
 ## Why this changed
 


### PR DESCRIPTION
Closes #985.

## The docs were wrong, and the wrong bit is what causes the reports

README and `migration-to-org.md` both said the old path **"is no longer served"** / **"no longer serves images"**.

It is served. I pulled the manifest and config straight from `ghcr.io/the-luap/picpeak/backend:latest` — it returns a complete image, created `2026-05-27`, label `version: main`. The registry responds normally; it just never receives anything new.

That distinction is the whole bug report in #982. An operator is told the path is no longer served, runs `docker compose pull`, watches it succeed, runs `docker rmi` and pulls again, watches that succeed too — and reasonably concludes the problem is somewhere other than their image path. Nothing in the system ever reports an error. The only symptom is an update notice that never resolves.

## What changed

Say what actually happens — the path freezes rather than failing — and give a self-diagnosis:

```bash
docker image inspect ghcr.io/the-luap/picpeak/backend:latest \
  --format '{{.Created}} {{index .Config.Labels "org.opencontainers.image.version"}}'
```

`2026-05-27`, or a `version` of `main` instead of a `v3.x.y` tag, means the retired path.

`MigrationBanner`'s wording is left alone — "no longer being **updated**" was accurate all along.

## Why this closes #985 rather than more code

#985 asked to surface the move through the update check. #993 did that, and in reviewing it we established it cannot reach the population #985 is about:

- `MigrationBanner` shipped 2026-06-29 (`2a4bf3b8`), a month after the 2026-05-27 freeze — affected builds predate it and can never render it.
- The #993 notice cannot fire either. Self-hosted installs run their own frozen backend; the only external call returns release metadata, not logic, so a v3.44.0 install runs v3.44.0's code forever. Every build containing the predicate is ≥ 3.45.0, where it is false by definition.
- Release notes do not work as a fallback: the changelog modal that renders them shipped 2026-05-29, two days after the freeze, and v3.44.0's `UpdateNotification` renders only `channel`, `current` and `latest.forChannel` — and that string must match `/^\d+\.\d+\.\d+$/`, so it cannot carry a message.

There is no in-app channel. What does reach these operators is GitHub, which is where they end up once confused — #982 being the worked example — and the GHCR page for the retired package, which renders this README through the images' own `org.opencontainers.image.source` label. So fixing the README propagates to the dead path's own package page without any further action.

Docs only; no code, no tests.
