### PR TITLE
fix(branding): hide "Powered by PicPeak" on every page, not only the gallery

### DIFF
--- a/frontend/src/components/common/CMSContentBlock.tsx
+++ b/frontend/src/components/common/CMSContentBlock.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import DOMPurify from 'dompurify';
 import { Card } from './Card';
 import { Loading } from './Loading';
+import { PoweredBy } from './PoweredBy';
 import { cmsService } from '../../services/cms.service';
 import { usePublicSettings } from '../../hooks/usePublicSettings';
 import { buildResourceUrl } from '../../utils/url';
@@ -132,11 +133,7 @@ export const CMSContentBlock: React.FC<CMSContentBlockProps> = ({ slug, fallback
             {lang === 'de' ? 'Datenschutz' : 'Privacy Policy'}
           </Link>
         </div>
-        {!settings?.branding_hide_powered_by && (
-          <p className="mt-2">
-            Powered by <span className="font-semibold">PicPeak</span>
-          </p>
-        )}
+        <PoweredBy className="mt-2" />
       </footer>
     </div>
   );

--- a/frontend/src/components/common/PoweredBy.tsx
+++ b/frontend/src/components/common/PoweredBy.tsx
@@ -3,32 +3,17 @@ import { useTranslation } from 'react-i18next';
 import { usePublicSettings } from '../../hooks/usePublicSettings';
 
 interface PoweredByProps {
-  /** Extra classes applied to the wrapping `<p>`, for per-context styling. */
   className?: string;
-  /** Inline styles applied to the wrapping `<p>`. */
   style?: React.CSSProperties;
 }
 
-/**
- * Renders the "Powered by PicPeak" attribution shown in public footers and
- * login screens.
- *
- * The component reads the public `branding_hide_powered_by` setting itself —
- * like `DynamicFavicon` / `RobotsMetaTags` — and renders nothing when the admin
- * has enabled white-labeling. Keeping the visibility check inside the component
- * lets every call site drop in `<PoweredBy />` instead of repeating the guard
- * or drilling the flag down through layout props.
- *
- * Only the "Powered by" prefix is translated (`common.poweredBy`); the brand
- * name is rendered verbatim and never localized.
- */
+// "Powered by PicPeak" footer/login attribution. Reads the setting itself (like
+// DynamicFavicon) so callers don't repeat the guard; hidden for white-label.
 export const PoweredBy: React.FC<PoweredByProps> = ({ className, style }) => {
   const { t } = useTranslation();
   const { data: settings } = usePublicSettings();
 
-  if (settings?.branding_hide_powered_by) {
-    return null;
-  }
+  if (settings?.branding_hide_powered_by) return null;
 
   return (
     <p className={className} style={style}>

--- a/frontend/src/components/common/PoweredBy.tsx
+++ b/frontend/src/components/common/PoweredBy.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { usePublicSettings } from '../../hooks/usePublicSettings';
+
+interface PoweredByProps {
+  /** Extra classes applied to the wrapping `<p>`, for per-context styling. */
+  className?: string;
+  /** Inline styles applied to the wrapping `<p>`. */
+  style?: React.CSSProperties;
+}
+
+/**
+ * Renders the "Powered by PicPeak" attribution shown in public footers and
+ * login screens.
+ *
+ * The component reads the public `branding_hide_powered_by` setting itself —
+ * like `DynamicFavicon` / `RobotsMetaTags` — and renders nothing when the admin
+ * has enabled white-labeling. Keeping the visibility check inside the component
+ * lets every call site drop in `<PoweredBy />` instead of repeating the guard
+ * or drilling the flag down through layout props.
+ *
+ * Only the "Powered by" prefix is translated (`common.poweredBy`); the brand
+ * name is rendered verbatim and never localized.
+ */
+export const PoweredBy: React.FC<PoweredByProps> = ({ className, style }) => {
+  const { t } = useTranslation();
+  const { data: settings } = usePublicSettings();
+
+  if (settings?.branding_hide_powered_by) {
+    return null;
+  }
+
+  return (
+    <p className={className} style={style}>
+      {t('common.poweredBy')} <span className="font-semibold">PicPeak</span>
+    </p>
+  );
+};

--- a/frontend/src/components/common/PoweredBy.tsx
+++ b/frontend/src/components/common/PoweredBy.tsx
@@ -13,7 +13,9 @@ export const PoweredBy: React.FC<PoweredByProps> = ({ className, style }) => {
   const { t } = useTranslation();
   const { data: settings } = usePublicSettings();
 
-  if (settings?.branding_hide_powered_by) return null;
+  // Hide while settings are still loading too, otherwise a white-labelled
+  // instance flashes the attribution before branding_hide_powered_by resolves.
+  if (!settings || settings.branding_hide_powered_by) return null;
 
   return (
     <p className={className} style={style}>

--- a/frontend/src/components/common/__tests__/PoweredBy.test.tsx
+++ b/frontend/src/components/common/__tests__/PoweredBy.test.tsx
@@ -33,10 +33,11 @@ describe('PoweredBy', () => {
     expect(screen.getByText('PicPeak')).toBeInTheDocument();
   });
 
-  it('still renders while settings are loading (data undefined)', () => {
+  it('renders nothing while settings are still loading (no attribution flash)', () => {
     setSettings(undefined);
-    render(<PoweredBy />);
-    expect(screen.getByText('PicPeak')).toBeInTheDocument();
+    const { container } = render(<PoweredBy />);
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByText('PicPeak')).not.toBeInTheDocument();
   });
 
   it('renders nothing when branding_hide_powered_by is enabled (white-label)', () => {

--- a/frontend/src/components/common/__tests__/PoweredBy.test.tsx
+++ b/frontend/src/components/common/__tests__/PoweredBy.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { PoweredBy } from '../PoweredBy';
+import { usePublicSettings } from '../../../hooks/usePublicSettings';
+
+// Only the "Powered by" prefix goes through i18n; the brand name is rendered
+// verbatim by the component. Map the key to English so assertions read clearly.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => (key === 'common.poweredBy' ? 'Powered by' : key),
+  }),
+}));
+
+vi.mock('../../../hooks/usePublicSettings', () => ({
+  usePublicSettings: vi.fn(),
+}));
+
+const mockUsePublicSettings = vi.mocked(usePublicSettings);
+
+const setSettings = (data: Record<string, unknown> | undefined) => {
+  mockUsePublicSettings.mockReturnValue({ data } as never);
+};
+
+describe('PoweredBy', () => {
+  beforeEach(() => {
+    mockUsePublicSettings.mockReset();
+  });
+
+  it('renders the "Powered by PicPeak" attribution by default', () => {
+    setSettings({});
+    render(<PoweredBy />);
+    expect(screen.getByText(/Powered by/)).toBeInTheDocument();
+    // Brand name lives in its own (bold) span and is never translated.
+    expect(screen.getByText('PicPeak')).toBeInTheDocument();
+  });
+
+  it('still renders while settings are loading (data undefined)', () => {
+    setSettings(undefined);
+    render(<PoweredBy />);
+    expect(screen.getByText('PicPeak')).toBeInTheDocument();
+  });
+
+  it('renders nothing when branding_hide_powered_by is enabled (white-label)', () => {
+    setSettings({ branding_hide_powered_by: true });
+    const { container } = render(<PoweredBy />);
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByText('PicPeak')).not.toBeInTheDocument();
+  });
+
+  it('renders when branding_hide_powered_by is explicitly false', () => {
+    setSettings({ branding_hide_powered_by: false });
+    render(<PoweredBy />);
+    expect(screen.getByText('PicPeak')).toBeInTheDocument();
+  });
+
+  it('forwards className and style to the wrapping paragraph', () => {
+    setSettings({});
+    render(<PoweredBy className="text-xs mt-2" style={{ opacity: 0.5 }} />);
+    const paragraph = screen.getByText('PicPeak').closest('p');
+    expect(paragraph).toHaveClass('text-xs', 'mt-2');
+    expect(paragraph).toHaveStyle({ opacity: '0.5' });
+  });
+});

--- a/frontend/src/components/common/__tests__/PoweredBy.test.tsx
+++ b/frontend/src/components/common/__tests__/PoweredBy.test.tsx
@@ -4,8 +4,7 @@ import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { PoweredBy } from '../PoweredBy';
 import { usePublicSettings } from '../../../hooks/usePublicSettings';
 
-// Only the "Powered by" prefix goes through i18n; the brand name is rendered
-// verbatim by the component. Map the key to English so assertions read clearly.
+// stub i18n so the prefix comes back as plain English for the assertions
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (key: string) => (key === 'common.poweredBy' ? 'Powered by' : key),
@@ -31,7 +30,6 @@ describe('PoweredBy', () => {
     setSettings({});
     render(<PoweredBy />);
     expect(screen.getByText(/Powered by/)).toBeInTheDocument();
-    // Brand name lives in its own (bold) span and is never translated.
     expect(screen.getByText('PicPeak')).toBeInTheDocument();
   });
 

--- a/frontend/src/components/common/index.ts
+++ b/frontend/src/components/common/index.ts
@@ -29,4 +29,5 @@ export { ProtectionWarning } from './ProtectionWarning';
 export { ReCaptcha } from './ReCaptcha';
 export { PasswordGenerator } from './PasswordGenerator';
 export { MarkdownContent } from './MarkdownContent';
+export { PoweredBy } from './PoweredBy';
 export { ConfirmDialogProvider, useConfirm, type ConfirmOptions, type ConfirmVariant } from './ConfirmDialog';

--- a/frontend/src/components/gallery/layouts/GalleryPremiumLayout.tsx
+++ b/frontend/src/components/gallery/layouts/GalleryPremiumLayout.tsx
@@ -18,7 +18,7 @@ import { useInView } from 'react-intersection-observer';
 
 import type { BaseGalleryLayoutProps } from './BaseGalleryLayout';
 import type { Photo } from '../../../types';
-import { AuthenticatedImage } from '../../common';
+import { AuthenticatedImage, PoweredBy } from '../../common';
 import { feedbackService } from '../../../services/feedback.service';
 import { PhotoReactions } from '../PhotoReactions';
 import { useGuestIdentityOptional } from '../../../contexts/GuestIdentityContext';
@@ -598,7 +598,7 @@ export const GalleryPremiumLayout: React.FC<GalleryPremiumLayoutProps> = ({
 
       {/* Footer */}
       <footer className="gallery-premium-footer">
-        <p>{t('gallery.poweredBy', 'Powered by PicPeak')}</p>
+        <PoweredBy />
         <p>© {new Date().getFullYear()} {t('gallery.allRightsReserved', 'All rights reserved')}</p>
       </footer>
 

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -152,7 +152,8 @@
     "duplicate": "Duplizieren",
     "showAll": "Alle anzeigen",
     "confirm": "Bestätigen",
-    "show": "Einblenden"
+    "show": "Einblenden",
+    "poweredBy": "Bereitgestellt von"
   },
   "upload": {
     "photoCategory": "Fotokategorie",
@@ -936,8 +937,7 @@
       "socials": "Soziale Netzwerke"
     },
     "photosCount_one": "{{count}} Foto",
-    "photosCount_other": "{{count}} Fotos",
-    "poweredBy": "Bereitgestellt von PicPeak"
+    "photosCount_other": "{{count}} Fotos"
   },
   "categories": {
     "title": "Fotokategorien",
@@ -3792,7 +3792,6 @@
     "invalidCredentials": "Ungültige E-Mail oder Passwort",
     "generalError": "Ein Fehler ist aufgetreten. Bitte versuchen Sie es erneut.",
     "needHelp": "Hilfe benötigt? Kontakt",
-    "poweredBy": "Bereitgestellt von PicPeak",
     "devModeHint": "Entwicklungsmodus: E-Mail: admin@example.com, Passwort: admin123",
     "mfa": {
       "title": "Zwei-Faktor-Authentifizierung",
@@ -3889,8 +3888,7 @@
       "adminHint": "Sie suchen das Admin-Panel? Besuchen Sie /admin/login.",
       "emailPlaceholder": "du@beispiel.de",
       "passwordPlaceholder": "Dein Passwort",
-      "needHelp": "Brauchst du Hilfe?",
-      "poweredBy": "Bereitgestellt von PicPeak"
+      "needHelp": "Brauchst du Hilfe?"
     },
     "acceptInvite": {
       "title": "Konto einrichten",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -152,7 +152,8 @@
     "duplicate": "Duplicate",
     "showAll": "Show all",
     "confirm": "Confirm",
-    "show": "Show"
+    "show": "Show",
+    "poweredBy": "Powered by"
   },
   "upload": {
     "photoCategory": "Photo Category",
@@ -478,7 +479,6 @@
     },
     "photosCount_one": "{{count}} photo",
     "photosCount_other": "{{count}} photos",
-    "poweredBy": "Powered by PicPeak",
     "photosSelected_one": "{{count}} photo selected",
     "photosSelected_other": "{{count}} photos selected",
     "downloadSelected_one": "Download {{count}} photo",
@@ -3678,7 +3678,6 @@
     "invalidCredentials": "Invalid email or password",
     "generalError": "An error occurred. Please try again.",
     "needHelp": "Need help? Contact",
-    "poweredBy": "Powered by PicPeak",
     "devModeHint": "Development Mode: Use email: admin@example.com, password: admin123",
     "mfa": {
       "title": "Two-factor authentication",
@@ -3889,8 +3888,7 @@
       "adminHint": "Looking for the admin panel? Visit /admin/login.",
       "emailPlaceholder": "you@example.com",
       "passwordPlaceholder": "Your password",
-      "needHelp": "Need help?",
-      "poweredBy": "Powered by PicPeak"
+      "needHelp": "Need help?"
     },
     "acceptInvite": {
       "title": "Set up your account",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -119,7 +119,8 @@
     "select": "Seleccionar",
     "selected": "Seleccionado",
     "chunk": "Fragmento",
-    "optional": "opcional"
+    "optional": "opcional",
+    "poweredBy": "Desarrollado por"
   },
   "upload": {
     "photoCategory": "Categoría de foto",
@@ -2458,7 +2459,6 @@
     "invalidCredentials": "Correo o contraseña inválidos",
     "generalError": "Ocurrió un error. Por favor, inténtalo de nuevo.",
     "needHelp": "¿Necesitas ayuda? Contacta",
-    "poweredBy": "Desarrollado por PicPeak",
     "devModeHint": "Modo desarrollo: usa admin@example.com, contraseña: admin123"
   },
   "clientAccess": {

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -124,7 +124,8 @@
     "saveChanges": "Enregistrer les modifications",
     "resetChanges": "Réinitialiser les modifications",
     "dismiss": "Ignorer",
-    "discard": "Abandonner"
+    "discard": "Abandonner",
+    "poweredBy": "Propulsé par"
   },
   "upload": {
     "photoCategory": "Catégorie de la photo",
@@ -334,7 +335,6 @@
     },
     "photosCount_one": "{{count}} photo",
     "photosCount_other": "{{count}} photos",
-    "poweredBy": "Propulsé par PicPeak",
     "photosSelected_one": "{{count}} photo sélectionnée",
     "photosSelected_other": "{{count}} photos sélectionnées",
     "downloadSelected_one": "Télécharger {{count}} photo",
@@ -2682,7 +2682,6 @@
     "invalidCredentials": "E-mail ou mot de passe invalide",
     "generalError": "Une erreur est survenue. Veuillez réessayer.",
     "needHelp": "Besoin d'aide ? Contactez",
-    "poweredBy": "Propulsé par PicPeak",
     "devModeHint": "Mode développement : Utilisez l'e-mail : admin@example.com, mot de passe : admin123"
   },
   "clientAccess": {
@@ -2762,8 +2761,7 @@
       "adminHint": "Vous cherchez le panneau d'administration ? Visitez /admin/login.",
       "emailPlaceholder": "vous@example.com",
       "passwordPlaceholder": "Votre mot de passe",
-      "needHelp": "Besoin d'aide ?",
-      "poweredBy": "Propulsé par PicPeak"
+      "needHelp": "Besoin d'aide ?"
     },
     "acceptInvite": {
       "title": "Configurer votre compte",

--- a/frontend/src/i18n/locales/nl.json
+++ b/frontend/src/i18n/locales/nl.json
@@ -124,7 +124,8 @@
     "saveChanges": "Wijzigingen opslaan",
     "resetChanges": "Wijzigingen ongedaan maken",
     "dismiss": "Sluiten",
-    "discard": "Verwerpen"
+    "discard": "Verwerpen",
+    "poweredBy": "Mogelijk gemaakt door"
   },
   "upload": {
     "photoCategory": "Fotocategorie",
@@ -337,8 +338,7 @@
       "socials": "Sociale media"
     },
     "photosCount_one": "{{count}} foto",
-    "photosCount_other": "{{count}} foto's",
-    "poweredBy": "Mogelijk gemaakt door PicPeak"
+    "photosCount_other": "{{count}} foto's"
   },
   "categories": {
     "title": "Fotocategorieen",
@@ -2680,7 +2680,6 @@
     "invalidCredentials": "Ongeldige e-mail of wachtwoord",
     "generalError": "Er is een fout opgetreden. Probeer het opnieuw.",
     "needHelp": "Hulp nodig? Neem contact op met",
-    "poweredBy": "Powered by PicPeak",
     "devModeHint": "Ontwikkelmodus: Gebruik e-mail: admin@example.com, wachtwoord: admin123"
   },
   "clientAccess": {
@@ -2751,8 +2750,7 @@
       "adminHint": "Op zoek naar het beheerderspaneel? Ga naar /admin/login.",
       "emailPlaceholder": "jij@voorbeeld.com",
       "passwordPlaceholder": "Je wachtwoord",
-      "needHelp": "Hulp nodig?",
-      "poweredBy": "Mogelijk gemaakt door PicPeak"
+      "needHelp": "Hulp nodig?"
     },
     "acceptInvite": {
       "title": "Account aanmaken",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -124,7 +124,8 @@
     "saveChanges": "Salvar alterações",
     "resetChanges": "Repor alterações",
     "dismiss": "Dispensar",
-    "discard": "Descartar"
+    "discard": "Descartar",
+    "poweredBy": "Desenvolvido por"
   },
   "upload": {
     "photoCategory": "Categoria da Foto",
@@ -345,8 +346,7 @@
     },
     "photosCount_many": "{{count}} fotos",
     "photosCount_one": "{{count}} foto",
-    "photosCount_other": "{{count}} fotos",
-    "poweredBy": "Desenvolvido por PicPeak"
+    "photosCount_other": "{{count}} fotos"
   },
   "categories": {
     "title": "Categorias de Fotos",
@@ -2701,7 +2701,6 @@
     "invalidCredentials": "E-mail ou senha inválidos",
     "generalError": "Ocorreu um erro. Tente novamente.",
     "needHelp": "Precisa de ajuda? Contate",
-    "poweredBy": "Distribuído por PicPeak",
     "devModeHint": "Modo Desenvolvimento: E-mail: admin@exemplo.com, Senha: admin123"
   },
   "clientAccess": {
@@ -2784,8 +2783,7 @@
       "adminHint": "Procurando o painel de administração? Acesse /admin/login.",
       "emailPlaceholder": "voce@exemplo.com",
       "passwordPlaceholder": "Sua senha",
-      "needHelp": "Precisa de ajuda?",
-      "poweredBy": "Desenvolvido por PicPeak"
+      "needHelp": "Precisa de ajuda?"
     },
     "acceptInvite": {
       "title": "Configure sua conta",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -124,7 +124,8 @@
     "saveChanges": "Сохранить изменения",
     "resetChanges": "Сбросить изменения",
     "dismiss": "Закрыть",
-    "discard": "Отменить"
+    "discard": "Отменить",
+    "poweredBy": "Работает на"
   },
   "upload": {
     "photoCategory": "Категория фото",
@@ -353,8 +354,7 @@
     "photosCount_few": "{{count}} фото",
     "photosCount_many": "{{count}} фото",
     "photosCount_one": "{{count}} фото",
-    "photosCount_other": "{{count}} фото",
-    "poweredBy": "Работает на PicPeak"
+    "photosCount_other": "{{count}} фото"
   },
   "categories": {
     "title": "Категории фото",
@@ -2731,7 +2731,6 @@
     "invalidCredentials": "Неверный email или пароль",
     "generalError": "Произошла ошибка. Попробуйте снова.",
     "needHelp": "Нужна помощь? Свяжитесь",
-    "poweredBy": "Работает на PicPeak",
     "devModeHint": "Режим разработки: используйте email: admin@example.com, пароль: admin123"
   },
   "clientAccess": {
@@ -2817,8 +2816,7 @@
       "adminHint": "Ищете админ-панель? Перейдите на /admin/login.",
       "emailPlaceholder": "you@example.com",
       "passwordPlaceholder": "Ваш пароль",
-      "needHelp": "Нужна помощь?",
-      "poweredBy": "Работает на PicPeak"
+      "needHelp": "Нужна помощь?"
     },
     "acceptInvite": {
       "title": "Создайте учётную запись",

--- a/frontend/src/i18n/locales/sl.json
+++ b/frontend/src/i18n/locales/sl.json
@@ -124,7 +124,8 @@
     "saveChanges": "Shrani spremembe",
     "resetChanges": "Ponastavi spremembe",
     "dismiss": "Zapri",
-    "discard": "Zavrzi"
+    "discard": "Zavrzi",
+    "poweredBy": "Poganja"
   },
   "upload": {
     "photoCategory": "Kategorija fotografije",
@@ -334,7 +335,6 @@
     },
     "photosCount_one": "{{count}} fotografija",
     "photosCount_other": "{{count}} fotografij",
-    "poweredBy": "Poganja PicPeak",
     "photosSelected_one": "Izbrana {{count}} fotografija",
     "photosSelected_other": "Izbranih {{count}} fotografij",
     "downloadSelected_one": "Prenesi {{count}} fotografijo",
@@ -2671,7 +2671,6 @@
     "invalidCredentials": "Neveljavna e-pošta ali geslo",
     "generalError": "Prišlo je do napake. Poskusite znova.",
     "needHelp": "Potrebujete pomoč? Kontakt",
-    "poweredBy": "Poganja PicPeak",
     "devModeHint": "Razvojni način: uporabite e-pošto: admin@example.com, geslo: admin123"
   },
   "clientAccess": {
@@ -2751,8 +2750,7 @@
       "adminHint": "Iščete administratorsko ploščo? Obiščite /admin/login.",
       "emailPlaceholder": "vi@example.com",
       "passwordPlaceholder": "Vaše geslo",
-      "needHelp": "Potrebujete pomoč?",
-      "poweredBy": "Poganja PicPeak"
+      "needHelp": "Potrebujete pomoč?"
     },
     "acceptInvite": {
       "title": "Nastavite svoj račun",

--- a/frontend/src/pages/ClientAccessPage.tsx
+++ b/frontend/src/pages/ClientAccessPage.tsx
@@ -3,7 +3,7 @@ import { useParams, useSearchParams, useNavigate, Link } from 'react-router-dom'
 import { AlertCircle, Lock } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
-import { Card, CardContent, Input, Button, Loading } from '../components/common';
+import { Card, CardContent, Input, Button, Loading, PoweredBy } from '../components/common';
 import { useGalleryAuth } from '../contexts';
 import { useGalleryInfo } from '../hooks/useGallery';
 import { usePublicSettings } from '../hooks/usePublicSettings';
@@ -197,9 +197,7 @@ export const ClientAccessPage: React.FC = () => {
               {t('legal.datenschutz')}
             </Link>
           </div>
-          <p className="text-xs mt-2 text-neutral-500">
-            Powered by <span className="font-semibold">PicPeak</span>
-          </p>
+          <PoweredBy className="text-xs mt-2 text-neutral-500" />
         </div>
       </div>
     </div>

--- a/frontend/src/pages/GalleryPage.tsx
+++ b/frontend/src/pages/GalleryPage.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { useLocalizedDate } from '../hooks/useLocalizedDate';
 import { usePublicSettings } from '../hooks/usePublicSettings';
 
-import { Card, CardContent, Input, Button, ReCaptcha, CMSContentBlock } from '../components/common';
+import { Card, CardContent, Input, Button, ReCaptcha, CMSContentBlock, PoweredBy } from '../components/common';
 import { useGalleryAuth, useTheme } from '../contexts';
 import { useGalleryInfo } from '../hooks/useGallery';
 import { GalleryView } from '../components/gallery';
@@ -386,9 +386,7 @@ export const GalleryPage: React.FC = () => {
                 {t('legal.datenschutz')}
               </Link>
             </div>
-            <p className="text-xs mt-2 text-neutral-500">
-              Powered by <span className="font-semibold">PicPeak</span>
-            </p>
+            <PoweredBy className="text-xs mt-2 text-neutral-500" />
           </div>
         </div>
       </div>
@@ -594,9 +592,7 @@ export const GalleryPage: React.FC = () => {
                 {t('legal.datenschutz')}
               </Link>
             </div>
-            <p className="text-xs mt-2 text-neutral-500">
-              Powered by <span className="font-semibold">PicPeak</span>
-            </p>
+            <PoweredBy className="text-xs mt-2 text-neutral-500" />
           </div>
         </div>
       </div>

--- a/frontend/src/pages/admin/AdminLoginPage.tsx
+++ b/frontend/src/pages/admin/AdminLoginPage.tsx
@@ -5,7 +5,7 @@ import { Lock, Mail, Eye, EyeOff, AlertCircle, ShieldCheck, KeyRound, ArrowLeft 
 import { toast } from 'react-toastify';
 import { useTranslation } from 'react-i18next';
 
-import { Button, Input, Card, ReCaptcha } from '../../components/common';
+import { Button, Input, Card, ReCaptcha, PoweredBy } from '../../components/common';
 import { useAdminAuth } from '../../contexts';
 import { authService } from '../../services/auth.service';
 import { isMfaChallenge } from '../../types';
@@ -486,9 +486,7 @@ export const AdminLoginPage: React.FC = () => {
               {settingsData?.branding_support_email || 'support@example.com'}
             </a>
           </p>
-          <p className="text-xs mt-2" style={{ color: 'var(--color-text, #171717)', opacity: 0.5 }}>
-            {t('adminLogin.poweredBy')}
-          </p>
+          <PoweredBy className="text-xs mt-2" style={{ color: 'var(--color-text, #171717)', opacity: 0.5 }} />
         </div>
 
         {/* Development Hint */}

--- a/frontend/src/pages/customer/CustomerLoginPage.tsx
+++ b/frontend/src/pages/customer/CustomerLoginPage.tsx
@@ -10,7 +10,7 @@ import { Lock, Mail, Eye, EyeOff, AlertCircle } from 'lucide-react';
 import { toast } from 'react-toastify';
 import { useTranslation } from 'react-i18next';
 
-import { Button, Input, Card, ReCaptcha } from '../../components/common';
+import { Button, Input, Card, ReCaptcha, PoweredBy } from '../../components/common';
 import { useCustomerAuth } from '../../contexts/CustomerAuthContext';
 import { customerService } from '../../services/customer.service';
 import { usePublicSettings } from '../../hooks/usePublicSettings';
@@ -261,9 +261,7 @@ export const CustomerLoginPage: React.FC = () => {
               {settingsData?.branding_support_email || 'support@example.com'}
             </a>
           </p>
-          <p className="text-xs mt-2" style={{ color: 'var(--color-text, #171717)', opacity: 0.5 }}>
-            {t('customer.login.poweredBy', 'Powered by PicPeak')}
-          </p>
+          <PoweredBy className="text-xs mt-2" style={{ color: 'var(--color-text, #171717)', opacity: 0.5 }} />
         </div>
       </div>
     </div>

--- a/frontend/src/pages/public/AcceptInvitePage.tsx
+++ b/frontend/src/pages/public/AcceptInvitePage.tsx
@@ -14,7 +14,7 @@ import {
 } from 'lucide-react';
 import { toast } from 'react-toastify';
 
-import { Button, Input, Card, Loading } from '../../components/common';
+import { Button, Input, Card, Loading, PoweredBy } from '../../components/common';
 import { useLocalizedDate } from '../../hooks/useLocalizedDate';
 import { api } from '../../config/api';
 
@@ -537,9 +537,7 @@ export const AcceptInvitePage: React.FC = () => {
               {t('acceptInvitation.signIn')}
             </a>
           </p>
-          <p className="text-xs mt-2" style={{ color: 'var(--color-text, #171717)', opacity: 0.5 }}>
-            {t('adminLogin.poweredBy')}
-          </p>
+          <PoweredBy className="text-xs mt-2" style={{ color: 'var(--color-text, #171717)', opacity: 0.5 }} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Description

The `branding_hide_powered_by` setting only hid the attribution on the main gallery footer; it stayed visible on the gallery password screen, client access page, Premium layout, admin/customer login, accept-invite and CMS pages. This routes all of those through one small `<PoweredBy />` component in `components/common` that reads the public setting itself (same approach as `DynamicFavicon`/`RobotsMetaTags`) and renders nothing when white-labeling is on. It also collapses three duplicate translation keys (`gallery.poweredBy`, `adminLogin.poweredBy`, `customer.login.poweredBy`) into a single `common.poweredBy`, and a few pages that had "Powered by" hardcoded in English are now translated in all 8 locales.

No linked issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code refactoring

## How Has This Been Tested?

Added `PoweredBy.test.tsx` (5 cases: default render, loading, hidden when the flag is set, explicit `false`, className/style forwarding); full frontend suite green on Node 20 (124 tests), `tsc` and ESLint clean. Verified both toggle states in the browser (local dev and a Docker env) on the login pages: the attribution shows when the setting is off and disappears when it's on.

- [x] Unit tests pass (`npm test`)
- [x] Manual testing completed (both toggle states)
- [x] Tested on Docker deployment
- [ ] Tested on production-like environment

**Test Configuration**:
* PicPeak Version: main (3.100.1-beta.0)
* Node.js Version: 20.x
* Database: PostgreSQL
* Browser: Chrome, Safari

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (N/A, no doc changes)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published (N/A, no dependency changes)
- [ ] I have updated the CHANGELOG.md file (N/A, handled by release-please)

## Screenshots (if appropriate):

Setting OFF shows the attribution, setting ON removes it:

| Page | Setting OFF (shown) | Setting ON (hidden) |
|------|---------------------|---------------------|
| Admin login | <img width="653" height="829" alt="image" src="https://github.com/user-attachments/assets/a781d8c0-a4e2-4702-b6b0-ed61b4b17b2d" /> | <img width="611" height="829" alt="image" src="https://github.com/user-attachments/assets/71899e6b-3e9a-451b-9971-842367b49b7b" /> |
| Customer login | <img width="602" height="763" alt="image" src="https://github.com/user-attachments/assets/b8ede33c-1d60-4285-a389-f71855e329e4" /> | <img width="648" height="793" alt="image" src="https://github.com/user-attachments/assets/7c1d1de6-5ea2-4a59-9703-eae2ff7ba1d6" /> |

## Additional Notes:

- Deliberately a small fix to get familiar with the contribution flow before proposing anything larger.
- Left `GalleryLayout.tsx` as-is: its "Powered by" is inline with the copyright line (different markup) and already respected the setting.
- "PicPeak" now renders semibold everywhere for consistency; the login pages showed it plain before.
- `<PoweredBy>` takes className/style per call site on purpose: the gallery/legal footers and the login screens already used different styles (fixed neutral gray vs themed text at 50% opacity), kept as-is to avoid visual changes. Could be folded into a `variant` prop if preferred, let me know
- Possible follow-up: "PicPeak" is a hardcoded literal in ~64 spots; a shared `PRODUCT_NAME` constant (separate from the customer's `branding_company_name` / `BRAND_TITLE`) could centralize it. Left out to keep this focused.