### PR TITLE
fix(branding): route the gallery footer through <PoweredBy /> (#1003)

### DIFF
--- a/frontend/src/components/common/PoweredBy.tsx
+++ b/frontend/src/components/common/PoweredBy.tsx
@@ -5,11 +5,21 @@ import { usePublicSettings } from '../../hooks/usePublicSettings';
 interface PoweredByProps {
   className?: string;
   style?: React.CSSProperties;
+  /**
+   * Render inside an existing paragraph — as ` | Powered by PicPeak` in a
+   * `<span>` — rather than as its own `<p>`. The gallery footer appends the
+   * attribution to its copyright line, and a `<p>` nested in a `<p>` is invalid.
+   *
+   * The separator belongs to the component on purpose: a caller placing its own
+   * ` | ` would have to repeat the visibility guard to avoid leaving a dangling
+   * separator behind, and repeating that guard is what #999 was fixing.
+   */
+  inline?: boolean;
 }
 
 // "Powered by PicPeak" footer/login attribution. Reads the setting itself (like
 // DynamicFavicon) so callers don't repeat the guard; hidden for white-label.
-export const PoweredBy: React.FC<PoweredByProps> = ({ className, style }) => {
+export const PoweredBy: React.FC<PoweredByProps> = ({ className, style, inline = false }) => {
   const { t } = useTranslation();
   const { data: settings } = usePublicSettings();
 
@@ -17,9 +27,19 @@ export const PoweredBy: React.FC<PoweredByProps> = ({ className, style }) => {
   // instance flashes the attribution before branding_hide_powered_by resolves.
   if (!settings || settings.branding_hide_powered_by) return null;
 
+  const label = (
+    <>
+      {t('common.poweredBy')} <span className="font-semibold">PicPeak</span>
+    </>
+  );
+
+  if (inline) {
+    return <span className={className} style={style}> | {label}</span>;
+  }
+
   return (
     <p className={className} style={style}>
-      {t('common.poweredBy')} <span className="font-semibold">PicPeak</span>
+      {label}
     </p>
   );
 };

--- a/frontend/src/components/common/__tests__/PoweredBy.test.tsx
+++ b/frontend/src/components/common/__tests__/PoweredBy.test.tsx
@@ -60,4 +60,38 @@ describe('PoweredBy', () => {
     expect(paragraph).toHaveClass('text-xs', 'mt-2');
     expect(paragraph).toHaveStyle({ opacity: '0.5' });
   });
+
+  // The gallery footer appends the attribution to its copyright line, inside an
+  // existing <p>. A nested <p> is invalid HTML, so that call site needs a span
+  // and the leading separator (#1003).
+  describe('inline variant', () => {
+    it('renders a span, not a paragraph, so it can live inside one', () => {
+      setSettings({});
+      const { container } = render(<PoweredBy inline />);
+      expect(screen.getByText('PicPeak').closest('p')).toBeNull();
+      expect(container.querySelector('span')).not.toBeNull();
+    });
+
+    it('carries its own separator', () => {
+      setSettings({});
+      const { container } = render(<PoweredBy inline />);
+      expect(container.textContent).toContain('| Powered by');
+    });
+
+    it('hides the separator along with the attribution when white-labelled', () => {
+      // The separator has to be inside the component: a caller rendering its
+      // own " | " would need to repeat the visibility guard, and would leave a
+      // dangling separator the moment it drifted.
+      setSettings({ branding_hide_powered_by: true });
+      const { container } = render(<PoweredBy inline />);
+      expect(container).toBeEmptyDOMElement();
+      expect(container.textContent).not.toContain('|');
+    });
+
+    it('hides while settings are still loading, like the block variant', () => {
+      setSettings(undefined);
+      const { container } = render(<PoweredBy inline />);
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
 });

--- a/frontend/src/components/gallery/GalleryLayout.tsx
+++ b/frontend/src/components/gallery/GalleryLayout.tsx
@@ -5,7 +5,7 @@ import { Calendar, Clock, Download, LogOut, Facebook, Instagram, Twitter, Youtub
 import { parseISO } from 'date-fns';
 import { useTranslation } from 'react-i18next';
 import { useLocalizedDate } from '../../hooks/useLocalizedDate';
-import { Button, MarkdownContent } from '../common';
+import { Button, MarkdownContent, PoweredBy } from '../common';
 import { DynamicFavicon } from '../common/DynamicFavicon';
 import { useTheme } from '../../contexts/ThemeContext';
 import { useGuestIdentityOptional } from '../../contexts/GuestIdentityContext';
@@ -48,7 +48,6 @@ interface GalleryLayoutProps {
     logo_display_header?: boolean;
     logo_display_hero?: boolean;
     logo_display_mode?: 'logo_only' | 'text_only' | 'logo_and_text';
-    hide_powered_by?: boolean;
     // Footer overhaul (#441 + #440). Empty strings hide each socials icon.
     facebook_url?: string;
     instagram_url?: string;
@@ -702,9 +701,7 @@ export const GalleryLayout: React.FC<GalleryLayoutProps> = ({
           )}
           <p className="text-xs sm:text-sm text-muted-theme">
             {brandingSettings?.footer_text || `© ${new Date().getFullYear()}${brandingSettings?.company_name ? ` ${brandingSettings.company_name}` : ''}. All rights reserved.`}
-            {!brandingSettings?.hide_powered_by && (
-              <> | Powered by <span className="font-semibold">PicPeak</span></>
-            )}
+            <PoweredBy inline />
           </p>
           {brandingSettings?.company_name && brandingSettings?.company_tagline && (
             <p className="text-xs text-muted-theme mt-2">

--- a/frontend/src/components/gallery/GalleryView.tsx
+++ b/frontend/src/components/gallery/GalleryView.tsx
@@ -316,7 +316,6 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event }) => {
         logo_display_header: settingsData.branding_logo_display_header !== false,
         logo_display_hero: settingsData.branding_logo_display_hero !== false,
         logo_display_mode: settingsData.branding_logo_display_mode || 'logo_and_text',
-        hide_powered_by: settingsData.branding_hide_powered_by === true,
         // Footer overhaul (#441 + #440). All five socials are optional;
         // empty strings → that icon is hidden. promo_markdown is the
         // global default; per-event override happens in GalleryLayout.


### PR DESCRIPTION
Closes #1003.

#999 centralised the attribution so `branding_hide_powered_by` is honoured everywhere, but `GalleryLayout` kept its own inline guard. Two consequences, and the second is the one that matters.

**The gallery footer still flashed.** #999 fixed that by hiding while settings are unresolved. `GalleryLayout` kept `!brandingSettings?.hide_powered_by`, where `undefined` is falsy, so a white-labelled instance briefly showed the attribution on first paint — on the surface a white-label customer is most likely to see.

**And there were two implementations of one rule.** #999 exists *because* the guard lived in one place and not the others. Leaving a second copy re-seeds that bug class, and the flash divergence was already a live example: the fix landed in one component and the other silently kept the old behaviour.

## The catch, and why the separator moved into the component

The footer appends the attribution to its copyright line **inside an existing `<p>`**:

```tsx
<p className="text-xs sm:text-sm text-muted-theme">
  {footer_text || `© … All rights reserved.`}
  {!brandingSettings?.hide_powered_by && (
    <> | Powered by <span className="font-semibold">PicPeak</span></>
  )}
</p>
```

So a straight swap would nest a `<p>` in a `<p>`, which is invalid. Added an `inline` variant that renders a `<span>` and carries the leading `" | "` itself.

The separator belongs to the component deliberately. A caller placing its own `" | "` would have to repeat the visibility guard to avoid leaving a dangling separator when the attribution is hidden — and repeating that guard is exactly what this issue is about.

## No extra request, and a small bonus

`GalleryView` already calls `usePublicSettings()` — the same hook and react-query key `<PoweredBy />` reads — so the cache is shared and the gallery pays nothing new. The footer also picks up `common.poweredBy`, so it is translated rather than hardcoded English, matching what #999 did for the other surfaces.

Removed the now-unread `hide_powered_by` from `GalleryLayout`'s prop type and the mapping feeding it in `GalleryView` — orphans this change created.

## Tests

Four cases for the variant: renders a `<span>` not a `<p>`, carries its own separator, hides the separator along with the attribution when white-labelled, and hides while loading like the block variant.

Each fails against the pre-fix shape — making `inline` render a `<p>`, or moving the separator out of the component, breaks one. Verified both.

Frontend suite 128 passed (up from 124), `tsc --noEmit` clean, ESLint clean on all four changed files, `npm run build` succeeds.
