### PR TITLE
fix(deps): bump nanoid and js-yaml out of two HIGH advisories

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "picpeak-backend",
-  "version": "3.99.0-beta.0",
+  "version": "3.101.3-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "picpeak-backend",
-      "version": "3.99.0-beta.0",
+      "version": "3.101.3-beta.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.850.0",
         "@aws-sdk/lib-storage": "^3.850.0",
@@ -7991,9 +7991,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -9086,9 +9086,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Clears both open Trivy code-scanning alerts on `main`.

| Package | Was | Now | Advisory |
|---|---|---|---|
| `nanoid` | 3.3.16 | 3.3.18 | [CVE-2026-67213](https://avd.aquasec.com/nvd/cve-2026-67213) — infinite loop in `customAlphabet` (HIGH) |
| `js-yaml` | 4.3.0 | 4.3.1 | [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) — quadratic CPU in `!!omap` resolution (HIGH) |

Both are **production** dependencies of the backend image (`backend/Dockerfile:20` runs `npm ci --omit=dev`), so they ship — this is not a devDependency-only finding:

- `nanoid` comes in transitively via `postcss@8.5.23`, whose `^3.3.11` range already permits the fix.
- `js-yaml` is a direct dependency at `^4.2.0`, which already permits the fix.

Neither needed a `package.json` range change, so this is lockfile-only: 8 lines, two packages, plus the lockfile `version` field which npm re-synced to `package.json` (it had drifted to 3.99.0-beta.0).

## On the `stable` branch

`stable` carries the **identical** vulnerable versions — `nanoid@3.3.16`, `js-yaml@4.3.0`. It currently shows zero open alerts, but that is a scanning-staleness artifact, not cleanliness: Trivy only runs on pushes to `stable`, and the last one was v3.45.14 on 2026-08-04, five days before either advisory was published. A matching backport is needed there.

## Verification

- Lockfile diff inspected — only the two intended packages change.
- `npm audit`: 0 vulnerabilities after the bump.
- Full CI suite.

Refs the two open Trivy alerts (#419, #420).

