### PR TITLE
chore: ignore all of backend/storage on stable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,5 +130,8 @@ docker-compose.dev.yml
 # New layout development files
 new-layouts/
 
-# Generated CRM/accounting documents (runtime) — never commit
-backend/storage/business-docs/
+# Backend runtime storage (generated media, previews, thumbnails,
+# CRM/accounting documents) — never commit. Matches main: a dev instance
+# writes event photos into backend/storage/, and the narrower
+# business-docs-only rule let `git add -A` sweep them into a commit.
+backend/storage/


### PR DESCRIPTION
`main` ignores `backend/storage/` wholesale; `stable` only ignores `backend/storage/business-docs/`.

A dev instance writes event photos, thumbnails and previews into `backend/storage/`, so on this branch a `git add -A` sweeps runtime artifacts into the commit — I hit exactly that while preparing #1032 (17 files: event JPEGs, `.download-cache/all.zip`, thumbnails, previews).

Broadens the rule to match main. No tracked files live under `backend/storage/` on this branch, so nothing is removed from the index.

