### PR TITLE
fix(storage): add S3 client timeouts so a dropped connection can't wedge uploads

### DIFF
--- a/backend/src/services/storage/__tests__/s3Storage.test.js
+++ b/backend/src/services/storage/__tests__/s3Storage.test.js
@@ -71,24 +71,32 @@ describe('S3StorageAdapter', () => {
         expect.objectContaining({
           requestHandler: {
             connectionTimeout: 10000,
-            requestTimeout: 10000
+            socketTimeout: 10000
           }
         })
       );
+    });
+
+    it('should not set requestTimeout, which caps total duration and only warns', () => {
+      // requestTimeout would abort legitimate large uploads (it is a
+      // total-duration cap, not inactivity) and by default only logs a
+      // warning — it needs throwOnRequestTimeout to abort at all.
+      const [[config]] = S3Client.mock.calls;
+      expect(config.requestHandler).not.toHaveProperty('requestTimeout');
     });
 
     it('should allow overriding timeouts via config', () => {
       new S3StorageAdapter({
         bucket: 'test-bucket',
         connectionTimeout: 5000,
-        requestTimeout: 30000
+        socketTimeout: 30000
       });
 
       expect(S3Client).toHaveBeenLastCalledWith(
         expect.objectContaining({
           requestHandler: {
             connectionTimeout: 5000,
-            requestTimeout: 30000
+            socketTimeout: 30000
           }
         })
       );

--- a/backend/src/services/storage/__tests__/s3Storage.test.js
+++ b/backend/src/services/storage/__tests__/s3Storage.test.js
@@ -70,11 +70,22 @@ describe('S3StorageAdapter', () => {
       expect(S3Client).toHaveBeenCalledWith(
         expect.objectContaining({
           requestHandler: {
-            connectionTimeout: 10000,
-            socketTimeout: 10000
+            connectionTimeout: 120000,
+            socketTimeout: 60000
           }
         })
       );
+    });
+
+    it('should keep connectionTimeout generous enough to survive socket-pool queuing', () => {
+      // connectionTimeout starts at request creation and only clears once a
+      // socket is assigned AND connected, so waiting for a free socket from
+      // the agent pool counts against it. A short value (e.g. 10s) fails
+      // every read under concurrent upload load. These timeouts bound an
+      // infinite hang; they are not latency targets.
+      const [[config]] = S3Client.mock.calls;
+      expect(config.requestHandler.connectionTimeout).toBeGreaterThanOrEqual(60000);
+      expect(config.requestHandler.socketTimeout).toBeGreaterThanOrEqual(30000);
     });
 
     it('should not set requestTimeout, which caps total duration and only warns', () => {

--- a/backend/src/services/storage/__tests__/s3Storage.test.js
+++ b/backend/src/services/storage/__tests__/s3Storage.test.js
@@ -65,6 +65,34 @@ describe('S3StorageAdapter', () => {
         })
       );
     });
+
+    it('should configure connection and socket-inactivity timeouts by default', () => {
+      expect(S3Client).toHaveBeenCalledWith(
+        expect.objectContaining({
+          requestHandler: {
+            connectionTimeout: 10000,
+            requestTimeout: 10000
+          }
+        })
+      );
+    });
+
+    it('should allow overriding timeouts via config', () => {
+      new S3StorageAdapter({
+        bucket: 'test-bucket',
+        connectionTimeout: 5000,
+        requestTimeout: 30000
+      });
+
+      expect(S3Client).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          requestHandler: {
+            connectionTimeout: 5000,
+            requestTimeout: 30000
+          }
+        })
+      );
+    });
   });
   
   describe('testConnection', () => {
@@ -239,6 +267,30 @@ describe('S3StorageAdapter', () => {
       s3Storage.config.retryDelay = originalDelay;
     });
     
+    it('should retry when the request handler times out a dead connection', async () => {
+      // @smithy/node-http-handler rejects with name 'TimeoutError' for both
+      // its connection-timeout and socket-inactivity timeouts
+      const timeoutError = new Error('Connection timed out after 10000ms');
+      timeoutError.name = 'TimeoutError';
+
+      const operation = jest.fn()
+        .mockRejectedValueOnce(timeoutError)
+        .mockResolvedValueOnce('success');
+
+      const originalRandom = Math.random;
+      const originalDelay = s3Storage.config.retryDelay;
+      Math.random = jest.fn(() => 0);
+      s3Storage.config.retryDelay = 0;
+
+      const result = await s3Storage._retryOperation(operation);
+
+      expect(result).toBe('success');
+      expect(operation).toHaveBeenCalledTimes(2);
+
+      Math.random = originalRandom;
+      s3Storage.config.retryDelay = originalDelay;
+    });
+
     it('should not retry on non-retryable errors', async () => {
       const nonRetryableError = new Error('Invalid credentials');
       nonRetryableError.code = 'InvalidCredentials';

--- a/backend/src/services/storage/index.js
+++ b/backend/src/services/storage/index.js
@@ -27,9 +27,9 @@ let instance = null;
  *   STORAGE_S3_PREFIX        — namespace prefix inside the bucket
  *   STORAGE_S3_FORCE_PATH_STYLE=true|false (default: auto when endpoint set)
  *   STORAGE_S3_SSL=true|false (default: true)
- *   STORAGE_S3_CONNECTION_TIMEOUT — ms to establish a connection (default 10000)
+ *   STORAGE_S3_CONNECTION_TIMEOUT — ms to acquire+establish a socket (default 120000)
  *   STORAGE_S3_SOCKET_TIMEOUT     — ms of socket inactivity before a request
- *                                   fails and is retried (default 10000)
+ *                                   fails and is retried (default 60000)
  */
 function buildStorage() {
   const backend = (process.env.STORAGE_BACKEND || 'local').toLowerCase();
@@ -51,8 +51,8 @@ function buildStorage() {
       prefix: process.env.STORAGE_S3_PREFIX,
       forcePathStyle: process.env.STORAGE_S3_FORCE_PATH_STYLE === 'true' ? true : undefined,
       sslEnabled: process.env.STORAGE_S3_SSL !== 'false',
-      connectionTimeout: parseInt(process.env.STORAGE_S3_CONNECTION_TIMEOUT || '10000', 10),
-      socketTimeout: parseInt(process.env.STORAGE_S3_SOCKET_TIMEOUT || '10000', 10),
+      connectionTimeout: parseInt(process.env.STORAGE_S3_CONNECTION_TIMEOUT || '120000', 10),
+      socketTimeout: parseInt(process.env.STORAGE_S3_SOCKET_TIMEOUT || '60000', 10),
     });
   }
 

--- a/backend/src/services/storage/index.js
+++ b/backend/src/services/storage/index.js
@@ -28,7 +28,7 @@ let instance = null;
  *   STORAGE_S3_FORCE_PATH_STYLE=true|false (default: auto when endpoint set)
  *   STORAGE_S3_SSL=true|false (default: true)
  *   STORAGE_S3_CONNECTION_TIMEOUT — ms to establish a connection (default 10000)
- *   STORAGE_S3_REQUEST_TIMEOUT    — ms of socket inactivity before a request
+ *   STORAGE_S3_SOCKET_TIMEOUT     — ms of socket inactivity before a request
  *                                   fails and is retried (default 10000)
  */
 function buildStorage() {
@@ -52,7 +52,7 @@ function buildStorage() {
       forcePathStyle: process.env.STORAGE_S3_FORCE_PATH_STYLE === 'true' ? true : undefined,
       sslEnabled: process.env.STORAGE_S3_SSL !== 'false',
       connectionTimeout: parseInt(process.env.STORAGE_S3_CONNECTION_TIMEOUT || '10000', 10),
-      requestTimeout: parseInt(process.env.STORAGE_S3_REQUEST_TIMEOUT || '10000', 10),
+      socketTimeout: parseInt(process.env.STORAGE_S3_SOCKET_TIMEOUT || '10000', 10),
     });
   }
 

--- a/backend/src/services/storage/index.js
+++ b/backend/src/services/storage/index.js
@@ -27,6 +27,9 @@ let instance = null;
  *   STORAGE_S3_PREFIX        — namespace prefix inside the bucket
  *   STORAGE_S3_FORCE_PATH_STYLE=true|false (default: auto when endpoint set)
  *   STORAGE_S3_SSL=true|false (default: true)
+ *   STORAGE_S3_CONNECTION_TIMEOUT — ms to establish a connection (default 10000)
+ *   STORAGE_S3_REQUEST_TIMEOUT    — ms of socket inactivity before a request
+ *                                   fails and is retried (default 10000)
  */
 function buildStorage() {
   const backend = (process.env.STORAGE_BACKEND || 'local').toLowerCase();
@@ -48,6 +51,8 @@ function buildStorage() {
       prefix: process.env.STORAGE_S3_PREFIX,
       forcePathStyle: process.env.STORAGE_S3_FORCE_PATH_STYLE === 'true' ? true : undefined,
       sslEnabled: process.env.STORAGE_S3_SSL !== 'false',
+      connectionTimeout: parseInt(process.env.STORAGE_S3_CONNECTION_TIMEOUT || '10000', 10),
+      requestTimeout: parseInt(process.env.STORAGE_S3_REQUEST_TIMEOUT || '10000', 10),
     });
   }
 

--- a/backend/src/services/storage/s3Storage.js
+++ b/backend/src/services/storage/s3Storage.js
@@ -41,7 +41,7 @@ class S3StorageAdapter extends stream.EventEmitter {
    * @param {number} [config.maxRetries=3] - Maximum number of retry attempts
    * @param {number} [config.retryDelay=1000] - Initial retry delay in milliseconds
    * @param {number} [config.connectionTimeout=10000] - Ms to wait for a connection to establish
-   * @param {number} [config.requestTimeout=10000] - Ms of socket inactivity before a request fails
+   * @param {number} [config.socketTimeout=10000] - Ms of socket inactivity before a request fails
    */
   constructor(config) {
     super();
@@ -61,7 +61,7 @@ class S3StorageAdapter extends stream.EventEmitter {
       maxRetries: 3,
       retryDelay: 1000,
       connectionTimeout: 10000,
-      requestTimeout: 10000,
+      socketTimeout: 10000,
       ...config
     };
     
@@ -70,12 +70,17 @@ class S3StorageAdapter extends stream.EventEmitter {
       region: this.config.region,
       forcePathStyle: this.config.forcePathStyle,
       // Without timeouts a silently dropped connection leaves the request —
-      // and with it every queued upload — hanging forever. requestTimeout is
-      // socket INACTIVITY, not total duration: an active transfer of any
-      // size never trips it, only a dead line does.
+      // and with it every queued upload — hanging forever.
+      //
+      // socketTimeout, NOT requestTimeout, is the right knob here:
+      // requestTimeout is a total-duration cap that would kill legitimate
+      // large uploads, and by default it only logs a warning (it needs
+      // throwOnRequestTimeout to abort at all). socketTimeout fires on
+      // socket INACTIVITY and destroys the request with a TimeoutError, so
+      // an active transfer of any size is safe and only a dead line trips.
       requestHandler: {
         connectionTimeout: this.config.connectionTimeout,
-        requestTimeout: this.config.requestTimeout
+        socketTimeout: this.config.socketTimeout
       }
     };
     

--- a/backend/src/services/storage/s3Storage.js
+++ b/backend/src/services/storage/s3Storage.js
@@ -40,6 +40,8 @@ class S3StorageAdapter extends stream.EventEmitter {
    * @param {number} [config.partSize=10485760] - Part size for multipart upload (default 10MB)
    * @param {number} [config.maxRetries=3] - Maximum number of retry attempts
    * @param {number} [config.retryDelay=1000] - Initial retry delay in milliseconds
+   * @param {number} [config.connectionTimeout=10000] - Ms to wait for a connection to establish
+   * @param {number} [config.requestTimeout=10000] - Ms of socket inactivity before a request fails
    */
   constructor(config) {
     super();
@@ -58,13 +60,23 @@ class S3StorageAdapter extends stream.EventEmitter {
       partSize: 10 * 1024 * 1024, // 10MB
       maxRetries: 3,
       retryDelay: 1000,
+      connectionTimeout: 10000,
+      requestTimeout: 10000,
       ...config
     };
     
     // Initialize S3 client
     const s3Config = {
       region: this.config.region,
-      forcePathStyle: this.config.forcePathStyle
+      forcePathStyle: this.config.forcePathStyle,
+      // Without timeouts a silently dropped connection leaves the request —
+      // and with it every queued upload — hanging forever. requestTimeout is
+      // socket INACTIVITY, not total duration: an active transfer of any
+      // size never trips it, only a dead line does.
+      requestHandler: {
+        connectionTimeout: this.config.connectionTimeout,
+        requestTimeout: this.config.requestTimeout
+      }
     };
     
     // Add credentials if provided
@@ -671,7 +683,9 @@ class S3StorageAdapter extends stream.EventEmitter {
       }
       
       // Check if error is retryable
-      const retryableErrors = ['ECONNRESET', 'ETIMEDOUT', 'ENOTFOUND', 'ESOCKETTIMEDOUT', 'RequestTimeout', 'SlowDown', 'ServiceUnavailable', 'InternalError'];
+      // 'TimeoutError' is what @smithy/node-http-handler names both its
+      // connection-timeout and socket-inactivity rejections.
+      const retryableErrors = ['ECONNRESET', 'ETIMEDOUT', 'ENOTFOUND', 'ESOCKETTIMEDOUT', 'RequestTimeout', 'TimeoutError', 'SlowDown', 'ServiceUnavailable', 'InternalError'];
       const isRetryable = retryableErrors.some(code => 
         error.code === code || 
         error.name === code || 

--- a/backend/src/services/storage/s3Storage.js
+++ b/backend/src/services/storage/s3Storage.js
@@ -40,8 +40,8 @@ class S3StorageAdapter extends stream.EventEmitter {
    * @param {number} [config.partSize=10485760] - Part size for multipart upload (default 10MB)
    * @param {number} [config.maxRetries=3] - Maximum number of retry attempts
    * @param {number} [config.retryDelay=1000] - Initial retry delay in milliseconds
-   * @param {number} [config.connectionTimeout=10000] - Ms to wait for a connection to establish
-   * @param {number} [config.socketTimeout=10000] - Ms of socket inactivity before a request fails
+   * @param {number} [config.connectionTimeout=120000] - Ms to acquire+establish a socket
+   * @param {number} [config.socketTimeout=60000] - Ms of socket inactivity before a request fails
    */
   constructor(config) {
     super();
@@ -60,8 +60,8 @@ class S3StorageAdapter extends stream.EventEmitter {
       partSize: 10 * 1024 * 1024, // 10MB
       maxRetries: 3,
       retryDelay: 1000,
-      connectionTimeout: 10000,
-      socketTimeout: 10000,
+      connectionTimeout: 120000,
+      socketTimeout: 60000,
       ...config
     };
     
@@ -78,6 +78,16 @@ class S3StorageAdapter extends stream.EventEmitter {
       // throwOnRequestTimeout to abort at all). socketTimeout fires on
       // socket INACTIVITY and destroys the request with a TimeoutError, so
       // an active transfer of any size is safe and only a dead line trips.
+      //
+      // Both values are deliberately GENEROUS. connectionTimeout starts
+      // when the request object is created and only clears once a socket
+      // is both assigned and connected — so time spent queuing for a free
+      // socket from the agent pool (maxSockets 50) counts against it. A
+      // 10s value looks reasonable and is not: under concurrent uploads
+      // it expires while merely waiting in line, and every read (photo
+      // download, thumbnail, background thumbnailing) fails with
+      // TimeoutError. These timeouts exist to convert an INFINITE hang
+      // into a bounded failure, not to enforce latency targets.
       requestHandler: {
         connectionTimeout: this.config.connectionTimeout,
         socketTimeout: this.config.socketTimeout


### PR DESCRIPTION
## The problem

Under sustained upload load to an S3-compatible backend, the backend eventually hangs: an upload request is accepted, the handler never completes, CPU goes idle, and no socket to the storage endpoint remains open. Every subsequent storage operation queues behind it forever — process-wide. Only a backend restart recovers.

Observed on v3.45.16 against Cloudflare R2 during a bulk migration (~19k photos): the wedge hit roughly every 40 minutes with serial uploads and every ~15–20 minutes with 4 parallel uploaders.

## Root cause

`S3StorageAdapter` constructs its `S3Client` with no `requestHandler` timeouts, and the SDK's defaults wait indefinitely. When a connection is dropped silently (no FIN/RST delivered — NAT/LB idle reaps, transient network faults), the in-flight request waits forever. The adapter's own `_retryOperation` exponential-backoff logic never gets a chance to run, because the promise it wraps never settles.

## The fix

Configure the client's `requestHandler` with `connectionTimeout` (default 120 000 ms) and `socketTimeout` (default 60 000 ms), overridable via config or the new `STORAGE_S3_CONNECTION_TIMEOUT` / `STORAGE_S3_SOCKET_TIMEOUT` env vars, and add `'TimeoutError'` to `_retryOperation`'s retryable list so a timed-out request is retried with the existing backoff.

**Two things I got wrong first, both found in production — worth recording so reviewers don't repeat them:**

**1. `requestTimeout` is the wrong knob.**

| | `requestTimeout` | `socketTimeout` |
|---|---|---|
| measures | total request duration | socket inactivity |
| large upload | aborts a legitimate slow/large transfer | unaffected — any byte resets the timer |
| on expiry | **only logs a warning** unless `throwOnRequestTimeout: true` | destroys the request, rejects with `TimeoutError` |

With `requestTimeout: 10000` the backend logged hundreds of `a request has exceeded the configured 10000 ms requestTimeout` warnings while continuing to hang — detection without action.

**2. The values must be generous, not tight.**

`connectionTimeout`'s timer starts when the request object is created and is only cleared once a socket is both *assigned and connected* (`set-connection-timeout.js`). Time spent **queuing for a free socket** from the agent pool (`maxSockets: 50`) therefore counts against it. A 10 s value looks reasonable and is not: under concurrent upload load it expires while merely waiting in line, and **every read fails** — admin photo downloads, thumbnail serving, and background thumbnail generation all returned 500 with `TimeoutError` until the value was raised.

These timeouts exist to convert an *infinite* hang into a *bounded* failure that the retry path can act on. They are not latency targets, and tightening them re-breaks the app in a new way.

No new dependencies: passing a plain config object as `requestHandler` is supported by the bundled SDK (resolves to a configured `NodeHttpHandler` — verified against `@aws-sdk/client-s3@^3.850`, `@smithy/node-http-handler@4.4.12`).

## Testing

- 5 new unit tests: defaults reach the client config; overrides work; `requestTimeout` is deliberately *not* set; `connectionTimeout`/`socketTimeout` are held above sane floors so a future tightening trips a test; `TimeoutError` is retried. Full `s3Storage.test.js` suite passes (23/23).
- Deployed on our production v3.45.16 instance (R2, Hetzner VPS): uploads run clean, and photo/thumbnail reads verified returning 200 with correct byte counts after the timeout values were corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)