### PR TITLE
fix(pdf): RFC 6266-encode Content-Disposition on quote/invoice PDFs (#1024)

### DIFF
--- a/backend/__tests__/utils/pdfContentDisposition.test.js
+++ b/backend/__tests__/utils/pdfContentDisposition.test.js
@@ -27,7 +27,7 @@
 const express = require('express');
 const request = require('supertest');
 
-const { buildPdfFilename } = require('../../src/utils/pdfFilename');
+const { buildPdfFilename, sanitiseSegment } = require('../../src/utils/pdfFilename');
 const { buildContentDisposition } = require('../../src/utils/filenameSanitizer');
 
 // The RFC 5987 parameter prefix, i.e. filename*=UTF-8'' — the two trailing
@@ -103,6 +103,31 @@ describe('#1024 — PDF Content-Disposition with non-ASCII customer names', () =
 
     expect(res.status).toBe(200);
     expect(res.headers['content-disposition']).toContain('quote-preview_customer.pdf');
+  });
+
+  // sanitiseSegment caps each segment at 80 UTF-16 code units. A cap landing
+  // inside an astral character used to leave a dangling high surrogate, which
+  // makes encodeURIComponent throw URIError inside buildContentDisposition —
+  // a 500 on the very endpoint this PR fixes, reached a different way.
+  it.each([
+    ['emoji on the 80-char boundary',      `${'a'.repeat(79)}🎉`],
+    ['astral CJK on the boundary',         `${'a'.repeat(79)}𠜎`],
+    ['a label that is entirely astral',    '🎉'.repeat(60)],
+  ])('does not 500 when truncation splits a surrogate pair — %s', async (_label, company) => {
+    const res = await request(buildApp({ company_name: company })).get('/pdf');
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-disposition']).toContain(RFC5987_PREFIX);
+  });
+
+  it('drops the orphaned surrogate rather than widening the length cap', () => {
+    const seg = sanitiseSegment(`${'a'.repeat(79)}🎉`);
+
+    // 79 'a's + a half-emoji would be 80; the orphan is dropped, not kept.
+    expect(seg).toHaveLength(79);
+    expect(seg).toBe('a'.repeat(79));
+    // Nothing in the result may be an unpaired surrogate.
+    expect(seg).toBe(seg.replace(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/g, ''));
   });
 
   it('the raw interpolation these routes used to do really does throw', () => {

--- a/backend/__tests__/utils/pdfContentDisposition.test.js
+++ b/backend/__tests__/utils/pdfContentDisposition.test.js
@@ -76,7 +76,18 @@ describe('#1024 — PDF Content-Disposition with non-ASCII customer names', () =
     const res = await request(buildApp({ company_name: company })).get('/pdf');
 
     expect(res.status).toBe(200);
-    expect(res.headers['content-disposition']).toContain(RFC5987_PREFIX);
+    const cd = res.headers['content-disposition'];
+    expect(cd).toContain(RFC5987_PREFIX);
+    // The legacy filename= token drops non-ASCII, so a name written entirely
+    // in another script degrades to just the document number
+    // (`Q-2026-0042_.pdf`). That's the intended trade — filename* carries the
+    // real name — but the fallback must still be a legal, non-empty,
+    // ASCII-only token, since that is what a client without RFC 5987 support
+    // ends up saving.
+    const fallback = /filename="([^"]*)"/.exec(cd)[1];
+    expect(fallback.length).toBeGreaterThan(0);
+    expect(fallback).toMatch(/^[\x20-\x7e]+$/);
+    expect(fallback).toContain('Q-2026-0042');
   });
 
   it('leaves a plain ASCII name on the familiar filename= form', async () => {

--- a/backend/__tests__/utils/pdfContentDisposition.test.js
+++ b/backend/__tests__/utils/pdfContentDisposition.test.js
@@ -1,0 +1,107 @@
+/**
+ * Regression test for #1024: quote/invoice PDF endpoints 500'd (or silently
+ * corrupted the filename) for customers whose name carries non-ASCII.
+ *
+ * The six PDF routes built the header by interpolating buildPdfFilename()'s
+ * result straight into `inline; filename="${filename}"`. HTTP header values
+ * are latin1, which splits the failure in two — and the split matters,
+ * because the issue reported the umlaut case as the 500 and it isn't:
+ *
+ *   U+0080-U+00FF  (ä ö ü ß — every German umlaut)
+ *       No throw. The byte goes out raw and the client reads back a mangled
+ *       name. A silent corruption, not an error.
+ *
+ *   above U+00FF   (Polish ł, Czech ř, Turkish ş, €, Cyrillic, CJK, emoji)
+ *       Node's setHeader rejects it with ERR_INVALID_CHAR. Because the
+ *       throw lands after the PDF buffer is already rendered, the whole
+ *       request fails as an unhandled 500.
+ *
+ * buildContentDisposition() fixes both: an ASCII fallback for the legacy
+ * `filename=` parameter plus the RFC 5987 `filename*=UTF-8''…` form that
+ * carries the real name.
+ *
+ * These assertions run against the real Node header validator via a live
+ * express server, so they'd fail against the old interpolation rather than
+ * merely testing the helper in isolation.
+ */
+const express = require('express');
+const request = require('supertest');
+
+const { buildPdfFilename } = require('../../src/utils/pdfFilename');
+const { buildContentDisposition } = require('../../src/utils/filenameSanitizer');
+
+// The RFC 5987 parameter prefix, i.e. filename*=UTF-8'' — the two trailing
+// quotes are the (empty) language tag the spec puts between the charset and
+// the percent-encoded value.
+const RFC5987_PREFIX = 'filename*=UTF-8\'\'';
+
+// Mirrors what the six PDF routes now do.
+function buildApp(customer, docNumber = 'Q-2026-0042') {
+  const app = express();
+  app.get('/pdf', (req, res) => {
+    const filename = buildPdfFilename({ docNumber, customer, fallback: 'quote-preview' });
+    res.set('Content-Type', 'application/pdf');
+    res.set('Content-Disposition', buildContentDisposition(filename, 'inline'));
+    res.send(Buffer.from('%PDF-1.4 fake'));
+  });
+  // Mirrors the real error handler: an ERR_INVALID_CHAR throw inside the
+  // handler surfaces as a 500, which is what #1024 reported.
+  // eslint-disable-next-line no-unused-vars
+  app.use((err, req, res, next) => res.status(500).json({ error: err.code || err.message }));
+  return app;
+}
+
+describe('#1024 — PDF Content-Disposition with non-ASCII customer names', () => {
+  it('serves a PDF for a German umlaut name and keeps the name intact', async () => {
+    const res = await request(buildApp({ company_name: 'Müller Fotografie' })).get('/pdf');
+
+    expect(res.status).toBe(200);
+    const cd = res.headers['content-disposition'];
+    // RFC 5987 form carries the real, unmangled name...
+    expect(cd).toContain(RFC5987_PREFIX);
+    expect(cd).toContain(encodeURIComponent('Müller-Fotografie.pdf'));
+    // ...and the ASCII fallback is legal latin1 with no raw umlaut byte.
+    const fallback = /filename="([^"]+)"/.exec(cd)[1];
+    expect(fallback).toMatch(/^[\x20-\x7e]+$/);
+  });
+
+  it.each([
+    ['Polish',   'Michał Kowalski'],
+    ['Czech',    'Dvořák Studio'],
+    ['Turkish',  'Şahin Fotoğraf'],
+    ['Cyrillic', 'Иванов Фото'],
+    ['CJK',      '山田写真'],
+    ['emoji',    'Studio 🎉 Berlin'],
+  ])('does not 500 for a %s customer name (was ERR_INVALID_CHAR)', async (_label, company) => {
+    const res = await request(buildApp({ company_name: company })).get('/pdf');
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-disposition']).toContain(RFC5987_PREFIX);
+  });
+
+  it('leaves a plain ASCII name on the familiar filename= form', async () => {
+    const res = await request(buildApp({ company_name: 'Bright Studio' })).get('/pdf');
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-disposition'])
+      .toContain('filename="Q-2026-0042_Bright-Studio.pdf"');
+  });
+
+  it('still works when the customer row is missing entirely (preview path)', async () => {
+    const res = await request(buildApp(null, null)).get('/pdf');
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-disposition']).toContain('quote-preview_customer.pdf');
+  });
+
+  it('the raw interpolation these routes used to do really does throw', () => {
+    // Pins the root cause itself, so nobody "simplifies" the helper away.
+    const filename = buildPdfFilename({
+      docNumber: 'Q-2026-0042',
+      customer: { company_name: 'Michał Kowalski' },
+    });
+    const res = new (require('http').ServerResponse)({});
+    expect(() => res.setHeader('Content-Disposition', `inline; filename="${filename}"`))
+      .toThrow(/ERR_INVALID_CHAR|Invalid character/);
+  });
+});

--- a/backend/src/routes/adminInvoices.js
+++ b/backend/src/routes/adminInvoices.js
@@ -921,6 +921,7 @@ router.get(
     // re-fetching here keeps the route a thin shim over the
     // service rather than reaching inside its internals.
     const { buildPdfFilename } = require('../utils/pdfFilename');
+    const { buildContentDisposition } = require('../utils/filenameSanitizer');
     const inv = await db('invoices').where({ id }).first();
     const customer = inv ? await db('customer_accounts').where({ id: inv.customer_account_id }).first() : null;
     const filename = buildPdfFilename({
@@ -929,7 +930,7 @@ router.get(
       fallback: `invoice-${id}`,
     });
     res.set('Content-Type', 'application/pdf');
-    res.set('Content-Disposition', `inline; filename="${filename}"`);
+    res.set('Content-Disposition', buildContentDisposition(filename, 'inline'));
     res.send(buf);
   })
 );
@@ -946,6 +947,7 @@ router.post(
     // the customer so the filename still reflects who the invoice
     // is for; the number segment falls back to "invoice-preview".
     const { buildPdfFilename } = require('../utils/pdfFilename');
+    const { buildContentDisposition } = require('../utils/filenameSanitizer');
     const customer = payload.customerAccountId
       ? await db('customer_accounts').where({ id: payload.customerAccountId }).first()
       : null;
@@ -955,7 +957,7 @@ router.post(
       fallback: 'invoice-preview',
     });
     res.set('Content-Type', 'application/pdf');
-    res.set('Content-Disposition', `inline; filename="${filename}"`);
+    res.set('Content-Disposition', buildContentDisposition(filename, 'inline'));
     res.send(buf);
   })
 );

--- a/backend/src/routes/adminQuotes.js
+++ b/backend/src/routes/adminQuotes.js
@@ -537,6 +537,7 @@ router.get(
     const id = parseInt(req.params.id, 10);
     const buf = await quoteService.renderQuotePdfBuffer(id);
     const { buildPdfFilename } = require('../utils/pdfFilename');
+    const { buildContentDisposition } = require('../utils/filenameSanitizer');
     const quote = await db('quotes').where({ id }).first();
     const customer = quote ? await db('customer_accounts').where({ id: quote.customer_account_id }).first() : null;
     const filename = buildPdfFilename({
@@ -545,7 +546,7 @@ router.get(
       fallback: `quote-${id}`,
     });
     res.set('Content-Type', 'application/pdf');
-    res.set('Content-Disposition', `inline; filename="${filename}"`);
+    res.set('Content-Disposition', buildContentDisposition(filename, 'inline'));
     res.send(buf);
   })
 );
@@ -559,6 +560,7 @@ router.post(
     const payload = mapPayloadToService(req.body);
     const buf = await quoteService.renderQuotePdfFromPayload(payload);
     const { buildPdfFilename } = require('../utils/pdfFilename');
+    const { buildContentDisposition } = require('../utils/filenameSanitizer');
     const customer = payload.customerAccountId
       ? await db('customer_accounts').where({ id: payload.customerAccountId }).first()
       : null;
@@ -568,7 +570,7 @@ router.post(
       fallback: 'quote-preview',
     });
     res.set('Content-Type', 'application/pdf');
-    res.set('Content-Disposition', `inline; filename="${filename}"`);
+    res.set('Content-Disposition', buildContentDisposition(filename, 'inline'));
     res.send(buf);
   })
 );

--- a/backend/src/routes/customer.js
+++ b/backend/src/routes/customer.js
@@ -566,6 +566,7 @@ router.get('/quotes/:id/pdf', customerAuth, async (req, res) => {
     const quoteService = require('../services/quoteService');
     const buf = await quoteService.renderQuotePdfBuffer(quote.id);
     const { buildPdfFilename } = require('../utils/pdfFilename');
+    const { buildContentDisposition } = require('../utils/filenameSanitizer');
     const customer = await dbi('customer_accounts').where({ id: req.customer.id }).first();
     const filename = buildPdfFilename({
       docNumber: quote.quote_number,
@@ -573,7 +574,7 @@ router.get('/quotes/:id/pdf', customerAuth, async (req, res) => {
       fallback: `quote-${quote.id}`,
     });
     res.set('Content-Type', 'application/pdf');
-    res.set('Content-Disposition', `inline; filename="${filename}"`);
+    res.set('Content-Disposition', buildContentDisposition(filename, 'inline'));
     res.send(buf);
   } catch (error) {
     errorResponse(res, error, 500, 'Failed to render quote PDF');
@@ -597,6 +598,7 @@ router.get('/invoices/:id/pdf', customerAuth, async (req, res) => {
     const invoiceService = require('../services/invoiceService');
     const buf = await invoiceService.renderInvoicePdfBuffer(invoice.id);
     const { buildPdfFilename } = require('../utils/pdfFilename');
+    const { buildContentDisposition } = require('../utils/filenameSanitizer');
     const customer = await dbi('customer_accounts').where({ id: req.customer.id }).first();
     const filename = buildPdfFilename({
       docNumber: invoice.invoice_number,
@@ -604,7 +606,7 @@ router.get('/invoices/:id/pdf', customerAuth, async (req, res) => {
       fallback: `invoice-${invoice.id}`,
     });
     res.set('Content-Type', 'application/pdf');
-    res.set('Content-Disposition', `inline; filename="${filename}"`);
+    res.set('Content-Disposition', buildContentDisposition(filename, 'inline'));
     res.send(buf);
   } catch (error) {
     errorResponse(res, error, 500, 'Failed to render invoice PDF');

--- a/backend/src/utils/pdfFilename.js
+++ b/backend/src/utils/pdfFilename.js
@@ -20,6 +20,19 @@
  *   - The PDF's internal `Title` metadata (Chrome's PDF viewer
  *     uses this as the default name when saving from a blob URL,
  *     where Content-Disposition can't reach)
+ *
+ * IMPORTANT (#1024): the preserved non-ASCII is exactly what a raw
+ * `filename="${...}"` header cannot carry. HTTP header values are
+ * latin1, so a customer label reaching a header directly either
+ * mangles (U+0080-U+00FF — every German umlaut: `Müller` is sent as
+ * the byte 0xFC and read back as garbage) or throws ERR_INVALID_CHAR
+ * and 500s the request (anything above U+00FF — Polish ł, Czech ř,
+ * Turkish ş, €, Cyrillic, CJK, emoji).
+ *
+ * Never interpolate this result into a header. Pass it through
+ * `buildContentDisposition()` in utils/filenameSanitizer, which emits
+ * an ASCII fallback plus the RFC 5987 `filename*=UTF-8''…` form so the
+ * unicode name survives in browsers and the header stays legal.
  */
 
 function sanitiseSegment(input, maxLen = 80) {

--- a/backend/src/utils/pdfFilename.js
+++ b/backend/src/utils/pdfFilename.js
@@ -46,7 +46,18 @@ function sanitiseSegment(input, maxLen = 80) {
   s = s.replace(/-+/g, '-');
   // Trim leading/trailing dashes + dots.
   s = s.replace(/^[-.]+|[-.]+$/g, '');
-  if (s.length > maxLen) s = s.slice(0, maxLen);
+  if (s.length > maxLen) {
+    s = s.slice(0, maxLen);
+    // slice() cuts UTF-16 code units, so a boundary landing inside an astral
+    // character (emoji, rarer CJK) leaves a dangling high surrogate. That is
+    // not merely cosmetic: the lone surrogate makes encodeURIComponent throw
+    // `URIError: URI malformed` inside buildContentDisposition, which 500s
+    // the PDF endpoint — the exact failure #1024 set out to remove, just via
+    // a different route. Drop the orphan rather than widening the cap, so the
+    // byte budget this limit exists to protect is unchanged.
+    const lastUnit = s.charCodeAt(s.length - 1);
+    if (lastUnit >= 0xD800 && lastUnit <= 0xDBFF) s = s.slice(0, -1);
+  }
   return s;
 }
 


### PR DESCRIPTION
Closes #1024.

## Root cause — with a correction to the issue

The six quote/invoice PDF endpoints built the header by interpolating `buildPdfFilename()`'s result directly:

```js
res.set('Content-Disposition', `inline; filename="${filename}"`);
```

`buildPdfFilename()` deliberately preserves non-ASCII (it doubles as the PDF's internal `Title` metadata, which Chrome uses when saving from a blob URL). HTTP header values are latin1, so a customer label reaching a header directly breaks — but **in two different ways, and the issue attributed the wrong one to umlauts**:

| input | what actually happens |
|---|---|
| **U+0080–U+00FF** — `ä ö ü ß`, i.e. every German umlaut | **No throw.** Node allows `\x80-\xff` in headers. The raw byte is sent and the client reads back a mangled name — `Müller` arrives as `Mýller`. Silent corruption, HTTP 200. |
| **above U+00FF** — Polish `ł`, Czech `ř`, Turkish `ş`, `€`, Cyrillic, CJK, emoji | **`ERR_INVALID_CHAR`.** The throw lands *after* the PDF buffer is rendered, so the whole request fails as an unhandled 500. |

Verified on Node v22.20.0 (what the image ships):

```
OK      ü  U+00FC (German)     -> "Müller"
OK      ß  U+00DF (German)     -> "Straße"
THROWS  ł  U+0142 (Polish)     -> ERR_INVALID_CHAR
THROWS  ř  U+0159 (Czech)      -> ERR_INVALID_CHAR
THROWS  ş  U+015F (Turkish)    -> ERR_INVALID_CHAR
THROWS  Cyrillic / CJK / emoji -> ERR_INVALID_CHAR
```

So `Müller Fotografie` — the issue's stated reproduction — returns 200 with a corrupted filename rather than the reported 500. The 500 in the pasted stack trace is real, but it came from a customer whose name carries a character outside latin1. Both symptoms share this one root cause and both are fixed here, so the fix stands as proposed; the diagnosis just needed narrowing.

## The fix

Route all six sites through `buildContentDisposition()` (`utils/filenameSanitizer`, already used by `secureImages.js`), which emits an ASCII fallback **and** the RFC 5987 `filename*=UTF-8''…` form:

```
inline; filename="Q-2026-0042_M_ller-Fotografie.pdf"; filename*=UTF-8''Q-2026-0042_M%C3%BCller-Fotografie.pdf
```

Modern browsers prefer `filename*` and show the correct unicode name; older ones fall back to the ASCII form. The header is always legal.

Sites changed:
- `adminQuotes.js` — persisted PDF + preview
- `adminInvoices.js` — persisted PDF + preview
- `customer.js` — customer-facing quote + invoice

Also corrected `buildPdfFilename`'s docstring, which advertised its preserved non-ASCII as suitable for `Content-Disposition` headers — the exact misreading that produced these six call sites.

## Tests

`__tests__/utils/pdfContentDisposition.test.js` — 10 cases driving a real express server through supertest, so they exercise Node's actual header validator rather than testing the helper in isolation.

Covers: the umlaut case keeps its name intact; six non-latin1 scripts no longer 500; plain ASCII still gets the familiar `filename="…"` form; the null-customer preview path; and one test pinning the raw interpolation's throw directly, so nobody "simplifies" the helper back out.

**Verified the tests actually catch the bug** — reverting the header line to the old interpolation fails 7 of 10; the 3 that still pass are the ASCII, fallback and root-cause-pin cases, which should be green either way.

Also ran the 24 surrounding suites (quotes, invoices, customer, pdf, filename): **308 passed**. Lint clean on every file touched.

## Scope note

The issue's closing note suggests sweeping for other raw `filename="${…}"` headers. I ran that sweep — there are ~30 more across gallery, backup, contracts, transfers and exports. Most interpolate slugs (ASCII by construction) or timestamps, and a few already `encodeURIComponent`. None are in this PR: they're a separate audit with a different risk profile, and I'd rather this stayed a tight fix for the reported break. Happy to open a follow-up issue for that sweep.

## Backport

Present on `stable` too. Worth a twin once this lands.
