### PR TITLE
ci(tests): run the gated real-Postgres .picpeak cases in the backend job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,29 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
+    # The .picpeak restore suites gate their real-Postgres cases behind
+    # PICPEAK_PG_TEST_URL and `describe.skip` themselves out when it is
+    # unset — so until now they never ran here. That hid the half that
+    # matters: sequence resync, operator/role preservation across a
+    # cross-instance restore, and (with #1041) whether a SQLite-shaped
+    # row actually lands in Postgres with the right STORED VALUES rather
+    # than merely not throwing. Everything else in the suite still runs
+    # on SQLite; this service only un-gates those cases.
+    services:
+      postgres:
+        image: postgres:15-alpine
+        env:
+          POSTGRES_USER: picpeak
+          POSTGRES_PASSWORD: testpass
+          POSTGRES_DB: picpeak_test
+        options: >-
+          --health-cmd "pg_isready -U picpeak -d picpeak_test"
+          --health-interval 2s
+          --health-timeout 2s
+          --health-retries 30
+        ports:
+          - 5432:5432
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -52,6 +75,9 @@ jobs:
           # The S3 path itself is covered separately by the integration
           # suite when MinIO is provisioned.
           SKIP_S3_TESTS: 'true'
+          # Un-gates the real-Postgres cases in the .picpeak restore suites
+          # (see the `services:` note above). Absent it they silently skip.
+          PICPEAK_PG_TEST_URL: 'postgres://picpeak:testpass@127.0.0.1:5432/picpeak_test'
         run: |
           # Excluded suites — fail on upstream/beta too, tracked
           # separately as test-infra debt:


### PR DESCRIPTION
## The gap

`backend/__tests__/integration/picpeakRestorePg.test.js` gates its cases behind `PICPEAK_PG_TEST_URL` and `describe.skip`s itself out when the variable is unset:

```js
const PG_URL = process.env.PICPEAK_PG_TEST_URL;
const maybe = PG_URL ? describe : describe.skip;
```

That variable is set in **no workflow**. So the suite has reported green in CI while silently skipping every case that needs a real database — sequence resync, `reinjectCurrentAdmin` against a stale sequence, `preserveOperatorRole` FK integrity, and the full cross-instance `replaceAllTables` round-trip. Four tests, none of them ever executed here.

The failure mode is the bad kind: green CI that isn't testing what its name says.

## The change

Add a `postgres:15-alpine` service to the `backend` job — the same shape `schema-drift.yml` already uses — and point `PICPEAK_PG_TEST_URL` at it. Everything else in the suite still runs on SQLite; this only un-gates the cases that were skipping.

## Verified before wiring

Ran both gated suites against a real PostgreSQL 15 locally rather than trusting the workflow to sort it out:

```
picpeakRestorePg.test.js     4 passed    (all 4 previously skipped)
picpeakCrossEngine.test.js  11 passed    (3 of them previously skipped, on #1043)
```

Also confirmed the full `__tests__/integration/picpeak*` set passes on plain `main` with the variable set — **13/13** — so this lands safely on its own and doesn't depend on #1043.

Only these two suites read the variable, so nothing else in the backend job changes behaviour.

## Why now

#1043 opens `sqlite → pg` restore to the upload UI. That makes the coercion layer's correctness a browser-facing concern rather than a CLI-only one, and the tests that verify a coerced row lands in Postgres with the right *stored values* — not merely without throwing — are exactly the ones that weren't running.
