### PR TITLE
ci(tests): run the gated real-Postgres .picpeak cases in the backend job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,29 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
+    # The .picpeak restore suites gate their real-Postgres cases behind
+    # PICPEAK_PG_TEST_URL and `describe.skip` themselves out when it is
+    # unset — so until now they never ran here. That hid the half that
+    # matters: sequence resync, operator/role preservation across a
+    # cross-instance restore, and (with #1041) whether a SQLite-shaped
+    # row actually lands in Postgres with the right STORED VALUES rather
+    # than merely not throwing. Everything else in the suite still runs
+    # on SQLite; this service only un-gates those cases.
+    services:
+      postgres:
+        image: postgres:15-alpine
+        env:
+          POSTGRES_USER: picpeak
+          POSTGRES_PASSWORD: testpass
+          POSTGRES_DB: picpeak_test
+        options: >-
+          --health-cmd "pg_isready -U picpeak -d picpeak_test"
+          --health-interval 2s
+          --health-timeout 2s
+          --health-retries 30
+        ports:
+          - 5432:5432
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -52,6 +75,9 @@ jobs:
           # The S3 path itself is covered separately by the integration
           # suite when MinIO is provisioned.
           SKIP_S3_TESTS: 'true'
+          # Un-gates the real-Postgres cases in the .picpeak restore suites
+          # (see the `services:` note above). Absent it they silently skip.
+          PICPEAK_PG_TEST_URL: 'postgres://picpeak:testpass@127.0.0.1:5432/picpeak_test'
         run: |
           # Excluded suites — fail on upstream/beta too, tracked
           # separately as test-infra debt:


### PR DESCRIPTION
Stable backport of #1056 (main: `18b1e0f6`). Change content is **byte-identical** to the main twin — verified by diffing normalised add/remove lines, not by inspection.

## What it does

The `.picpeak` restore suites gate their real-Postgres cases behind `PICPEAK_PG_TEST_URL` and `describe.skip` themselves out when it is unset. That variable is set in no workflow, so those cases have never run in CI. This adds a `postgres:15-alpine` service to the `backend` job (same shape `schema-drift` already uses) and points the variable at it.

## Sequencing note

On `stable` this is a no-op **on its own**: there is no `picpeakRestorePg.test.js` here, so nothing currently reads the variable. It becomes live together with the #1041 backport (`feat/cross-engine-picpeak-restore-1041-stable`), which brings `picpeakCrossEngine.test.js` and its three real-Postgres stored-value cases.

Merging it as its own PR — rather than folding it into the feature backport — keeps the two twins mirroring their main counterparts one-for-one, which is what the parity rule wants. Merge this first, then the feature twin picks the workflow up.

Everything else in the suite still runs on SQLite; this only un-gates cases that were skipping.
