### PR TITLE
fix(storage): write business documents under STORAGE_PATH, not the cwd

### DIFF
--- a/backend/__tests__/services/businessDocsStoragePath.test.js
+++ b/backend/__tests__/services/businessDocsStoragePath.test.js
@@ -93,28 +93,34 @@ describe('business documents honour STORAGE_PATH', () => {
     expect(() => assertContractPdfPath(foreign)).toThrow(/outside the storage roots/i);
   });
 
-  it('writer and guard agree on the root when STORAGE_PATH is unset', () => {
-    // The fallbacks used to differ: getStoragePath() resolves module-relative
-    // (<repo>/storage) while the guard resolved <cwd>/storage, and the backend
-    // is normally started from backend/ — so with no STORAGE_PATH set the guard
-    // refused the very files the writers had just produced. Both sides must
-    // come from the one resolver.
-    delete process.env.STORAGE_PATH;
+  it('the guard takes its root from the shared resolver, not its own fallback', () => {
+    // The regression this pins: the guard used to compute
+    // `STORAGE_PATH || <cwd>/storage` itself. That agrees with getStoragePath()
+    // only while STORAGE_PATH is set — unset, the shared resolver falls back
+    // module-relative to <repo>/storage while the guard fell back to
+    // <cwd>/storage, and the backend is normally started from backend/. Writers
+    // and guard then disagreed and contract downloads 403'd.
+    //
+    // Mocking the resolver is what makes this provable AND safe. If the guard
+    // consumes getStoragePath(), the mock moves its root; if it rolled its own
+    // expression, the mock would have no effect and the assertion fails. It
+    // also keeps every path inside the tmpdir — an earlier version of this test
+    // deleted `<resolved root>/business-docs` in cleanup, which with
+    // STORAGE_PATH unset resolves to a developer's real, gitignored
+    // <repo>/storage and would have destroyed local documents on `npm test`.
     jest.resetModules();
+    jest.doMock('../../src/config/storage', () => ({ getStoragePath: () => tmpRoot }));
 
-    const { getStoragePath } = require('../../src/config/storage');
     const { assertContractPdfPath } = require('../../src/utils/safePath');
 
-    const root = path.join(getStoragePath(), 'business-docs', 'contract', '2026');
+    const root = path.join(tmpRoot, 'business-docs', 'contract', '2026');
     fs.mkdirSync(root, { recursive: true });
     const generated = path.join(root, 'C-2026-0002.pdf');
     fs.writeFileSync(generated, 'bytes');
 
-    try {
-      expect(() => assertContractPdfPath(generated)).not.toThrow();
-    } finally {
-      fs.rmSync(path.join(getStoragePath(), 'business-docs'), { recursive: true, force: true });
-    }
+    expect(() => assertContractPdfPath(generated)).not.toThrow();
+
+    jest.dontMock('../../src/config/storage');
   });
 
   it('writes land under STORAGE_PATH, not the working directory', () => {

--- a/backend/__tests__/services/businessDocsStoragePath.test.js
+++ b/backend/__tests__/services/businessDocsStoragePath.test.js
@@ -1,0 +1,96 @@
+/**
+ * Regression test: business documents must be written under STORAGE_PATH.
+ *
+ * quoteService.persistDocPdf, the invoice sending/reminder writers and the
+ * contract signature writers all built their target from
+ * `path.join(process.cwd(), 'storage', 'business-docs', ...)`. Both compose
+ * files pin STORAGE_PATH=/app/storage and the image's WORKDIR is /app, so the
+ * two expressions name the same directory and the bug was invisible on a stock
+ * deployment. Point STORAGE_PATH anywhere else — a NAS mount, a second disk,
+ * the single-container image's /data volume — and quotes, invoices, Mahnungen
+ * and contract PDFs were written outside the configured storage root, so they
+ * were missed by backups and lost when the container was replaced.
+ *
+ * Rather than assert on internals, this drives the module boundary the fix
+ * changed: getStoragePath() is the one resolver, so a temporary STORAGE_PATH
+ * must be where the bytes land.
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+describe('business documents honour STORAGE_PATH', () => {
+  let tmpRoot;
+  let originalStoragePath;
+
+  beforeEach(() => {
+    originalStoragePath = process.env.STORAGE_PATH;
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'picpeak-storage-'));
+    process.env.STORAGE_PATH = tmpRoot;
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    if (originalStoragePath === undefined) delete process.env.STORAGE_PATH;
+    else process.env.STORAGE_PATH = originalStoragePath;
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('getStoragePath is the resolver the writers share', () => {
+    const { getStoragePath } = require('../../src/config/storage');
+    expect(getStoragePath()).toBe(tmpRoot);
+  });
+
+  it('no business-document writer still targets process.cwd()/storage', () => {
+    // The bug was a literal, and a literal is what regresses. Every writer that
+    // persists a business document is covered here; a new one that copies the
+    // old pattern fails this immediately.
+    const writers = [
+      'src/services/quoteService.js',
+      'src/services/invoice/sending.js',
+      'src/services/invoice/reminders.js',
+      'src/services/contract/signatureAssets.js',
+      'src/routes/adminDev.js',
+    ];
+    const offenders = writers.filter((rel) => {
+      const source = fs.readFileSync(path.join(__dirname, '../../', rel), 'utf8');
+      return source.includes("process.cwd(), 'storage', 'business-docs'");
+    });
+    expect(offenders).toEqual([]);
+  });
+
+  it('writes land under STORAGE_PATH, not the working directory', () => {
+    const { getStoragePath } = require('../../src/config/storage');
+
+    // Mirror what persistDocPdf does: derive the root, create it, write.
+    const root = path.join(getStoragePath(), 'business-docs', 'quote', '2026');
+    fs.mkdirSync(root, { recursive: true });
+    const filePath = path.join(root, 'Q-2026-0001.pdf');
+    fs.writeFileSync(filePath, 'pdf-bytes');
+
+    expect(fs.existsSync(filePath)).toBe(true);
+    expect(filePath.startsWith(tmpRoot)).toBe(true);
+    // And crucially NOT beside the process working directory.
+    expect(filePath.startsWith(path.join(process.cwd(), 'storage'))).toBe(false);
+  });
+
+  it('the PDF font lookup consults the storage root before the legacy path', () => {
+    // A custom font under STORAGE_PATH/fonts used to be unreachable, so the
+    // document silently rendered with the built-in face instead.
+    const fontDir = path.join(tmpRoot, 'fonts');
+    fs.mkdirSync(fontDir, { recursive: true });
+    const fontPath = path.join(fontDir, 'Brand.ttf');
+    fs.writeFileSync(fontPath, 'ttf');
+
+    const { getStoragePath } = require('../../src/config/storage');
+    const raw = 'Brand.ttf';
+    const candidates = [
+      path.join(getStoragePath(), raw.replace(/^\/+/, '')),
+      path.join(getStoragePath(), 'fonts', path.basename(raw)),
+      path.join(process.cwd(), 'storage', 'fonts', path.basename(raw)),
+    ];
+    const found = candidates.find((p) => fs.existsSync(p));
+    expect(found).toBe(fontPath);
+  });
+});

--- a/backend/__tests__/services/businessDocsStoragePath.test.js
+++ b/backend/__tests__/services/businessDocsStoragePath.test.js
@@ -43,9 +43,11 @@ describe('business documents honour STORAGE_PATH', () => {
   });
 
   it('no business-document writer still targets process.cwd()/storage', () => {
-    // The bug was a literal, and a literal is what regresses. Every writer that
-    // persists a business document is covered here; a new one that copies the
-    // old pattern fails this immediately.
+    // Whitespace is collapsed before matching on purpose. The first version of
+    // this test compared against the single-line literal and therefore missed
+    // persistSignatureImage(), whose identical path.join was simply spread over
+    // seven lines — it reported green while signature PNGs still wrote outside
+    // STORAGE_PATH. Formatting must not decide whether a bug is visible.
     const writers = [
       'src/services/quoteService.js',
       'src/services/invoice/sending.js',
@@ -55,9 +57,40 @@ describe('business documents honour STORAGE_PATH', () => {
     ];
     const offenders = writers.filter((rel) => {
       const source = fs.readFileSync(path.join(__dirname, '../../', rel), 'utf8');
-      return source.includes("process.cwd(), 'storage', 'business-docs'");
+      return /process\.cwd\(\),'storage'/.test(source.replace(/\s+/g, ''));
     });
     expect(offenders).toEqual([]);
+  });
+
+  it('generated contract PDFs pass the containment check that serves them', () => {
+    // assertContractPdfPath guards the admin and public contract download
+    // routes. It listed only <cwd>/storage/business-docs/contract, so once the
+    // writers moved to STORAGE_PATH every freshly generated contract was
+    // refused with PATH_OUTSIDE_STORAGE — a worse failure than the bug being
+    // fixed. Both roots must be accepted.
+    const { assertContractPdfPath } = require('../../src/utils/safePath');
+    const { getStoragePath } = require('../../src/config/storage');
+
+    // assertPathInside realpaths both the file and each root, so the guard only
+    // means anything against a filesystem that actually has them — write them.
+    const write = (...segments) => {
+      const p = path.join(getStoragePath(), 'business-docs', 'contract', ...segments);
+      fs.mkdirSync(path.dirname(p), { recursive: true });
+      fs.writeFileSync(p, 'bytes');
+      return p;
+    };
+
+    const generated = write('2026', 'C-2026-0001.pdf');
+    expect(() => assertContractPdfPath(generated)).not.toThrow();
+
+    // Signature PNGs live under the same root and are served by the same guard.
+    const signature = write('signatures', '7', 'customer-1.png');
+    expect(() => assertContractPdfPath(signature)).not.toThrow();
+
+    // And the guard still refuses a real file outside every allowed root.
+    const foreign = path.join(tmpRoot, 'outside.pdf');
+    fs.writeFileSync(foreign, 'bytes');
+    expect(() => assertContractPdfPath(foreign)).toThrow(/outside the storage roots/i);
   });
 
   it('writes land under STORAGE_PATH, not the working directory', () => {

--- a/backend/__tests__/services/businessDocsStoragePath.test.js
+++ b/backend/__tests__/services/businessDocsStoragePath.test.js
@@ -93,6 +93,30 @@ describe('business documents honour STORAGE_PATH', () => {
     expect(() => assertContractPdfPath(foreign)).toThrow(/outside the storage roots/i);
   });
 
+  it('writer and guard agree on the root when STORAGE_PATH is unset', () => {
+    // The fallbacks used to differ: getStoragePath() resolves module-relative
+    // (<repo>/storage) while the guard resolved <cwd>/storage, and the backend
+    // is normally started from backend/ — so with no STORAGE_PATH set the guard
+    // refused the very files the writers had just produced. Both sides must
+    // come from the one resolver.
+    delete process.env.STORAGE_PATH;
+    jest.resetModules();
+
+    const { getStoragePath } = require('../../src/config/storage');
+    const { assertContractPdfPath } = require('../../src/utils/safePath');
+
+    const root = path.join(getStoragePath(), 'business-docs', 'contract', '2026');
+    fs.mkdirSync(root, { recursive: true });
+    const generated = path.join(root, 'C-2026-0002.pdf');
+    fs.writeFileSync(generated, 'bytes');
+
+    try {
+      expect(() => assertContractPdfPath(generated)).not.toThrow();
+    } finally {
+      fs.rmSync(path.join(getStoragePath(), 'business-docs'), { recursive: true, force: true });
+    }
+  });
+
   it('writes land under STORAGE_PATH, not the working directory', () => {
     const { getStoragePath } = require('../../src/config/storage');
 

--- a/backend/src/routes/adminDev.js
+++ b/backend/src/routes/adminDev.js
@@ -28,6 +28,7 @@
  */
 
 const express = require('express');
+const { getStoragePath } = require('../config/storage');
 const { body } = require('express-validator');
 const path = require('path');
 const fs = require('fs');
@@ -128,7 +129,7 @@ router.get(
 );
 
 const FRONTEND_URL_FALLBACK = 'https://app.example.com';
-const DEV_TEST_DIR = () => path.join(process.cwd(), 'storage', 'business-docs', 'dev-test');
+const DEV_TEST_DIR = () => path.join(getStoragePath(), 'business-docs', 'dev-test');
 
 function fakeMoney(major, currency, locale = 'de') {
   return new Intl.NumberFormat(locale === 'de' ? 'de-CH' : 'en-GB', {

--- a/backend/src/services/backupCoverageService.js
+++ b/backend/src/services/backupCoverageService.js
@@ -40,11 +40,17 @@
 
 const fs = require('fs').promises;
 const path = require('path');
+const { getStoragePath } = require('../config/storage');
 const { db } = require('../database/db');
 const logger = require('../utils/logger');
 const backupService = require('./backupService');
 
-const STORAGE_ROOT = () => process.env.STORAGE_PATH || path.join(process.cwd(), 'storage');
+// The shared resolver, not a second `STORAGE_PATH || cwd` expression. With
+// STORAGE_PATH unset the two disagree — getStoragePath() falls back
+// module-relative while cwd is normally backend/ — and this diagnostic would
+// then report the business-docs tree as missing while the backup walker, which
+// uses the module-relative root, was backing it up correctly.
+const STORAGE_ROOT = () => getStoragePath();
 
 /**
  * Top-level subdirectories we expect to find under STORAGE_PATH but

--- a/backend/src/services/backupIntegrityService.js
+++ b/backend/src/services/backupIntegrityService.js
@@ -49,12 +49,18 @@
  */
 
 const fs = require('fs');
+const { getStoragePath } = require('../config/storage');
 const crypto = require('crypto');
 const path = require('path');
 const { db } = require('../database/db');
 const logger = require('../utils/logger');
 
-const STORAGE_ROOT = () => process.env.STORAGE_PATH || path.join(process.cwd(), 'storage');
+// The shared resolver, not a second `STORAGE_PATH || cwd` expression. With
+// STORAGE_PATH unset the two disagree — getStoragePath() falls back
+// module-relative while cwd is normally backend/ — and this diagnostic would
+// then report the business-docs tree as missing while the backup walker, which
+// uses the module-relative root, was backing it up correctly.
+const STORAGE_ROOT = () => getStoragePath();
 
 /**
  * Every column the verifier walks, declared once so the test suite

--- a/backend/src/services/contract/signatureAssets.js
+++ b/backend/src/services/contract/signatureAssets.js
@@ -2,6 +2,7 @@
 // module-level overview. Do not add behavior here without updating the entry re-exports.
 
 const crypto = require('crypto');
+const { getStoragePath } = require('../../config/storage');
 const fs = require('fs');
 const path = require('path');
 const logger = require('../../utils/logger');
@@ -42,7 +43,7 @@ function sha256OfFile(filePath) {
 async function persistContractPdf(contract, buffer, suffix = '') {
   if (!contract.contract_number) return { filePath: null, sha256: null };
   const year = (contract.issue_date ? new Date(contract.issue_date) : new Date()).getFullYear();
-  const root = path.join(process.cwd(), 'storage', 'business-docs', 'contract', String(year));
+  const root = path.join(getStoragePath(), 'business-docs', 'contract', String(year));
   fs.mkdirSync(root, { recursive: true });
   // Always append a millisecond timestamp to the filename so writes
   // never overwrite an earlier version on disk. Forensic preservation.
@@ -194,7 +195,7 @@ async function persistAuditCertificate(contract) {
   try {
     const { buffer } = await pdfStampService.renderAuditCertificate(ctx);
     const year = (contract.issue_date ? new Date(contract.issue_date) : new Date()).getFullYear();
-    const root = path.join(process.cwd(), 'storage', 'business-docs', 'contract', String(year));
+    const root = path.join(getStoragePath(), 'business-docs', 'contract', String(year));
     fs.mkdirSync(root, { recursive: true });
     const stamp = new Date().toISOString().replace(/[:.]/g, '-');
     const filePath = path.join(root, `${contract.contract_number}_audit_${stamp}.pdf`);

--- a/backend/src/services/contract/signatureAssets.js
+++ b/backend/src/services/contract/signatureAssets.js
@@ -93,8 +93,7 @@ async function persistSignatureImage(contract, role, dataUrl) {
   }
   const ext = match[1] === 'jpeg' ? 'jpg' : 'png';
   const root = path.join(
-    process.cwd(),
-    'storage',
+    getStoragePath(),
     'business-docs',
     'contract',
     'signatures',

--- a/backend/src/services/invoice/reminders.js
+++ b/backend/src/services/invoice/reminders.js
@@ -2,6 +2,7 @@
 // module-level overview. Do not add behavior here without updating the entry re-exports.
 
 const { db, logActivity } = require('../../database/db');
+const { getStoragePath } = require('../../config/storage');
 const { getAppSetting } = require('../../utils/appSettings');
 const { AppError } = require('../../utils/errors');
 const { formatShortDate } = require('../../utils/dateFormatter');
@@ -132,7 +133,7 @@ async function applyReminder(invoice, lineItems, level, adminId) {
   const fs = require('fs');
   const path = require('path');
   const year = new Date(fresh.issue_date).getFullYear();
-  const root = path.join(process.cwd(), 'storage', 'business-docs', 'mahnung', String(year));
+  const root = path.join(getStoragePath(), 'business-docs', 'mahnung', String(year));
   fs.mkdirSync(root, { recursive: true });
   const mahnungPath = path.join(root, `${fresh.invoice_number}_mahnung_L${level}.pdf`);
   fs.writeFileSync(mahnungPath, buffer);

--- a/backend/src/services/invoice/sending.js
+++ b/backend/src/services/invoice/sending.js
@@ -2,6 +2,7 @@
 // module-level overview. Do not add behavior here without updating the entry re-exports.
 
 const crypto = require('crypto');
+const { getStoragePath } = require('../../config/storage');
 const { db, logActivity } = require('../../database/db');
 const logger = require('../../utils/logger');
 const { AppError } = require('../../utils/errors');
@@ -114,7 +115,7 @@ async function sendInvoice(id, adminId, options = {}) {
   const fs = require('fs');
   const path = require('path');
   const year = new Date(invoice.issue_date).getFullYear();
-  const root = path.join(process.cwd(), 'storage', 'business-docs', 'invoice', String(year));
+  const root = path.join(getStoragePath(), 'business-docs', 'invoice', String(year));
   fs.mkdirSync(root, { recursive: true });
   const pdfPath = path.join(root, `${invoice.invoice_number}.pdf`);
   fs.writeFileSync(pdfPath, buffer);
@@ -389,7 +390,7 @@ async function sendStorno(stornoId, adminId) {
   const fs = require('fs');
   const path = require('path');
   const year = new Date(storno.issue_date).getFullYear();
-  const root = path.join(process.cwd(), 'storage', 'business-docs', 'invoice', String(year));
+  const root = path.join(getStoragePath(), 'business-docs', 'invoice', String(year));
   fs.mkdirSync(root, { recursive: true });
   const pdfPath = path.join(root, `${storno.invoice_number}.pdf`);
   fs.writeFileSync(pdfPath, buffer);

--- a/backend/src/services/pdfService.js
+++ b/backend/src/services/pdfService.js
@@ -26,6 +26,7 @@
  */
 
 const PDFDocument = require('pdfkit');
+const { getStoragePath } = require('../config/storage');
 const { SwissQRBill, Table } = require('swissqrbill/pdf');
 const { t } = require('./pdf-i18n');
 
@@ -1361,8 +1362,16 @@ function registerCustomFonts(doc, issuer) {
   if (issuer.pdfFontTtfPath) {
     try {
       const raw = issuer.pdfFontTtfPath;
+      // The configured storage root first; process.cwd()/storage stays on as a
+      // legacy fallback so installs predating STORAGE_PATH keep resolving.
+      // Compose makes the two the same directory, which is why only a custom
+      // STORAGE_PATH ever exposed this — the font just silently was not found
+      // and the document fell back to the built-in face.
+      const storageRoot = getStoragePath();
       const candidates = [
         path.isAbsolute(raw) ? raw : null,
+        path.join(storageRoot, raw.replace(/^\/+/, '')),
+        path.join(storageRoot, 'fonts', path.basename(raw)),
         path.join(process.cwd(), 'storage', raw.replace(/^\/+/, '')),
         path.join(process.cwd(), 'storage', 'fonts', path.basename(raw)),
       ].filter(Boolean);

--- a/backend/src/services/quoteService.js
+++ b/backend/src/services/quoteService.js
@@ -27,6 +27,7 @@
  */
 
 const crypto = require('crypto');
+const { getStoragePath } = require('../config/storage');
 const { db, withRetry, logActivity } = require('../database/db');
 const logger = require('../utils/logger');
 const { getAppSetting } = require('../utils/appSettings');
@@ -1065,7 +1066,7 @@ async function persistDocPdf(type, doc, buffer) {
   const number = doc.quote_number || doc.invoice_number;
   if (!number) return null;
   const year = (doc.issue_date ? new Date(doc.issue_date) : new Date()).getFullYear();
-  const root = path.join(process.cwd(), 'storage', 'business-docs', type, String(year));
+  const root = path.join(getStoragePath(), 'business-docs', type, String(year));
   fs.mkdirSync(root, { recursive: true });
   const filePath = path.join(root, `${number}.pdf`);
   fs.writeFileSync(filePath, buffer);

--- a/backend/src/utils/safePath.js
+++ b/backend/src/utils/safePath.js
@@ -35,10 +35,15 @@
  *
  * **What the contract surface uses**
  *
- * Two roots:
- *   1. `<cwd>/storage/business-docs/contract/<year>/` — system-stamped
- *      PDFs (immutable as-sent + signed copies).
- *   2. `<STORAGE_PATH or cwd/storage>/uploads/contracts/signed/` —
+ * Three roots:
+ *   1. `<storage root>/business-docs/contract/` — system-stamped PDFs
+ *      (immutable as-sent + signed copies) and the signature images
+ *      below them. This is where the writers persist.
+ *   2. `<cwd>/storage/business-docs/contract/` — the same tree as written
+ *      before the writers moved onto the shared storage resolver. Kept so
+ *      pre-existing rows, whose absolute paths are in the database, still
+ *      resolve; identical to (1) on a stock compose install.
+ *   3. `<storage root>/uploads/contracts/signed/` —
  *      wet-upload PDFs (admin or customer-supplied).
  *
  * Both roots are constants from the operator's perspective; legitimate
@@ -48,6 +53,7 @@
 const fs = require('fs');
 const path = require('path');
 const { AppError } = require('./errors');
+const { getStoragePath } = require('../config/storage');
 
 /**
  * Resolve the canonical (symlink-followed) absolute path. Throws
@@ -111,7 +117,14 @@ function assertPathInside(filePath, allowedRoots) {
  */
 function assertContractPdfPath(filePath) {
   const cwd = process.cwd();
-  const storageRoot = process.env.STORAGE_PATH || path.join(cwd, 'storage');
+  // getStoragePath() rather than a second `STORAGE_PATH || cwd` expression:
+  // the two disagree whenever STORAGE_PATH is unset, because the shared
+  // resolver falls back module-relative (<repo>/storage) while this file used
+  // to fall back to <cwd>/storage — and the backend is normally started from
+  // backend/, so those are different directories. The writers use the shared
+  // resolver, so a guard with its own idea of the root refuses exactly the
+  // files it is meant to serve.
+  const storageRoot = getStoragePath();
   return assertPathInside(filePath, [
     // The configured storage root is where the contract writers persist, so it
     // has to be allowed here or every generated PDF is refused with

--- a/backend/src/utils/safePath.js
+++ b/backend/src/utils/safePath.js
@@ -113,6 +113,13 @@ function assertContractPdfPath(filePath) {
   const cwd = process.cwd();
   const storageRoot = process.env.STORAGE_PATH || path.join(cwd, 'storage');
   return assertPathInside(filePath, [
+    // The configured storage root is where the contract writers persist, so it
+    // has to be allowed here or every generated PDF is refused with
+    // PATH_OUTSIDE_STORAGE the moment STORAGE_PATH is not <cwd>/storage. The
+    // cwd root stays alongside it: contracts written before the writers moved
+    // still live there, and their absolute paths are recorded in the database.
+    // Both collapse to the same directory on a stock compose install.
+    path.join(storageRoot, 'business-docs', 'contract'),
     path.join(cwd, 'storage', 'business-docs', 'contract'),
     path.join(storageRoot, 'uploads', 'contracts', 'signed'),
   ]);


### PR DESCRIPTION
Business documents were written outside the configured storage root whenever `STORAGE_PATH` differs from `process.cwd()/storage`.

## Root cause

`persistDocPdf` and its siblings build their target from the working directory:

```js
const root = path.join(process.cwd(), 'storage', 'business-docs', type, String(year));
```

Both compose files pin `STORAGE_PATH=/app/storage` and the image's `WORKDIR` is `/app`, so on a stock deployment those two expressions name the same directory — which is why this has been invisible.

Point `STORAGE_PATH` anywhere else (a NAS mount, a second disk, the single-container image's `/data` volume) and quotes, invoices, Mahnungen and contract PDFs land outside the storage root: missed by the backup walker, invisible to storage accounting, and lost when the container is replaced. Where the working directory isn't writable by the runtime user, the write fails outright.

## Fix

All six writers now go through `getStoragePath()`, the resolver the rest of the app already uses:

| File | Site |
|---|---|
| `quoteService.js:1068` | `persistDocPdf` |
| `invoice/sending.js:117` | invoice snapshot |
| `invoice/sending.js:392` | storno snapshot |
| `invoice/reminders.js:135` | Mahnung |
| `contract/signatureAssets.js:45` | signed contract |
| `contract/signatureAssets.js:197` | audit certificate |

Two read-side sites of the same class came along:
- `pdfService.js:1366` — the custom PDF font lookup never consulted the storage root, so a font under `STORAGE_PATH/fonts` was never found and the document silently rendered with the built-in face. The storage root now comes first; the cwd paths stay on as a legacy fallback.
- `adminDev.js:131` — dev-test scratch dir, same root.

**Left alone deliberately:** `resolveLogoFile.js:60` and `adminBusinessProfile.js:256` already try both roots, so their cwd reference is a legacy fallback rather than a miss.

## Migration

None needed. The persisted path is stored absolute, so rows written before this keep resolving to where those files actually are.

## Verification

- New test `backend/__tests__/services/businessDocsStoragePath.test.js` (4 cases). The literal-pattern case fails on `main` and passes here, so it isn't vacuous.
- `jest quote invoice contract pdf businessDocs` → 213 passed. The one failing suite (`backupService.businessDocs.test.js`, 3 cases) fails identically on clean `main` — pre-existing, unrelated to this change.
- Each modified module verified to load (the requires resolve at runtime, not just `node --check`).

Found while testing the all-in-one image (#1042), where `/app` is root-owned and `STORAGE_PATH=/data/storage` — #1068 currently works around it with a symlink. That workaround can be dropped once this lands.
