### PR TITLE
test(e2e): read the admin JWT from the cookie, not the login body

### DIFF
--- a/tests/e2e/auth-smoke.spec.ts
+++ b/tests/e2e/auth-smoke.spec.ts
@@ -18,9 +18,9 @@ async function createEventWithPhotos(page: Page, adminToken?: string, attempt = 
       },
     });
     expect(loginResponse.ok()).toBeTruthy();
-    const loginData = await loginResponse.json();
-    token = loginData.token;
-    expect(token).toBeTruthy();
+    const cookies = await page.context().cookies();
+    token = cookies.find((c) => c.name === 'admin_token')?.value;
+    expect(token, 'admin_token cookie missing from the login response').toBeTruthy();
   }
 
   const eventName = `Playwright Smoke ${Date.now()}`;

--- a/tests/e2e/customer-portal-flow.spec.ts
+++ b/tests/e2e/customer-portal-flow.spec.ts
@@ -40,9 +40,14 @@ async function adminLogin(page: Page): Promise<string> {
     failOnStatusCode: false,
   });
   expect(res.ok()).toBeTruthy();
-  const json = await res.json();
-  expect(json.token).toBeTruthy();
-  return json.token;
+  // The admin JWT is delivered as the httpOnly `admin_token` cookie, not in
+  // the response body. Server-side the cookie and an Authorization: Bearer
+  // header are interchangeable, so read it back out of the context jar and
+  // keep threading it as a Bearer — every downstream call stays as it was.
+  const cookies = await page.context().cookies();
+  const token = cookies.find((c) => c.name === 'admin_token')?.value;
+  expect(token, 'admin_token cookie missing from the login response').toBeTruthy();
+  return token as string;
 }
 
 async function setCustomerPortalEnabled(page: Page, adminToken: string, enabled: boolean) {

--- a/tests/e2e/optional-email-event-creation.spec.ts
+++ b/tests/e2e/optional-email-event-creation.spec.ts
@@ -8,9 +8,14 @@ async function getAdminToken(page: Page): Promise<string> {
     data: { username: ADMIN_EMAIL, password: ADMIN_PASSWORD },
   });
   expect(res.ok()).toBeTruthy();
-  const body = await res.json();
-  expect(body.token).toBeTruthy();
-  return body.token;
+  // The admin JWT is delivered as the httpOnly `admin_token` cookie, not in
+  // the response body. Server-side the cookie and an Authorization: Bearer
+  // header are interchangeable, so read it back out of the context jar and
+  // keep threading it as a Bearer — every downstream call stays as it was.
+  const cookies = await page.context().cookies();
+  const token = cookies.find((c) => c.name === 'admin_token')?.value;
+  expect(token, 'admin_token cookie missing from the login response').toBeTruthy();
+  return token as string;
 }
 
 async function updateEventSettings(


### PR DESCRIPTION
Three E2E specs have been failing at their first assertion for some time, so nothing they cover has actually been exercised.

## Root cause

They acquire an admin token from the login response body:

```ts
const body = await res.json();
expect(body.token).toBeTruthy();   // undefined
return body.token;
```

The admin login stopped returning a token in the body when auth moved to cookies. `establishAdminSession()` calls `setAdminAuthCookie(res, token)` and responds with `res.json({ user })` — the JWT is only ever in the httpOnly `admin_token` cookie.

Affected: `auth-smoke.spec.ts`, `customer-portal-flow.spec.ts`, `optional-email-event-creation.spec.ts`.

## Fix

Server-side the cookie and an `Authorization: Bearer` header are interchangeable — `middleware/gallery.js:31-33` reads the cookie first and accepts an admin-typed Bearer second. So each login helper now reads the value back out of the context cookie jar and keeps threading it as a Bearer. **Every downstream call in these specs is unchanged**; only the three helpers move.

## Measured

Running only these three files against a real stack:

| | passed | failed |
|---|---|---|
| `main` | 0 | 6 — all at the token assertion |
| this branch | 3 | 3 |

`optional-email-event-creation.spec.ts` is now fully green (3/3). The three still failing no longer fail on auth — they get deep into the flow and then miss UI that has since changed (a settings label that no longer resolves, a `locator.fill` timeout).

## Scope — please read

This fixes the **auth mechanism**, not the suite. A full run is **12 passed against roughly two dozen failures** of the UI-staleness kind: changed labels, a dark-mode preference no longer in `localStorage`, settings endpoints returning non-OK. That's a separate and much larger job, and I've deliberately not attempted it here.

Two things worth deciding separately:

1. **No CI workflow runs `tests/e2e` at all.** I grepped every workflow. That's why this rotted silently while `npm run test:e2e` stayed documented in CLAUDE.md. Wiring it up is the obvious follow-up — but only once the suite is green, otherwise it pins `main` red.
2. **`tests/e2e/local/_helpers/seedAdmin.ts` hardcodes `docker exec picpeak-backend`**, so that suite can only ever run against the dev stack. It's gitignored (`.gitignore:112`), so it's out of scope for any PR — noting it because it's the same class of rot.

Found while E2E-testing the all-in-one image (#1042).
