### PR TITLE
test(e2e): read the admin JWT from the cookie, not the login body

### DIFF
--- a/tests/e2e/auth-smoke.spec.ts
+++ b/tests/e2e/auth-smoke.spec.ts
@@ -18,9 +18,9 @@ async function createEventWithPhotos(page: Page, adminToken?: string, attempt = 
       },
     });
     expect(loginResponse.ok()).toBeTruthy();
-    const loginData = await loginResponse.json();
-    token = loginData.token;
-    expect(token).toBeTruthy();
+    const cookies = await page.context().cookies();
+    token = cookies.find((c) => c.name === 'admin_token')?.value;
+    expect(token, 'admin_token cookie missing from the login response').toBeTruthy();
   }
 
   const eventName = `Playwright Smoke ${Date.now()}`;

--- a/tests/e2e/customer-portal-flow.spec.ts
+++ b/tests/e2e/customer-portal-flow.spec.ts
@@ -40,9 +40,14 @@ async function adminLogin(page: Page): Promise<string> {
     failOnStatusCode: false,
   });
   expect(res.ok()).toBeTruthy();
-  const json = await res.json();
-  expect(json.token).toBeTruthy();
-  return json.token;
+  // The admin JWT is delivered as the httpOnly `admin_token` cookie, not in
+  // the response body. Server-side the cookie and an Authorization: Bearer
+  // header are interchangeable, so read it back out of the context jar and
+  // keep threading it as a Bearer — every downstream call stays as it was.
+  const cookies = await page.context().cookies();
+  const token = cookies.find((c) => c.name === 'admin_token')?.value;
+  expect(token, 'admin_token cookie missing from the login response').toBeTruthy();
+  return token as string;
 }
 
 async function setCustomerPortalEnabled(page: Page, adminToken: string, enabled: boolean) {

--- a/tests/e2e/optional-email-event-creation.spec.ts
+++ b/tests/e2e/optional-email-event-creation.spec.ts
@@ -8,9 +8,14 @@ async function getAdminToken(page: Page): Promise<string> {
     data: { username: ADMIN_EMAIL, password: ADMIN_PASSWORD },
   });
   expect(res.ok()).toBeTruthy();
-  const body = await res.json();
-  expect(body.token).toBeTruthy();
-  return body.token;
+  // The admin JWT is delivered as the httpOnly `admin_token` cookie, not in
+  // the response body. Server-side the cookie and an Authorization: Bearer
+  // header are interchangeable, so read it back out of the context jar and
+  // keep threading it as a Bearer — every downstream call stays as it was.
+  const cookies = await page.context().cookies();
+  const token = cookies.find((c) => c.name === 'admin_token')?.value;
+  expect(token, 'admin_token cookie missing from the login response').toBeTruthy();
+  return token as string;
 }
 
 async function updateEventSettings(


### PR DESCRIPTION
Stable twin of #1071. Merge after that one lands.

The same three specs are broken on this branch for the same reason. I checked the thing that could have made this twin unnecessary — whether stable's login still returns a token in the body — and it does not: `establishAdminSession()` calls `setAdminAuthCookie(res, token)` and responds with `res.json({ user: {...} })`. No token. So `body.token` is `undefined` and each spec fails at its first assertion, before exercising anything it covers.

## Fix

Cookie and `Authorization: Bearer` are interchangeable server-side, so each login helper reads the JWT back out of the Playwright context cookie jar and keeps threading it as a Bearer. Every downstream call is unchanged — only the three helpers move.

## Verification — weaker than the main twin, deliberately

The three spec files are **byte-identical** (sha-compared) to the ones measured on #1071 against a live stack, where the result was **0 passed / 6 failed → 3 passed / 3 failed**. On this branch they compile and enumerate (12 tests across 3 files).

I did not stand up a full stable compose stack to re-measure, on the grounds that this is test-only code and the content is identical to what was already measured. Say the word if you'd rather I did that before merge.

## Scope

This fixes the auth mechanism, not the suite. The three that still fail no longer fail on auth — they get deep into the flow and miss UI that has since changed. That's a separate, larger staleness problem.

Also worth knowing: no CI workflow runs `tests/e2e` on this branch either, which is why this rotted unnoticed while `npm run test:e2e` stayed documented.
