### PR TITLE
chore(security): shrink the ML image's CVE surface, override deepmerge-ts

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -212,6 +212,14 @@ jobs:
         format: 'sarif'
         output: 'trivy-backend-${{ env.PLATFORM_PAIR }}.sarif'
         severity: 'CRITICAL,HIGH'
+        # Base-image CVEs with no released fix are not actionable: the
+        # Dockerfiles already run `apt-get upgrade -y` behind a CACHEBUST,
+        # so a fix lands in the next build automatically. Reporting them
+        # buries the findings someone can actually do something about --
+        # the ML image alone contributed 123 unfixable alerts. Dropping
+        # them is also the precondition for ever setting exit-code: 1,
+        # which build-backend's comment flags as a deliberate follow-up.
+        ignore-unfixed: true
         timeout: '10m'
 
     - name: Upload Trivy scan results to GitHub Security tab
@@ -474,6 +482,14 @@ jobs:
         format: 'sarif'
         output: 'trivy-frontend-${{ env.PLATFORM_PAIR }}.sarif'
         severity: 'CRITICAL,HIGH'
+        # Base-image CVEs with no released fix are not actionable: the
+        # Dockerfiles already run `apt-get upgrade -y` behind a CACHEBUST,
+        # so a fix lands in the next build automatically. Reporting them
+        # buries the findings someone can actually do something about --
+        # the ML image alone contributed 123 unfixable alerts. Dropping
+        # them is also the precondition for ever setting exit-code: 1,
+        # which build-backend's comment flags as a deliberate follow-up.
+        ignore-unfixed: true
         timeout: '10m'
 
     - name: Upload Trivy scan results to GitHub Security tab
@@ -716,6 +732,14 @@ jobs:
         format: 'sarif'
         output: 'trivy-aio-${{ env.PLATFORM_PAIR }}.sarif'
         severity: 'CRITICAL,HIGH'
+        # Base-image CVEs with no released fix are not actionable: the
+        # Dockerfiles already run `apt-get upgrade -y` behind a CACHEBUST,
+        # so a fix lands in the next build automatically. Reporting them
+        # buries the findings someone can actually do something about --
+        # the ML image alone contributed 123 unfixable alerts. Dropping
+        # them is also the precondition for ever setting exit-code: 1,
+        # which build-backend's comment flags as a deliberate follow-up.
+        ignore-unfixed: true
         timeout: '10m'
 
     - name: Upload Trivy scan results to GitHub Security tab
@@ -1109,6 +1133,14 @@ jobs:
         format: 'sarif'
         output: 'trivy-ml-${{ env.PLATFORM_PAIR }}.sarif'
         severity: 'CRITICAL,HIGH'
+        # Base-image CVEs with no released fix are not actionable: the
+        # Dockerfiles already run `apt-get upgrade -y` behind a CACHEBUST,
+        # so a fix lands in the next build automatically. Reporting them
+        # buries the findings someone can actually do something about --
+        # the ML image alone contributed 123 unfixable alerts. Dropping
+        # them is also the precondition for ever setting exit-code: 1,
+        # which build-backend's comment flags as a deliberate follow-up.
+        ignore-unfixed: true
         timeout: '10m'
 
     - name: Upload Trivy scan results to GitHub Security tab

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "picpeak-backend",
-  "version": "3.103.1-beta.0",
+  "version": "3.107.1-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "picpeak-backend",
-      "version": "3.103.1-beta.0",
+      "version": "3.107.1-beta.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.850.0",
         "@aws-sdk/lib-storage": "^3.850.0",
@@ -324,6 +324,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1000.0.tgz",
       "integrity": "sha512-7kPy33qNGq3NfwHC0412T6LDK1bp4+eiPzetX0sVd9cpTSXuQDKpoOFnB0Njj6uZjJDcLS3n2OeyarwwgkQ0Ow==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -1052,6 +1053,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -3946,6 +3948,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4560,6 +4563,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.38",
         "caniuse-lite": "^1.0.30001799",
@@ -5367,9 +5371,19 @@
       }
     },
     "node_modules/deepmerge-ts": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
-      "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-8.0.1.tgz",
+      "integrity": "sha512-szCXE7YLCvLKR9bFPJcvsezOShdalctSvrgN/LM/QGUEPZQajwjmsMObZ6/DuANT5lxzM/wtO8Feubwdkz8myA==",
+      "funding": [
+        {
+          "type": "ko-fi",
+          "url": "https://ko-fi.com/rebeccastevens"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/deepmerge-ts"
+        }
+      ],
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=16.0.0"
@@ -5753,6 +5767,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -6000,6 +6015,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -6967,6 +6983,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.27.6"
       },
@@ -9884,6 +9901,7 @@
       "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.17.2.tgz",
       "integrity": "sha512-UnwF5fXy08f0dnp4jchFYAROKMNTaPqb/xgR8GtCzIcqoTnbOqtp3bwKvO4688oHI6vzEEs8Q6vqqEnC5IUELw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "crypto-js": "^4.2.0",
         "fontkit": "^2.0.4",
@@ -10978,6 +10996,7 @@
       "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.12.0.tgz",
       "integrity": "sha512-b1YMh3+DHZp59DLna3qVwQ5iOla/nrI6mLBNW02XxU77M3046Df6VLkoaJyFz20VsGIG5kkp+FK0kg4K4HnUFw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "parseley": "~0.13.1"
       },

--- a/backend/package.json
+++ b/backend/package.json
@@ -96,6 +96,7 @@
     "@tootallnate/once": ">=3.0.1",
     "ip-address": ">=10.3.1",
     "uuid": "^11.1.1",
-    "nodemailer": "^9.0.1"
+    "nodemailer": "^9.0.1",
+    "deepmerge-ts": ">=8.0.1"
   }
 }

--- a/ml/Dockerfile
+++ b/ml/Dockerfile
@@ -73,10 +73,25 @@ ARG CACHEBUST=1
 RUN echo "cachebust=${CACHEBUST}" \
     && apt-get update \
     && apt-get upgrade -y \
-    # libGL and libglib are opencv-python-headless's remaining shared-library
-    # deps. The headless wheel drops the GUI toolkits but still links libGL.
-    && apt-get install -y --no-install-recommends libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+
+# No runtime apt packages at all — deliberately.
+#
+# opencv-python-headless 4.14 needs neither libgl1 nor libglib2.0-0. The
+# wheel bundles what it needs; `ldd .../cv2/cv2*.so` resolves fully on a
+# bare python:3.12-slim. Both were installed here on the assumption that
+# the headless build still links libGL, which was true of much older
+# wheels and is not true of this one.
+#
+# What they cost: libgl1 alone pulls 36 transitive packages (mesa, LLVM,
+# X11) into a service that never opens a display, and libglib2.0-0t64
+# carries a critical plus six highs. Together they accounted for 42 of
+# this image's Trivy findings — none of which have an upstream fix, so
+# not installing them is the only lever that exists.
+#
+# Before re-adding either, confirm it is actually needed: build without
+# it and run `ml/tests` plus a real FaceDetectorYN.detect() call, since
+# the API tests stub the pipeline and will pass either way.
 
 WORKDIR /app
 


### PR DESCRIPTION
Three Trivy cleanups off the code-scanning tab. No UI surface touched.

## Context

The tab showed **166 open alerts**. 165 were OS-package CVEs in `picpeak/picpeak/ml` — the ML sidecar's scan leg went live when it landed on main, and `python:3.12-slim` (Debian trixie) carries a far larger package surface than the alpine-based backend/frontend/aio images. **Every one of the 165 has an empty `Fixed Version`.**

## 1. No runtime apt packages in the ML image

`ml/Dockerfile` installed `libgl1 libglib2.0-0` on this rationale:

> `libGL and libglib are opencv-python-headless's remaining shared-library deps. The headless wheel drops the GUI toolkits but still links libGL.`

True of much older headless wheels, not 4.14.0 — which needs **neither**. Verified on a bare `python:3.12-slim` with zero apt packages installed:

- `cv2` imports; `ldd .../cv2/cv2*.so` resolves fully, no `libGL`
- real `FaceDetectorYN.create()` + `detect()` on the pinned YuNet model → ran, retval 1
- `facenet512.onnx` under onnxruntime → embedding `(1, 512)`
- `imencode`/`imdecode`/`resize`/`cvtColor` all exercised

`apt-get install --simulate libgl1` pulls **36 transitive packages** — mesa, LLVM, X11 — into a service that never opens a display. `libglib2.0-0t64` carried a critical plus six highs.

### Measured — each variant built locally and scanned with `trivy image`

| | findings | low | med | high | crit |
|---|---|---|---|---|---|
| before | 165 | 88 | 49 | 19 | 6 |
| without `libgl1` | 133 | 58 | 48 | 19 | 5 |
| **without either** | **123** | 57 | 46 | **13** | **4** |

42 findings gone, 2 criticals and 6 highs among them. Image **1.05GB → 774MB**, 130 → 92 dpkg packages. The before-column reproduces the Security tab exactly, which is the check that the local scan and CI's agree.

Since none of the 165 had an upstream fix, *not installing the packages* is the only lever that exists here.

## 2. `ignore-unfixed` on all four Trivy steps

All 123 remaining ML findings are unfixed base-OS CVEs. I checked Debian's security tracker — they are **already fixed in sid**, pending backport to trixie:

```
perl    CVE-2026-8376   [sid] resolved 5.40.1-8   [trixie] open
perl    CVE-2026-57433  [sid] resolved 5.40.1-8   [trixie] open
perl    CVE-2026-13221  [sid] resolved 5.42.3-1   [trixie] open
glib2.0 CVE-2026-58016  [sid] resolved 2.88.3-2   [trixie] open
gzip    CVE-2026-41992  [sid] resolved 1.14-1     [trixie] open
```

Because the Dockerfiles pair `apt-get upgrade -y` with `CACHEBUST`, each fix is picked up automatically on the next build once it reaches trixie. Nothing is being parked — the alerts are just noise until then, and they bury anything actionable.

This is also the precondition for setting `exit-code: 1`, which `docker-build.yml:192-195` flags as a deliberate follow-up. **Not flipping it in this PR** — that's a separate call.

Trade-off, stated plainly: unfixable ≠ harmless. It's defensible here because the upgrade path still pulls every fix the moment it exists, and residual exposure is low regardless — perl, tar, gzip, apt, login/pam are never invoked by a uvicorn process running non-root.

## 3. Override `deepmerge-ts` to ≥8.0.1

CVE-2026-40345 (high, stack exhaustion on recursive object graphs), fixed in 8.0.0, reaching us via `mailparser → html-to-text@10.0.0 → deepmerge-ts ^7.1.5`. html-to-text pins `^7`, so `npm audit fix` cannot get there — hence the `overrides` entry, matching the existing block's pattern.

**Not reachable in our code**, and worth saying so this isn't read as an incident: `html-to-text` only passes deepmerge-ts its *options* object (`html-to-text.mjs:1468`, `:1442`). Parsed email HTML never touches that path, so `simpleParser` on untrusted inbound mail at `emailIntakeService.js:14` does not put attacker data through the vulnerable merge. Hygiene, not exposure.

## Verification

- `docker build ml/` green; models load and infer in the built image
- `ml/tests` — **27 passed** with no apt packages present. Note these stub `FacePipeline`, so the model path was verified separately (above) rather than relying on the suite
- Trivy on the final image with the new flags: **0 reported**, 123 present-but-unfixable
- `npm audit`: **3 high → 0**
- deepmerge-ts@8 is a major bump, so html-to-text was exercised end-to-end through `simpleParser` — headings, paragraphs, list bullets, link-URL expansion all correct
- Backend Jest: **1919 passed**. 6 suites / 22 tests fail — `adminSettings.logo`, `adminPhotos.reference`, `crmMintPaths`, `webhookDelivery`, `backupService.enhanced`, `adminAuth`. **Pre-existing**: the identical 22 fail on clean `origin/main` with these changes stashed
- `docker-build.yml` re-parsed as YAML; all four Trivy steps confirmed to carry the flag

## Notes

- Lockfile diff carries two things beyond deepmerge-ts: the `version` field release-please had left at `3.103.1-beta.0`, and 9 `"peer": true` lines npm 11.6.2 recomputes. Both unavoidable when touching the lockfile.
- Follow-up worth tracking separately: a Wolfi/Chainguard base scans at **0 findings** and is glibc, which retires the "Alpine means musl, so ORT builds from source" constraint. Filed as an issue — it needs real work (Python 3.14 vs our pinned 3.12, floating `:latest` tag vs this file's pinning discipline) and does not belong here.
- Needs a `stable` twin per the backport-parity rule.
