### PR TITLE
chore(security): ignore unfixed CVEs in Trivy, override deepmerge-ts (#1083)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -203,6 +203,14 @@ jobs:
         format: 'sarif'
         output: 'trivy-backend-${{ env.PLATFORM_PAIR }}.sarif'
         severity: 'CRITICAL,HIGH'
+        # Base-image CVEs with no released fix are not actionable: the
+        # Dockerfiles already run `apt-get upgrade -y` behind a CACHEBUST,
+        # so a fix lands in the next build automatically. Reporting them
+        # buries the findings someone can actually do something about.
+        # Dropping them is also the precondition for ever setting
+        # exit-code: 1, which build-backend's comment flags as a
+        # deliberate follow-up.
+        ignore-unfixed: true
         timeout: '10m'
 
     - name: Upload Trivy scan results to GitHub Security tab
@@ -425,6 +433,14 @@ jobs:
         format: 'sarif'
         output: 'trivy-frontend-${{ env.PLATFORM_PAIR }}.sarif'
         severity: 'CRITICAL,HIGH'
+        # Base-image CVEs with no released fix are not actionable: the
+        # Dockerfiles already run `apt-get upgrade -y` behind a CACHEBUST,
+        # so a fix lands in the next build automatically. Reporting them
+        # buries the findings someone can actually do something about.
+        # Dropping them is also the precondition for ever setting
+        # exit-code: 1, which build-backend's comment flags as a
+        # deliberate follow-up.
+        ignore-unfixed: true
         timeout: '10m'
 
     - name: Upload Trivy scan results to GitHub Security tab

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "picpeak-backend",
-  "version": "3.45.14",
+  "version": "3.46.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "picpeak-backend",
-      "version": "3.45.14",
+      "version": "3.46.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.850.0",
         "@aws-sdk/lib-storage": "^3.850.0",
@@ -5315,9 +5315,19 @@
       }
     },
     "node_modules/deepmerge-ts": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
-      "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-8.0.1.tgz",
+      "integrity": "sha512-szCXE7YLCvLKR9bFPJcvsezOShdalctSvrgN/LM/QGUEPZQajwjmsMObZ6/DuANT5lxzM/wtO8Feubwdkz8myA==",
+      "funding": [
+        {
+          "type": "ko-fi",
+          "url": "https://ko-fi.com/rebeccastevens"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/deepmerge-ts"
+        }
+      ],
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=16.0.0"

--- a/backend/package.json
+++ b/backend/package.json
@@ -93,6 +93,7 @@
     "@tootallnate/once": ">=3.0.1",
     "ip-address": ">=10.3.1",
     "uuid": "^11.1.1",
-    "nodemailer": "^9.0.1"
+    "nodemailer": "^9.0.1",
+    "deepmerge-ts": ">=8.0.1"
   }
 }


### PR DESCRIPTION
Stable twin of #1083, scoped to what exists on this branch.

## What carries over

| #1083 change | stable |
|---|---|
| `ignore-unfixed` on Trivy steps | ✅ applied — **2 steps** here (backend, frontend) vs 4 on main; stable has no aio and no ml leg |
| `deepmerge-ts` override | ✅ applied — stable carries the same `mailparser ^3.9.9` and the identical 3-high exposure |
| `ml/Dockerfile` — drop `libgl1`/`libglib2.0-0` | ➖ **N/A** — the face sidecar does not exist on stable (`git ls-tree origin/stable ml/` is empty), so there is nothing to drift |

Per the backport-parity rule this twin carries everything #1083 carries that has a counterpart here. The ml/ half is genuinely absent rather than skipped.

## 1. `ignore-unfixed` on both Trivy steps

Base-image CVEs with no released fix are not actionable — the Dockerfiles already pair `apt-get upgrade -y` with `CACHEBUST`, so a fix lands in the next build automatically. Reporting them buries anything someone can act on, and suppressing them is the precondition for ever setting `exit-code: 1`. **Not flipping that here** — same as on main, it's a separate call.

## 2. Override `deepmerge-ts` to ≥8.0.1

CVE-2026-40345 (high, stack exhaustion), fixed in 8.0.0, reaching us via `mailparser → html-to-text@10.0.0 → deepmerge-ts ^7.1.5`. html-to-text pins `^7`, so `npm audit fix` can't get there — hence the `overrides` entry.

**Not reachable in our code**: html-to-text only passes deepmerge-ts its *options* object, never parsed email content, so `simpleParser` on untrusted inbound mail doesn't put attacker data through the vulnerable merge. Hygiene, not exposure.

## Verification — re-run on stable, not inherited from main

The parity rule says never assume main's results transfer, so everything below was measured on this branch:

- `npm audit` **before**: 3 high (`deepmerge-ts <8.0.0`, `html-to-text >=10.0.0`, `mailparser >=3.9.9`) — confirming stable had the identical exposure
- `npm audit` **after**: **0 vulnerabilities**; resolves to `mailparser@3.9.14 → html-to-text@10.0.0 → deepmerge-ts@8.0.1`
- deepmerge-ts@8 is a major bump, so html-to-text was exercised end-to-end through `simpleParser` — headings, paragraphs, list bullets and link-URL expansion all correct
- Backend Jest on stable: **1577 passed**. 5 suites / 20 tests fail — `adminSettings.logo`, `adminPhotos.reference`, `webhookDelivery`, `backupService.enhanced`, `adminAuth`. **Pre-existing**: the identical 20 fail on clean `origin/stable` with these changes stashed. (Main shows 6 suites / 22 — stable simply lacks `crmMintPaths`.)
- Workflow YAML re-parsed; both Trivy steps confirmed to carry the flag

## Note

Lockfile diff also picks up `"peer": true` metadata that npm 11.6.2 recomputes — unavoidable when touching the lockfile.
