### PR TITLE
fix(faces): scan external/reference photos instead of skipping them (#1090)

### DIFF
--- a/backend/__tests__/integration/faceExternalImportEnqueue.test.js
+++ b/backend/__tests__/integration/faceExternalImportEnqueue.test.js
@@ -1,129 +1,175 @@
 /**
- * External imports are queued for face scanning (#1090).
+ * External imports are queued for face scanning, in the right order (#1090).
  *
- * Managed uploads are enqueued by photoProcessor, which writes
- * face_status 'pending' once a photo is processed (photoProcessor.js:573 —
- * "the only correct place to enqueue"). External media never goes through
- * photoProcessor: adminExternalMedia inserts rows directly.
+ * Managed uploads are enqueued by photoProcessor, which writes face_status
+ * 'pending' once a photo is processed (photoProcessor.js:573 — "the only
+ * correct place to enqueue"). External media never goes through photoProcessor:
+ * adminExternalMedia inserts rows directly, so they stayed NULL and were only
+ * ever picked up by a manual Re-scan.
  *
- * Before #1090 that gap was invisible, because faceProcessor skipped every
- * external photo regardless. Once they became scannable, importing into an
- * already-enabled event still produced nothing until someone pressed Re-scan —
- * the second half of the reported bug, and the half that is easy to miss
- * because the first half looks like a complete fix.
+ * The ordering matters as much as the enqueue. events.external_path is written
+ * only AFTER the whole import loop, so marking rows 'pending' as they are
+ * inserted publishes claimable work while the event still points at the old
+ * directory — or none at all, on a first import. The face worker polls
+ * continuously, would resolve those photos against the wrong path, and mark
+ * them permanently 'failed', a state only an explicit Re-scan clears.
  *
- * This asserts the insert itself, not the HTTP route: the route needs a real
- * mounted directory tree, and the contract worth pinning is "rows arrive
- * queued when the feature is on, and untouched when it is off".
+ * This drives the real route rather than re-implementing it, so removing the
+ * enqueue fails the first test and moving it back onto the insert fails the
+ * second.
  */
 
-const path = require('path');
 const fs = require('fs');
+const path = require('path');
 const os = require('os');
-
-process.env.NODE_ENV = 'test';
-process.env.TEST_DATABASE_PATH = path.join(
-  fs.mkdtempSync(path.join(os.tmpdir(), 'picpeak-extenq-')), 'db.sqlite',
-);
-process.env.JWT_SECRET = process.env.JWT_SECRET || 'extenq-test-secret';
-
-const { bootCrmDb } = require('./helpers/crmDb');
-
-let db; let cleanup; let faceSettings;
-
-async function seedEvent({ facesEnabled }) {
-  const [e] = await db('events').insert({
-    slug: `extenq-${Math.random().toString(36).slice(2, 8)}`,
-    event_type: 'wedding',
-    event_name: 'extenq',
-    event_date: '2026-01-01',
-    host_email: 'h@example.com',
-    admin_email: 'a@example.com',
-    password_hash: 'x',
-    share_link: `extenq-${Math.random()}`,
-    expires_at: new Date().toISOString(),
-    face_recognition_enabled: facesEnabled,
-    source_mode: 'reference',
-  }).returning('id');
-  return typeof e === 'object' ? e.id : e;
-}
-
-/** Mirrors the insert adminExternalMedia performs per imported file. */
-async function importOne(eventId, queueFaces) {
-  const [p] = await db('photos').insert({
-    event_id: eventId,
-    filename: 'nas.jpg',
-    path: 'slug/nas.jpg',
-    thumbnail_path: null,
-    type: 'individual',
-    size_bytes: 1234,
-    width: 4000,
-    height: 3000,
-    source_origin: 'external',
-    external_relpath: 'nas/nas.jpg',
-    face_status: queueFaces ? 'pending' : null,
-  }).returning('id');
-  return typeof p === 'object' ? p.id : p;
-}
+const express = require('express');
+const request = require('supertest');
 
 describe('external import queues faces (#1090)', () => {
+  let tmpDir; let db; let app; let mediaRoot;
+  // Recorded from inside the per-photo thumbnail call, i.e. mid-loop.
+  let pendingSeenDuringLoop = 0;
+  let externalPathDuringLoop;
+
   beforeAll(async () => {
-    ({ db, cleanup } = await bootCrmDb());
-    faceSettings = require('../../src/services/faceSettings');
-  }, 120000);
+    tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'picpeak-extenq-'));
+    mediaRoot = path.join(tmpDir, 'media');
+    await fs.promises.mkdir(path.join(mediaRoot, 'nas', 'individual'), { recursive: true });
+    for (const name of ['a.jpg', 'b.jpg', 'c.jpg']) {
+      await fs.promises.writeFile(path.join(mediaRoot, 'nas', 'individual', name), 'not-a-real-jpeg');
+    }
 
-  afterAll(async () => { if (cleanup) await cleanup(); });
+    process.env.NODE_ENV = 'test';
+    process.env.TEST_DATABASE_PATH = path.join(tmpDir, 'data', 'db.sqlite');
+    await fs.promises.mkdir(path.dirname(process.env.TEST_DATABASE_PATH), { recursive: true });
+    process.env.STORAGE_PATH = path.join(tmpDir, 'storage');
+    process.env.EXTERNAL_MEDIA_ROOT = mediaRoot;
+    process.env.JWT_SECRET = process.env.JWT_SECRET || 'extenq-secret';
 
-  async function setFeatureFlag(on) {
-    await db('feature_flags').insert({ key: 'faces', value: on })
+    jest.resetModules();
+
+    jest.doMock('../../src/middleware/auth', () => ({
+      adminAuth: (req, _res, next) => { req.admin = { id: 1, username: 'tester', roleName: 'admin' }; next(); },
+    }));
+    jest.doMock('../../src/middleware/permissions', () => ({
+      requirePermission: () => (_req, _res, next) => next(),
+    }));
+    jest.doMock('../../src/middleware/ownership', () => ({
+      requireEventOwnership: (_req, _res, next) => next(),
+    }));
+
+    // Runs once per photo, inside the import loop — the only hook that can
+    // observe the intermediate state the ordering bug would expose.
+    jest.doMock('../../src/services/imageProcessor', () => ({
+      generateThumbnail: jest.fn(async () => {
+        const { db: liveDb } = require('../../src/database/db');
+        const rows = await liveDb('photos').where({ face_status: 'pending' });
+        pendingSeenDuringLoop += rows.length;
+        const ev = await liveDb('events').first();
+        externalPathDuringLoop = ev ? ev.external_path : undefined;
+        return 'thumbnails/mock.jpg';
+      }),
+      ensureThumbnail: jest.fn(),
+    }));
+
+    jest.doMock('../../src/utils/logger', () => ({
+      debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(),
+    }));
+
+    // bootCrmDb runs every migrations/core/*.up() directly — knex's Migrator
+    // deadlocks on 001_init's nested initializeDatabase() call.
+    ({ db } = await require('./helpers/crmDb').bootCrmDb());
+
+    app = express();
+    app.use(express.json());
+    app.use('/api/admin/external-media', require('../../src/routes/adminExternalMedia'));
+  }, 180000);
+
+  afterAll(async () => {
+    if (db) await db.destroy?.();
+    await fs.promises.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  async function seedEvent({ facesEnabled, flagOn }) {
+    await db('feature_flags').insert({ key: 'faces', value: flagOn })
       .onConflict('key').merge()
-      .catch(async () => { await db('feature_flags').where({ key: 'faces' }).update({ value: on }); });
+      .catch(async () => { await db('feature_flags').where({ key: 'faces' }).update({ value: flagOn }); });
     // The flag read is TTL-cached (requireFeatureFlag.js:26-34); production
-    // invalidates after every write, and so must this or the second flip in
-    // this suite reads a stale `true`.
+    // invalidates after every write, and so must this.
     require('../../src/middleware/requireFeatureFlag').invalidateFeatureFlagCache();
+
+    await db('photos').del();
+    await db('events').del();
+    const [e] = await db('events').insert({
+      slug: `extenq-${Math.random().toString(36).slice(2, 8)}`,
+      event_type: 'wedding',
+      event_name: 'extenq',
+      event_date: '2026-01-01',
+      host_email: 'h@example.com',
+      admin_email: 'a@example.com',
+      password_hash: 'x',
+      share_link: `extenq-${Math.random()}`,
+      expires_at: new Date().toISOString(),
+      face_recognition_enabled: facesEnabled,
+      source_mode: 'reference',
+    }).returning('id');
+
+    pendingSeenDuringLoop = 0;
+    externalPathDuringLoop = undefined;
+    return typeof e === 'object' ? e.id : e;
   }
 
-  it('marks imported photos pending when detection is on for the event', async () => {
-    await setFeatureFlag(true);
-    const eventId = await seedEvent({ facesEnabled: true });
-    const event = await db('events').where({ id: eventId }).first();
+  async function runImport(eventId) {
+    return request(app)
+      .post(`/api/admin/external-media/events/${eventId}/import-external`)
+      .send({ external_path: 'nas', recursive: true });
+  }
 
-    const queueFaces = await faceSettings.isEnabledForEvent(event);
-    expect(queueFaces).toBe(true);
+  it('queues imported photos when detection is on', async () => {
+    const eventId = await seedEvent({ facesEnabled: true, flagOn: true });
 
-    const photoId = await importOne(eventId, queueFaces);
+    const res = await runImport(eventId);
+    expect(res.status).toBe(200);
 
-    // 'pending' specifically: faceQueue.claimNextPhoto only claims that value
-    // (faceQueue.js:64), so NULL here means the photo waits for a manual
-    // Re-scan — which is the bug.
-    const photo = await db('photos').where({ id: photoId }).first();
-    expect(photo.face_status).toBe('pending');
+    const photos = await db('photos').where({ event_id: eventId });
+    expect(photos.length).toBeGreaterThan(0);
+    // The regression: these stayed NULL and waited for a manual Re-scan.
+    expect(photos.every((p) => p.face_status === 'pending')).toBe(true);
+  });
+
+  it('does not publish claimable rows before events.external_path is written', async () => {
+    const eventId = await seedEvent({ facesEnabled: true, flagOn: true });
+
+    await runImport(eventId);
+
+    // Observed from inside the loop: nothing may be claimable yet, because the
+    // event still resolves to the old (here: empty) directory. Marking rows on
+    // insert would make this non-zero and leave photos permanently 'failed'.
+    expect(pendingSeenDuringLoop).toBe(0);
+    expect(externalPathDuringLoop).toBeFalsy();
+
+    // ...and afterwards both are in place.
+    const ev = await db('events').where({ id: eventId }).first();
+    expect(ev.external_path).toBe('nas');
+    expect((await db('photos').where({ event_id: eventId, face_status: 'pending' })).length)
+      .toBe((await db('photos').where({ event_id: eventId })).length);
   });
 
   it('leaves face_status untouched when the per-event toggle is off', async () => {
-    await setFeatureFlag(true);
-    const eventId = await seedEvent({ facesEnabled: false });
-    const event = await db('events').where({ id: eventId }).first();
-
-    const queueFaces = await faceSettings.isEnabledForEvent(event);
-    expect(queueFaces).toBe(false);
-
-    const photo = await db('photos').where({ id: await importOne(eventId, queueFaces) }).first();
-    expect(photo.face_status).toBeNull();
+    const eventId = await seedEvent({ facesEnabled: false, flagOn: true });
+    await runImport(eventId);
+    const photos = await db('photos').where({ event_id: eventId });
+    expect(photos.length).toBeGreaterThan(0);
+    expect(photos.every((p) => p.face_status === null)).toBe(true);
   });
 
   it('leaves face_status untouched when the global flag is off', async () => {
     // Installs without the feature must never accumulate face_status rows —
     // the same invariant photoProcessor's guard protects.
-    await setFeatureFlag(false);
-    const eventId = await seedEvent({ facesEnabled: true });
-    const event = await db('events').where({ id: eventId }).first();
-
-    const queueFaces = await faceSettings.isEnabledForEvent(event);
-    expect(queueFaces).toBe(false);
-
-    const photo = await db('photos').where({ id: await importOne(eventId, queueFaces) }).first();
-    expect(photo.face_status).toBeNull();
+    const eventId = await seedEvent({ facesEnabled: true, flagOn: false });
+    await runImport(eventId);
+    const photos = await db('photos').where({ event_id: eventId });
+    expect(photos.length).toBeGreaterThan(0);
+    expect(photos.every((p) => p.face_status === null)).toBe(true);
   });
 });

--- a/backend/__tests__/integration/faceExternalImportEnqueue.test.js
+++ b/backend/__tests__/integration/faceExternalImportEnqueue.test.js
@@ -1,0 +1,129 @@
+/**
+ * External imports are queued for face scanning (#1090).
+ *
+ * Managed uploads are enqueued by photoProcessor, which writes
+ * face_status 'pending' once a photo is processed (photoProcessor.js:573 —
+ * "the only correct place to enqueue"). External media never goes through
+ * photoProcessor: adminExternalMedia inserts rows directly.
+ *
+ * Before #1090 that gap was invisible, because faceProcessor skipped every
+ * external photo regardless. Once they became scannable, importing into an
+ * already-enabled event still produced nothing until someone pressed Re-scan —
+ * the second half of the reported bug, and the half that is easy to miss
+ * because the first half looks like a complete fix.
+ *
+ * This asserts the insert itself, not the HTTP route: the route needs a real
+ * mounted directory tree, and the contract worth pinning is "rows arrive
+ * queued when the feature is on, and untouched when it is off".
+ */
+
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+process.env.NODE_ENV = 'test';
+process.env.TEST_DATABASE_PATH = path.join(
+  fs.mkdtempSync(path.join(os.tmpdir(), 'picpeak-extenq-')), 'db.sqlite',
+);
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'extenq-test-secret';
+
+const { bootCrmDb } = require('./helpers/crmDb');
+
+let db; let cleanup; let faceSettings;
+
+async function seedEvent({ facesEnabled }) {
+  const [e] = await db('events').insert({
+    slug: `extenq-${Math.random().toString(36).slice(2, 8)}`,
+    event_type: 'wedding',
+    event_name: 'extenq',
+    event_date: '2026-01-01',
+    host_email: 'h@example.com',
+    admin_email: 'a@example.com',
+    password_hash: 'x',
+    share_link: `extenq-${Math.random()}`,
+    expires_at: new Date().toISOString(),
+    face_recognition_enabled: facesEnabled,
+    source_mode: 'reference',
+  }).returning('id');
+  return typeof e === 'object' ? e.id : e;
+}
+
+/** Mirrors the insert adminExternalMedia performs per imported file. */
+async function importOne(eventId, queueFaces) {
+  const [p] = await db('photos').insert({
+    event_id: eventId,
+    filename: 'nas.jpg',
+    path: 'slug/nas.jpg',
+    thumbnail_path: null,
+    type: 'individual',
+    size_bytes: 1234,
+    width: 4000,
+    height: 3000,
+    source_origin: 'external',
+    external_relpath: 'nas/nas.jpg',
+    face_status: queueFaces ? 'pending' : null,
+  }).returning('id');
+  return typeof p === 'object' ? p.id : p;
+}
+
+describe('external import queues faces (#1090)', () => {
+  beforeAll(async () => {
+    ({ db, cleanup } = await bootCrmDb());
+    faceSettings = require('../../src/services/faceSettings');
+  }, 120000);
+
+  afterAll(async () => { if (cleanup) await cleanup(); });
+
+  async function setFeatureFlag(on) {
+    await db('feature_flags').insert({ key: 'faces', value: on })
+      .onConflict('key').merge()
+      .catch(async () => { await db('feature_flags').where({ key: 'faces' }).update({ value: on }); });
+    // The flag read is TTL-cached (requireFeatureFlag.js:26-34); production
+    // invalidates after every write, and so must this or the second flip in
+    // this suite reads a stale `true`.
+    require('../../src/middleware/requireFeatureFlag').invalidateFeatureFlagCache();
+  }
+
+  it('marks imported photos pending when detection is on for the event', async () => {
+    await setFeatureFlag(true);
+    const eventId = await seedEvent({ facesEnabled: true });
+    const event = await db('events').where({ id: eventId }).first();
+
+    const queueFaces = await faceSettings.isEnabledForEvent(event);
+    expect(queueFaces).toBe(true);
+
+    const photoId = await importOne(eventId, queueFaces);
+
+    // 'pending' specifically: faceQueue.claimNextPhoto only claims that value
+    // (faceQueue.js:64), so NULL here means the photo waits for a manual
+    // Re-scan — which is the bug.
+    const photo = await db('photos').where({ id: photoId }).first();
+    expect(photo.face_status).toBe('pending');
+  });
+
+  it('leaves face_status untouched when the per-event toggle is off', async () => {
+    await setFeatureFlag(true);
+    const eventId = await seedEvent({ facesEnabled: false });
+    const event = await db('events').where({ id: eventId }).first();
+
+    const queueFaces = await faceSettings.isEnabledForEvent(event);
+    expect(queueFaces).toBe(false);
+
+    const photo = await db('photos').where({ id: await importOne(eventId, queueFaces) }).first();
+    expect(photo.face_status).toBeNull();
+  });
+
+  it('leaves face_status untouched when the global flag is off', async () => {
+    // Installs without the feature must never accumulate face_status rows —
+    // the same invariant photoProcessor's guard protects.
+    await setFeatureFlag(false);
+    const eventId = await seedEvent({ facesEnabled: true });
+    const event = await db('events').where({ id: eventId }).first();
+
+    const queueFaces = await faceSettings.isEnabledForEvent(event);
+    expect(queueFaces).toBe(false);
+
+    const photo = await db('photos').where({ id: await importOne(eventId, queueFaces) }).first();
+    expect(photo.face_status).toBeNull();
+  });
+});

--- a/backend/__tests__/integration/faceExternalImportEnqueue.test.js
+++ b/backend/__tests__/integration/faceExternalImportEnqueue.test.js
@@ -30,6 +30,9 @@ describe('external import queues faces (#1090)', () => {
   // Recorded from inside the per-photo thumbnail call, i.e. mid-loop.
   let pendingSeenDuringLoop = 0;
   let externalPathDuringLoop;
+  // When set to an event id, the mocked thumbnail call turns detection on
+  // mid-loop, standing in for an admin flipping the toggle during an import.
+  let flipFacesOnDuringLoop = null;
 
   beforeAll(async () => {
     tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'picpeak-extenq-'));
@@ -67,6 +70,10 @@ describe('external import queues faces (#1090)', () => {
         pendingSeenDuringLoop += rows.length;
         const ev = await liveDb('events').first();
         externalPathDuringLoop = ev ? ev.external_path : undefined;
+        if (flipFacesOnDuringLoop) {
+          await liveDb('events').where({ id: flipFacesOnDuringLoop })
+            .update({ face_recognition_enabled: true });
+        }
         return 'thumbnails/mock.jpg';
       }),
       ensureThumbnail: jest.fn(),
@@ -153,6 +160,22 @@ describe('external import queues faces (#1090)', () => {
     expect(ev.external_path).toBe('nas');
     expect((await db('photos').where({ event_id: eventId, face_status: 'pending' })).length)
       .toBe((await db('photos').where({ event_id: eventId })).length);
+  });
+
+  it('honours a toggle flipped DURING the import', async () => {
+    // The setting is read after the loop, not before: on a large library the
+    // loop runs for minutes, and the toggle endpoint only queues rows that
+    // already existed when it fired. Reading it up front would strand every
+    // photo imported after that moment at NULL forever.
+    const eventId = await seedEvent({ facesEnabled: false, flagOn: true });
+    flipFacesOnDuringLoop = eventId;
+
+    await runImport(eventId);
+    flipFacesOnDuringLoop = null;
+
+    const photos = await db('photos').where({ event_id: eventId });
+    expect(photos.length).toBeGreaterThan(0);
+    expect(photos.every((p) => p.face_status === 'pending')).toBe(true);
   });
 
   it('leaves face_status untouched when the per-event toggle is off', async () => {

--- a/backend/__tests__/integration/faceExternalPhotos.test.js
+++ b/backend/__tests__/integration/faceExternalPhotos.test.js
@@ -1,0 +1,148 @@
+/**
+ * External / reference photos are scannable (#1090).
+ *
+ * faceProcessor used to short-circuit every photo with source_origin
+ * 'external' or 'reference' to 'skipped', because resolvePhotoStorageKey
+ * returns null for anything outside managed storage and ensurePreviewImage
+ * could not build a preview for it. #1078 removed that limitation —
+ * ensurePreviewImage now reads externals straight off the mount and writes
+ * the preview into managed storage — but the guard stayed, so the whole
+ * feature was a no-op on external-media installs. The reporter's gallery sat
+ * at 0/3230 with every row 'skipped' and no error.
+ *
+ * These pin both halves: the guard is gone, and a photo whose source is
+ * genuinely missing still fails rather than being quietly skipped — the blanket
+ * skip used to absorb that case too, so a real breakage looked like an
+ * unsupported one.
+ */
+
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+process.env.NODE_ENV = 'test';
+process.env.TEST_DATABASE_PATH = path.join(
+  fs.mkdtempSync(path.join(os.tmpdir(), 'picpeak-faceext-')), 'db.sqlite',
+);
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'faceext-test-secret';
+
+const sharp = require('sharp');
+
+let mockPreviewBuffer;
+// Set per-test: what ensurePreviewImage returns for the photo under test.
+let previewKeyResult;  // eslint-disable-line prefer-const
+const mockEnsurePreviewImage = jest.fn(async () => previewKeyResult);
+const mockDetectFaces = jest.fn();
+
+jest.mock('../../src/services/imageProcessor', () => ({
+  ...jest.requireActual('../../src/services/imageProcessor'),
+  ensurePreviewImage: (...args) => mockEnsurePreviewImage(...args),
+}));
+
+jest.mock('../../src/services/storage', () => ({
+  getStorage: () => ({ get: async () => mockPreviewBuffer }),
+}));
+
+jest.mock('../../src/services/faceClient', () => ({
+  detectFaces: (...args) => mockDetectFaces(...args),
+  SidecarUnavailableError: class extends Error {},
+}));
+
+const { bootCrmDb } = require('./helpers/crmDb');
+
+let db; let cleanup; let faceProcessor;
+
+async function seedPhoto({ sourceOrigin = 'managed', sourceMode = 'managed' } = {}) {
+  const [e] = await db('events').insert({
+    slug: `ext-${Math.random().toString(36).slice(2, 8)}`,
+    event_type: 'wedding',
+    event_name: 'ext',
+    event_date: '2026-01-01',
+    host_email: 'h@example.com',
+    admin_email: 'a@example.com',
+    password_hash: 'x',
+    share_link: `ext-${Math.random()}`,
+    expires_at: new Date().toISOString(),
+    face_recognition_enabled: true,
+    source_mode: sourceMode,
+  }).returning('id');
+  const eventId = typeof e === 'object' ? e.id : e;
+
+  const [p] = await db('photos').insert({
+    event_id: eventId,
+    filename: 'ext.jpg',
+    path: '/tmp/ext.jpg',
+    type: 'individual',
+    width: 1920,
+    height: 1440,
+    processing_status: 'complete',
+    face_status: 'processing',
+    source_origin: sourceOrigin,
+    external_relpath: sourceOrigin === 'managed' ? null : 'nas/ext.jpg',
+  }).returning('id');
+  return { eventId, photoId: typeof p === 'object' ? p.id : p };
+}
+
+describe('face scanning of external/reference photos (#1090)', () => {
+  beforeAll(async () => {
+    mockPreviewBuffer = await sharp({
+      create: { width: 1920, height: 1440, channels: 3, background: { r: 20, g: 40, b: 80 } },
+    }).jpeg().toBuffer();
+
+    ({ db, cleanup } = await bootCrmDb());
+    await db('feature_flags').insert({ key: 'faces', value: true })
+      .onConflict('key').merge()
+      .catch(async () => { await db('feature_flags').where({ key: 'faces' }).update({ value: true }); });
+    faceProcessor = require('../../src/services/faceProcessor');
+  }, 120000);
+
+  afterAll(async () => { if (cleanup) await cleanup(); });
+
+  beforeEach(() => {
+    mockEnsurePreviewImage.mockClear();
+    mockDetectFaces.mockClear();
+    previewKeyResult = 'previews/preview_ext.jpg';
+    mockDetectFaces.mockResolvedValue({
+      model_version: 'test-v1',
+      faces: [{
+        bbox: [100, 100, 50, 50],
+        score: 0.99,
+        landmarks: [[0, 0], [0, 0], [0, 0], [0, 0], [0, 0]],
+        yaw: 0, pitch: 0, blur: 500,
+        embedding: Array.from({ length: 64 }, (_, i) => (i === 0 ? 1 : 0)),
+      }],
+    });
+  });
+
+  it.each(['external', 'reference'])('scans a %s photo instead of skipping it', async (origin) => {
+    const { photoId } = await seedPhoto({ sourceOrigin: origin, sourceMode: 'reference' });
+
+    const result = await faceProcessor.processPhotoFaces(photoId);
+
+    // The regression: this used to return 'skipped' without ever building a
+    // preview or contacting the sidecar.
+    expect(result.status).not.toBe('skipped');
+    expect(mockEnsurePreviewImage).toHaveBeenCalled();
+    expect(mockDetectFaces).toHaveBeenCalled();
+
+    const photo = await db('photos').where({ id: photoId }).first();
+    expect(photo.face_status).toBe('done');
+    expect(await db('photo_faces').where({ photo_id: photoId }).first()).toBeTruthy();
+  });
+
+  it('fails, not skips, when the external source is genuinely gone', async () => {
+    // A missing file is a property of that photo, so it should be visible as a
+    // failure the admin can act on — not silently absorbed the way the old
+    // blanket skip did.
+    previewKeyResult = null;
+    const { photoId } = await seedPhoto({ sourceOrigin: 'external', sourceMode: 'reference' });
+
+    const result = await faceProcessor.processPhotoFaces(photoId);
+
+    expect(result.status).toBe('failed');
+    expect(mockDetectFaces).not.toHaveBeenCalled();
+    const photo = await db('photos').where({ id: photoId }).first();
+    expect(photo.face_status).toBe('failed');
+    expect(photo.face_error).toMatch(/preview/i);
+  });
+});

--- a/backend/src/routes/adminExternalMedia.js
+++ b/backend/src/routes/adminExternalMedia.js
@@ -106,18 +106,12 @@ router.post('/events/:id/import-external', adminAuth, requirePermission('photos.
     // import into an already-enabled event would still sit unscanned until
     // someone pressed Re-scan.
     //
-    // Resolved once for the whole import rather than per photo: it is a
-    // per-event setting and this loop can run to a thousand files. Guarded the
-    // same way photoProcessor guards it, so installs without the feature keep
-    // writing no face_status at all.
-    let queueFaces = false;
-    try {
-      const { isEnabledForEvent } = require('../services/faceSettings');
-      queueFaces = await isEnabledForEvent(event);
-    } catch (err) {
-      // Never let the face feature break an import — the photos are the point.
-      logger.warn(`Could not resolve face settings for event ${eventId}: ${err.message}`);
-    }
+    // Ids are collected unconditionally and the setting is read at the END,
+    // not here: this loop can run for many minutes on a large library, and an
+    // admin who enables detection during it would otherwise leave every photo
+    // imported after that moment stuck at NULL forever — the toggle endpoint
+    // only queues rows that already existed when it fired.
+    //
     // Collected during the loop and marked 'pending' only AFTER
     // events.external_path is written below. Setting it on insert would publish
     // claimable rows while the event still carries the old path — or none, on a
@@ -199,7 +193,7 @@ router.post('/events/:id/import-external', adminAuth, requirePermission('photos.
           }
         }
 
-        if (photoId != null && queueFaces) importedPhotoIds.push(photoId);
+        if (photoId != null) importedPhotoIds.push(photoId);
         imported += (inserted?.length ? 1 : 0);
       } catch (e) {
         skipped++;
@@ -210,9 +204,23 @@ router.post('/events/:id/import-external', adminAuth, requirePermission('photos.
     await db('events').where('id', eventId).update({ source_mode: 'reference', external_path });
 
     // Only now does the event resolve to the new directory, so only now is it
-    // safe to open the queue. Chunked because SQLite caps a statement at 999
-    // bound parameters and an import can be far larger than that.
-    if (importedPhotoIds.length) {
+    // safe to open the queue. Guarded the same way photoProcessor guards it
+    // (both the global flag and the per-event toggle), so installs without the
+    // feature still never write a face_status. Re-read here rather than before
+    // the loop so a toggle flipped mid-import is honoured.
+    let queueFaces = false;
+    try {
+      const { isEnabledForEvent } = require('../services/faceSettings');
+      const freshEvent = await db('events').where('id', eventId).first();
+      queueFaces = await isEnabledForEvent(freshEvent);
+    } catch (err) {
+      // Never let the face feature break an import — the photos are the point.
+      logger.warn(`Could not resolve face settings for event ${eventId}: ${err.message}`);
+    }
+
+    // Chunked because SQLite caps a statement at 999 bound parameters and an
+    // import can be far larger than that.
+    if (queueFaces && importedPhotoIds.length) {
       for (let i = 0; i < importedPhotoIds.length; i += 500) {
         await db('photos')
           .whereIn('id', importedPhotoIds.slice(i, i + 500))

--- a/backend/src/routes/adminExternalMedia.js
+++ b/backend/src/routes/adminExternalMedia.js
@@ -98,6 +98,27 @@ router.post('/events/:id/import-external', adminAuth, requirePermission('photos.
     let thumbnailsGenerated = 0;
     let thumbnailsFailed = 0;
 
+    // Face detection (#1090). Managed uploads are enqueued by photoProcessor,
+    // which sets face_status 'pending' once a photo is processed
+    // (photoProcessor.js:573) — but external media never goes through it, it
+    // is inserted directly here. Before #1090 that was invisible, because
+    // faceProcessor skipped externals anyway; now that they are scannable, an
+    // import into an already-enabled event would still sit unscanned until
+    // someone pressed Re-scan.
+    //
+    // Resolved once for the whole import rather than per photo: it is a
+    // per-event setting and this loop can run to a thousand files. Guarded the
+    // same way photoProcessor guards it, so installs without the feature keep
+    // writing no face_status at all.
+    let queueFaces = false;
+    try {
+      const { isEnabledForEvent } = require('../services/faceSettings');
+      queueFaces = await isEnabledForEvent(event);
+    } catch (err) {
+      // Never let the face feature break an import — the photos are the point.
+      logger.warn(`Could not resolve face settings for event ${eventId}: ${err.message}`);
+    }
+
     // Insert photos
     for (const f of dedupeMap.values()) {
       // Infer type by subfolder names
@@ -137,7 +158,10 @@ router.post('/events/:id/import-external', adminAuth, requirePermission('photos.
             width,
             height,
             source_origin: 'external',
-            external_relpath: f.rel
+            external_relpath: f.rel,
+            // No video guard needed: walkDir only collects jpg/jpeg/png/webp,
+            // so nothing faceProcessor would skip as video can arrive here.
+            face_status: queueFaces ? 'pending' : null
           })
           .returning('id');
 

--- a/backend/src/routes/adminExternalMedia.js
+++ b/backend/src/routes/adminExternalMedia.js
@@ -118,6 +118,15 @@ router.post('/events/:id/import-external', adminAuth, requirePermission('photos.
       // Never let the face feature break an import — the photos are the point.
       logger.warn(`Could not resolve face settings for event ${eventId}: ${err.message}`);
     }
+    // Collected during the loop and marked 'pending' only AFTER
+    // events.external_path is written below. Setting it on insert would publish
+    // claimable rows while the event still carries the old path — or none, on a
+    // first import: the face worker polls continuously, resolvePhotoFilePath
+    // would resolve against the wrong directory, and a multi-minute import
+    // would leave photos permanently 'failed', a state only an explicit
+    // Re-scan clears. No video guard needed either way: walkDir collects only
+    // jpg/jpeg/png/webp.
+    const importedPhotoIds = [];
 
     // Insert photos
     for (const f of dedupeMap.values()) {
@@ -158,10 +167,7 @@ router.post('/events/:id/import-external', adminAuth, requirePermission('photos.
             width,
             height,
             source_origin: 'external',
-            external_relpath: f.rel,
-            // No video guard needed: walkDir only collects jpg/jpeg/png/webp,
-            // so nothing faceProcessor would skip as video can arrive here.
-            face_status: queueFaces ? 'pending' : null
+            external_relpath: f.rel
           })
           .returning('id');
 
@@ -193,6 +199,7 @@ router.post('/events/:id/import-external', adminAuth, requirePermission('photos.
           }
         }
 
+        if (photoId != null && queueFaces) importedPhotoIds.push(photoId);
         imported += (inserted?.length ? 1 : 0);
       } catch (e) {
         skipped++;
@@ -201,6 +208,18 @@ router.post('/events/:id/import-external', adminAuth, requirePermission('photos.
 
     // Update event fields
     await db('events').where('id', eventId).update({ source_mode: 'reference', external_path });
+
+    // Only now does the event resolve to the new directory, so only now is it
+    // safe to open the queue. Chunked because SQLite caps a statement at 999
+    // bound parameters and an import can be far larger than that.
+    if (importedPhotoIds.length) {
+      for (let i = 0; i < importedPhotoIds.length; i += 500) {
+        await db('photos')
+          .whereIn('id', importedPhotoIds.slice(i, i + 500))
+          .update({ face_status: 'pending' });
+      }
+      logger.info(`Queued ${importedPhotoIds.length} imported external photo(s) for face scanning (event ${eventId})`);
+    }
 
     await logActivity(
       'external_import_completed',

--- a/backend/src/services/faceProcessor.js
+++ b/backend/src/services/faceProcessor.js
@@ -75,18 +75,18 @@ async function processPhotoFaces(photoId) {
     return { status: 'skipped' };
   }
 
-  // External / reference photos live outside managed storage, and
-  // resolvePhotoStorageKey returns null for them by design (photoResolver.js).
-  // ensurePreviewImage therefore cannot build a preview, so scanning them is
-  // unsupported rather than broken — 'skipped', not 'failed', so an external
-  // gallery does not report every photo as an error.
-  if (photo.source_origin === 'external' || photo.source_origin === 'reference') {
-    await db('photos').where({ id: photoId }).update({
-      face_status: 'skipped', face_started_at: null, face_error: null,
-    });
-    return { status: 'skipped' };
-  }
-
+  // No external/reference guard here on purpose (#1090). One used to skip
+  // them, because resolvePhotoStorageKey returns null for photos outside
+  // managed storage and ensurePreviewImage could not build a preview. #1078
+  // removed that limitation: ensurePreviewImage now reads externals straight
+  // off the mount via resolvePhotoFilePath and writes the preview into
+  // managed storage, so the key below is readable like any other. Keeping the
+  // guard made the whole feature a no-op on external-media installs, where
+  // every photo in the library can be external.
+  //
+  // A photo whose source really is gone still returns null and lands in the
+  // 'failed' branch below, which is the honest outcome — that is a broken
+  // photo, not an unsupported one.
   const previewKey = await ensurePreviewImage(photo);
   if (!previewKey) {
     // No preview and no way to make one — the source is missing or corrupt.


### PR DESCRIPTION
Fixes #1090. The diagnosis in that report is correct and complete — thanks @BraynArts, the `git log -S` trail made this a verification rather than an investigation.

## 1. The reported bug

`faceProcessor.js` short-circuited every photo with `source_origin` `external` or `reference` to `skipped` before the sidecar was ever contacted. On an external-media install that is the whole library: 0/3230 scanned, every row `skipped`, no error.

The guard was correct when written — `resolvePhotoStorageKey` returns null outside managed storage, so `ensurePreviewImage` had nothing to build a preview from. **#1078 removed that limitation one release earlier** (`af7970b0`, v3.107.1-beta.0). The guard outlived its reason by exactly one release.

Verified the fix is sound rather than plausible: `faceProcessor.js:104` fetches the preview via `getStorage().get(previewKey)`, and `generatePreviewImage` writes into managed storage — so the key the external branch produces is readable on the same path as any managed photo.

Photos whose source is genuinely missing now land in the existing `!previewKey → 'failed'` branch, which is an improvement in itself: the blanket skip was absorbing real breakage, so a missing file was indistinguishable from an unsupported one.

## 2. The half that wasn't in the report

Managed uploads are enqueued by `photoProcessor`, which writes `face_status: 'pending'` once a photo is processed (`photoProcessor.js:573`, commented "the only correct place to enqueue"). **External media never goes through `photoProcessor`** — `adminExternalMedia` inserts rows directly, leaving `face_status` NULL, and `faceQueue.claimNextPhoto` only claims `'pending'` (`faceQueue.js:64`).

So lifting the guard alone made external photos *scannable but still not scanned*. Importing into an already-enabled event produced nothing until someone pressed Re-scan — which looks like a complete fix right up until you import a photo.

Imports now queue their rows. Three things about *how*, each of which the review forced:

- **After `events.external_path` is written, not on insert.** The route writes the path only after the whole loop, so rows marked pending inside it are claimable while the event still points at the old directory — or none, on a first import. The worker polls continuously; on a multi-minute import it would resolve them against the wrong path and mark them permanently `failed`, which is *worse* than the unscanned state this set out to fix.
- **Setting read after the loop, not before.** On a large library the loop runs for minutes. An admin enabling detection during it would otherwise strand every photo imported after that moment at NULL forever, because the toggle endpoint only queues rows that already existed when it fired.
- **Chunked at 500**, since SQLite caps a statement at 999 bound parameters.

No `enqueueEvent` call and no migration: `enqueueEvent` (`faceProcessor.js:250`) already re-queues NULL/`failed`/`skipped`, so existing skipped photos are picked up on the next scan — exactly as the reporter noted.

## Verification

- **8 tests** across two suites. The import tests drive the real route rather than re-implementing it, and observe mid-loop state from inside the mocked per-photo thumbnail call — the only hook that can see the window the race lived in.
- Confirmed they discriminate: deleting the enqueue fails two tests; moving it back onto the insert fails the ordering test specifically; stashing the guard fix fails all three scan tests.
- Full backend face suite: **55 passed across 7 suites**. Pre-push E2E smoke: 13 passed.

## Known-and-deferred

Two findings from review that are real but belong in their own issues rather than growing this PR — happy to file both:

1. **Transient mount errors become permanent failures.** On NFS/SMB, an unmount or read error makes `ensurePreviewImage` return null exactly like a corrupt image, so the photo is marked `failed` and restoring the mount does not resume it. This behaviour is pre-existing for managed photos, but network mounts make it far more likely for external ones — worth distinguishing transient I/O from invalid images and returning the former to the retry path.
2. **Concurrent enqueue during a long import.** `enqueueEvent` accepts `processing_status` NULL (`faceProcessor.js:243-246`), which external inserts leave unset — so an admin hitting the toggle or Re-scan mid-import can queue partial rows before the path is committed. Narrow (needs concurrent admin action) but the same class as the ordering bug above; the clean fix is to keep partial imports ineligible, which touches shared `processing_status` semantics.

`getExternalMediaRoot` is flagged unused by eslint at `adminExternalMedia.js:7` — pre-existing on `main`, not touched here.
