### PR TITLE
docs(readme): point the single-container install at a tag that exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,12 @@ For a home server, a NAS, or a single small studio, the all-in-one image runs th
 docker run -d --name picpeak -p 3000:3000 \
   -v picpeak:/data \
   -e JWT_SECRET="$(openssl rand -base64 48)" \
-  ghcr.io/picpeak/picpeak/aio:stable
+  ghcr.io/picpeak/picpeak/aio:main
 ```
 
 Then open **http://localhost:3000/admin** and read the setup token with `docker exec picpeak cat /data/db/SETUP_TOKEN`.
+
+`:main` is the active-development tag, and today it is the only one the all-in-one image has — `Dockerfile.aio` landed after the current stable release, so `:stable` and `:latest` first appear for this image once the aio build reaches the `stable` branch. Switch to `:stable` then, or pin a version tag (`3.107.4-beta.0`) if you would rather not track `main`.
 
 The compose stack above is still the right choice for anything busier — SQLite takes one writer at a time, and Postgres is what scales. You can move to it later without reinstalling: take a `.picpeak` backup and restore it into the full stack. See **[Single-container install](https://docs.picpeak.app/deployment/single-container)** for the volume layout, the external-Postgres variant, TLS, and the limits.
 


### PR DESCRIPTION
## Problem

The all-in-one quickstart in the README tells people to pull `ghcr.io/picpeak/picpeak/aio:stable`. That tag has never been published, so the documented one-liner fails on a clean machine:

```
docker: Error response from daemon: failed to resolve reference
"ghcr.io/picpeak/picpeak/aio:stable": ghcr.io/picpeak/picpeak/aio:stable: not found
```

Hit while doing a first-time single-container install from the README.

## Why the tag is missing

`merge-aio` gates `:stable`/`:latest` correctly, exactly like backend and frontend (`.github/workflows/docker-build.yml`):

```yaml
type=raw,value=stable,enable=${{ github.ref == 'refs/heads/stable' || (startsWith(github.ref, 'refs/tags/v') && steps.context.outputs.is_prerelease == 'false') }}
```

The workflow is fine — the image is just younger than the channel. `Dockerfile.aio` landed on `main` in 0874a30a (#1068, 2026-08-18), and the current `stable` head (3.46.1, #1082) does not contain the file at all. Every aio build so far has come from `main` or a beta tag.

Actual tag lists today:

| Image | Tags |
|---|---|
| `aio` | `main`, `beta`, `3.106.0-beta.0` … `3.107.4-beta.0`, `sha-*` |
| `backend` | `main`, `beta`, **`stable`**, **`latest`**, … |
| `frontend` | `main`, `beta`, **`stable`**, **`latest`**, … |

Same on the Docker Hub mirror (`picpeak/aio`): `main`, `beta`, beta versions only. aio is the only image without a stable channel.

## Change

One line in the quickstart, plus a sentence saying when `:stable` starts working so this can be flipped back after the next stable promotion. No workflow changes — nothing there is broken.

## Verification

`ghcr.io/picpeak/picpeak/aio:main` pulls and runs clean; `/health` healthy, 155 migrations applied, setup token written to `/data/db/SETUP_TOKEN` as documented.

## Note for the maintainer

If you would rather the README keep saying `:stable`, the alternative fix is to promote the aio build to the `stable` branch so the tag materialises — happy to close this in favour of that. Either way the README and the registry should agree, since right now the very first command a single-container user runs is the one that fails.