### PR TITLE
ci: give the backend job headroom over its observed tail

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,18 @@ permissions:
 jobs:
   backend:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # 20, not 10. This job normally finishes in ~3 minutes, but it is the only
+    # one that boots Postgres and runs the full integration suite, so it is the
+    # only one exposed to runner contention — observed spread has reached 9.2
+    # minutes, and a release PR (#1088) was cancelled at 10.3 with every test
+    # passing and jest still running. A cancelled job reads as a red X on a
+    # green branch, which costs a re-run and a diagnosis every time it happens.
+    #
+    # The cap is a runaway guard, not a performance budget; 20 leaves real
+    # headroom over the worst observed run while still killing a hung suite
+    # well inside the hour GitHub would otherwise allow. frontend and ml keep
+    # 10 — they take seconds and have never come close.
+    timeout-minutes: 20
 
     # The .picpeak restore suites gate their real-Postgres cases behind
     # PICPEAK_PG_TEST_URL and `describe.skip` themselves out when it is


### PR DESCRIPTION
The backend test job is capped at `timeout-minutes: 10`. It normally finishes in ~3 minutes — the last eight runs on `main` were **2.6 to 3.4** — but it is the only job that boots Postgres and runs the full integration suite, so it is the only one exposed to runner contention.

The tail has already bitten:

- **9.2 minutes** on one run — inside the cap, but only just
- **10.3 minutes on #1088, cancelled** — with every test in the log passing and jest still running when the runner killed it

That failure is expensive out of proportion to its frequency: a cancelled job is a red X on a branch that is actually green, so each occurrence costs a diagnosis and a re-run. And it lands on release PRs, because those run when everything else does.

**20, not 10.** The cap is a runaway guard rather than a performance budget — 20 gives real headroom over the worst run observed while still killing a genuinely hung suite well inside the hour GitHub would otherwise allow.

`frontend` and `ml` keep 10; they finish in seconds and have never come close, so raising them would only weaken the guard.

Verified the YAML parses and all three job timeouts read back as intended.