### PR TITLE
fix(ui): stop iOS Safari zooming in on 14px form fields

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -716,3 +716,56 @@
     margin-top: 0;
   }
 }
+
+/*
+ * iOS Safari zooms the whole page in when a focused form control computes to
+ * less than 16px, and it does not zoom back out (#1105). Unlocking a gallery
+ * is a client-side transition rather than a document navigation, so the zoom
+ * the password field triggered carries straight into the gallery: the layout
+ * pans horizontally and the header actions sit off-screen until the visitor
+ * pinch-zooms out by hand.
+ *
+ * The lever is the font size, not the viewport meta — adding maximum-scale=1
+ * would suppress the zoom by disabling pinch-to-zoom for everyone, which is an
+ * accessibility regression, so index.html deliberately omits it.
+ *
+ * Keyed to the POINTER, not a width. The zoom depends on the computed font
+ * size and a touch device, never on how wide the viewport is — and a phone in
+ * landscape is 667–956 CSS px, above any width you could call "phone". A
+ * max-width query fixes portrait and leaves every landscape phone (and iPad)
+ * still zooming. `pointer: coarse` is the population that actually has the
+ * behaviour; a mouse-driven desktop reports `fine` and keeps its 14px density.
+ *
+ * Deliberately NOT inside @layer, and deliberately more specific than a single
+ * utility class: `.input` is 14px and ~440 raw controls carry their own
+ * `text-sm`, so a rule that loses to a utility fixes almost nothing. The
+ * `:not()` on each selector is what buys that specificity — without it,
+ * `select`/`textarea` (0,0,1) lose to `.text-sm` (0,1,0) and keep zooming,
+ * while `input` alone happens to win. Excluding checkbox and radio keeps
+ * font-size off controls that size their box from it.
+ *
+ * max(16px, 1em, 1rem) is a FLOOR, not a size. Writing a flat 16px would make
+ * controls that are already larger smaller: Typography -> Large sets
+ * --font-size-base to 18px on body, so anything inheriting it would be clamped
+ * down and the setting quietly ignored. Each term covers a case the others
+ * miss - 1em follows the theme's body size, 1rem follows a browser default the
+ * visitor raised themselves, 16px catches Small themes and .text-sm controls:
+ *
+ *   normal (body 16)      16px      Large theme (body 18)   18px
+ *   Small theme (body 14) 16px      browser default 20px    20px
+ *
+ * The specificity that beats a utility class also beats a gallery's custom CSS
+ * (Theme -> Custom CSS), so `.input-themed { font-size: 20px }` lands at 16px
+ * on touch. That is unavoidable here rather than an oversight: nothing in CSS
+ * distinguishes a class that sets 14px from one that sets 20px, so a rule that
+ * loses to the second also loses to the first and fixes nothing. Overriding
+ * DOWNWARD is the point; upward is the cost. `font-size: 20px !important`
+ * still wins for anyone who wants it.
+ */
+@media (pointer: coarse) {
+  input:not([type="checkbox"]):not([type="radio"]),
+  select:not([hidden]),
+  textarea:not([hidden]) {
+    font-size: max(16px, 1em, 1rem);
+  }
+}


### PR DESCRIPTION
Closes #1105.

@BraynArts's report is accurate on every point — I verified each against the tree before writing this. The breakpoint really is inverted at `GalleryPage.tsx:549`, `.input`/`.input-themed` really are `text-sm` (`index.css:209`, `:219`), the viewport meta really does omit `maximum-scale` (so font size is the right lever, not the meta), and `GalleryPage.tsx:421` confirms the unlock is a conditional render in the same component — no document navigation, which is exactly why the zoom survives it.

## Why one media query instead of flipping the call sites

The issue's preferred fix — flip `.input` to `text-base sm:text-sm` and correct the call sites — fixes the `<Input>` path but leaves most of the app:

- `.input` backs **334** `<Input>` usages
- there are also **240** raw `<input>`, **163** `<select>` and **39** `<textarea>` that never pass through it
- Tailwind utilities sit in a later layer than `@layer components`, so any call site adding `text-sm` overrides the fix — and any *new* one silently reintroduces the bug

A single guard covers all of them and is self-enforcing.

## The `:not()` is load-bearing

The issue offers a global-guard variant as an alternative. It has a specificity hole, which I measured in a browser rather than reasoning about:

| selector | computed | why |
|---|---|---|
| `input.text-sm` | **16px** | `input:not([type=…]):not([type=…])` is (0,2,1), beats `.text-sm` (0,1,0) |
| `select.text-sm` | **14px** | bare `select` is (0,0,1) — loses |
| `textarea.text-sm` | **14px** | same |

**24 selects and textareas** in the tree carry `text-sm`, so the bare form would have left them zooming. Adding `:not([hidden])` lifts them to (0,1,1) and all three resolve to 16px. Checkbox and radio stay excluded so font-size never sizes their box.

## Verified

Production build, real pages, measured computed `font-size`:

| | mobile 390×844 @DPR3 | desktop 1280×800 @DPR1 |
|---|---|---|
| gallery password | 14px → **16px** | 16px → 16px |
| admin login | 14px → **16px** | 14px → 14px |

Desktop density is deliberately untouched — the rule only applies below `sm`, and iOS never zooms at those widths anyway.

Frontend suite 174 passing, build clean, no new type errors (43 pre-existing, same as `main`).

## Screenshot

Gallery password field at 390×844 DPR3, before and after:

<img width="912" height="664" alt="issue-1105-comparison" src="https://github.com/user-attachments/assets/a305f68f-c534-4f6c-a189-68bb88a6ad4f" />


One honest cosmetic note visible in that shot: the German placeholder truncates one character earlier at 16px (`…Passwort ei` rather than `…Passwort ein`). It's a placeholder rather than content, and the trade against a page-wide zoom that never resets is clearly worth it — but it's there, so I'm pointing at it rather than letting it be found.

## Stable

Stable carries the identical bug (`index.css:209`, `GalleryPage.tsx:446` on `origin/stable`, v3.46.1), and stable is what most self-hosters run — so this needs a twin. Filing it separately and verifying on the stable branch itself rather than assuming this branch's results transfer.
