### PR TITLE
fix(ui): stop iOS Safari zooming in on 14px form fields (stable)

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -716,3 +716,56 @@
     margin-top: 0;
   }
 }
+
+/*
+ * iOS Safari zooms the whole page in when a focused form control computes to
+ * less than 16px, and it does not zoom back out (#1105). Unlocking a gallery
+ * is a client-side transition rather than a document navigation, so the zoom
+ * the password field triggered carries straight into the gallery: the layout
+ * pans horizontally and the header actions sit off-screen until the visitor
+ * pinch-zooms out by hand.
+ *
+ * The lever is the font size, not the viewport meta — adding maximum-scale=1
+ * would suppress the zoom by disabling pinch-to-zoom for everyone, which is an
+ * accessibility regression, so index.html deliberately omits it.
+ *
+ * Keyed to the POINTER, not a width. The zoom depends on the computed font
+ * size and a touch device, never on how wide the viewport is — and a phone in
+ * landscape is 667–956 CSS px, above any width you could call "phone". A
+ * max-width query fixes portrait and leaves every landscape phone (and iPad)
+ * still zooming. `pointer: coarse` is the population that actually has the
+ * behaviour; a mouse-driven desktop reports `fine` and keeps its 14px density.
+ *
+ * Deliberately NOT inside @layer, and deliberately more specific than a single
+ * utility class: `.input` is 14px and ~440 raw controls carry their own
+ * `text-sm`, so a rule that loses to a utility fixes almost nothing. The
+ * `:not()` on each selector is what buys that specificity — without it,
+ * `select`/`textarea` (0,0,1) lose to `.text-sm` (0,1,0) and keep zooming,
+ * while `input` alone happens to win. Excluding checkbox and radio keeps
+ * font-size off controls that size their box from it.
+ *
+ * max(16px, 1em, 1rem) is a FLOOR, not a size. Writing a flat 16px would make
+ * controls that are already larger smaller: Typography -> Large sets
+ * --font-size-base to 18px on body, so anything inheriting it would be clamped
+ * down and the setting quietly ignored. Each term covers a case the others
+ * miss - 1em follows the theme's body size, 1rem follows a browser default the
+ * visitor raised themselves, 16px catches Small themes and .text-sm controls:
+ *
+ *   normal (body 16)      16px      Large theme (body 18)   18px
+ *   Small theme (body 14) 16px      browser default 20px    20px
+ *
+ * The specificity that beats a utility class also beats a gallery's custom CSS
+ * (Theme -> Custom CSS), so `.input-themed { font-size: 20px }` lands at 16px
+ * on touch. That is unavoidable here rather than an oversight: nothing in CSS
+ * distinguishes a class that sets 14px from one that sets 20px, so a rule that
+ * loses to the second also loses to the first and fixes nothing. Overriding
+ * DOWNWARD is the point; upward is the cost. `font-size: 20px !important`
+ * still wins for anyone who wants it.
+ */
+@media (pointer: coarse) {
+  input:not([type="checkbox"]):not([type="radio"]),
+  select:not([hidden]),
+  textarea:not([hidden]) {
+    font-size: max(16px, 1em, 1rem);
+  }
+}


### PR DESCRIPTION
Stable twin of #1113. Closes #1105 on `stable`.

Same one-line-idea fix, verified **on this branch** rather than assumed from `main` — the twin is byte-identical because `frontend/src/index.css` has not diverged (both branches: 718 lines, same `@layer` boundaries at 20/131, 133/603, 605/718), so the cherry-pick applied clean.

## Why stable needs it

The bug is present here in full:

- `frontend/src/index.css:209` — `.input { @apply … text-sm }` (and `:219` for `.input-themed`)
- `frontend/src/pages/GalleryPage.tsx:446` — the same inverted `text-sm sm:text-base` on the password field

Stable is what most self-hosters run, and this hits every guest who opens a password-protected gallery on an iPhone — which is the common case, not an edge one. It also reaches every other form in the app: **312** `<Input>` usages, plus **212** raw `<input>`, **151** `<select>` and **34** `<textarea>` that never pass through the shared component.

Counts differ slightly from `main` (334/240/163/39 there) because stable predates some features, but the shape is the same — including exactly the same **24** selects and textareas carrying `text-sm`, which is the case the issue's suggested snippet would have missed on specificity.

## Verified on stable

Production build of this branch against a production build of `origin/stable`, measured computed `font-size` on real pages:

| | mobile 390×844 @DPR3 | desktop 1280×800 @DPR1 |
|---|---|---|
| gallery password | 14px → **16px** | 16px → 16px |
| admin login | 14px → **16px** | 14px → 14px |

Desktop density untouched. Frontend suite **104 passing** (stable's own suite, smaller than main's 174), build clean.

## Parity

Nothing extra is needed here — `main` carries exactly this commit and no more. If #1113 picks up review changes, they get cherry-picked here before either merges.
