### PR TITLE
docs(faces): link the face-recognition guidance from where people look (#1125)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -249,7 +249,8 @@ LOGS=./logs
 #
 # Face embeddings are biometric data (GDPR Art. 9 special category in the EU).
 # The photographer is the controller and needs a lawful basis for the people
-# in their photos — see docs/feature-face-recognition.md before enabling.
+# in their photos — read https://docs.picpeak.app/features/face-recognition
+# before enabling.
 #
 # NOT AVAILABLE ON THE ALL-IN-ONE IMAGE. The single-container build sets
 # PICPEAK_SINGLE_CONTAINER=true and the backend refuses to enable face

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Unlike expensive SaaS solutions, PicPeak gives you:
 
 **For photographers** — drag & drop upload, auto-expiring & password-protected galleries, automated emails, an analytics dashboard, custom themes, a public landing page, and a [Live Slideshow](https://docs.picpeak.app/features/live-slideshow) projector view that auto-picks-up new uploads during live events.
 
-**For clients** — clean mobile-optimized galleries, one-click bulk downloads, smart search, **People in this gallery** face grouping (opt-in per gallery, needs the optional [ML sidecar](ml/README.md)), optional guest uploads, and download protection (watermarking + right-click prevention).
+**For clients** — clean mobile-optimized galleries, one-click bulk downloads, smart search, **[People in this gallery](https://docs.picpeak.app/features/face-recognition)** face grouping (opt-in per gallery, needs the optional [ML sidecar](https://github.com/PicPeak/picpeak/blob/main/ml/README.md)), optional guest uploads, and download protection (watermarking + right-click prevention).
 
 **Technical** — Docker-ready, automatic thumbnail generation, external media reference mode, smart archiving of expired galleries, S3-compatible [storage backends](https://docs.picpeak.app/features/storage-backends), [webhooks](https://docs.picpeak.app/features/webhooks), and security-first defaults (JWT, rate limiting, CORS).
 
@@ -139,6 +139,7 @@ Full documentation lives at **[docs.picpeak.app](https://docs.picpeak.app)** —
 | ⚙️ Admin settings reference | [docs.picpeak.app/guides/admin-settings](https://docs.picpeak.app/guides/admin-settings) |
 | 🎯 Creating events | [docs.picpeak.app/guides/creating-events](https://docs.picpeak.app/guides/creating-events) |
 | 📽️ Live Slideshow | [docs.picpeak.app/features/live-slideshow](https://docs.picpeak.app/features/live-slideshow) |
+| 🙂 People in galleries (face grouping) | [docs.picpeak.app/features/face-recognition](https://docs.picpeak.app/features/face-recognition) |
 | 💾 Backup & Restore | [docs.picpeak.app/guides/backup-restore](https://docs.picpeak.app/guides/backup-restore) |
 | 🔌 API reference | [docs.picpeak.app/api](https://docs.picpeak.app/api) |
 | 🪝 Webhooks | [docs.picpeak.app/features/webhooks](https://docs.picpeak.app/features/webhooks) |

--- a/docs/single-container.md
+++ b/docs/single-container.md
@@ -148,4 +148,6 @@ docker inspect --format='{{.State.Health.Status}}' picpeak
   thumbnail and preview generation in one container would slow everything
   down rather than fail cleanly. The toggle in Settings → Features is
   disabled here and says so. Use the multi-container deployment if you want
-  it.
+  it — see
+  [People in galleries](https://docs.picpeak.app/features/face-recognition)
+  for what the feature does and what enabling it commits you to.

--- a/frontend/src/components/admin/FaceRecognitionCard.tsx
+++ b/frontend/src/components/admin/FaceRecognitionCard.tsx
@@ -19,7 +19,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'react-toastify';
-import { Users, RefreshCw, Trash2, AlertTriangle, ShieldCheck, SlidersHorizontal } from 'lucide-react';
+import { Users, RefreshCw, Trash2, AlertTriangle, ShieldCheck, SlidersHorizontal, ExternalLink } from 'lucide-react';
 import { PeopleManagerModal } from './PeopleManagerModal';
 
 import { Button, Card, Loading } from '../common';
@@ -276,6 +276,20 @@ export const FaceRecognitionCard: React.FC<FaceRecognitionCardProps> = ({ eventI
             defaultValue:
               'Detected faces are personal data, and in the EU they count as a special category. You are the controller for this gallery: make sure you have a lawful basis for the people in these photos before switching this on. Nothing leaves your server — detection runs in your own container.',
           })}
+          {/* The guidance is reachable from the one screen where someone is
+              about to start Art. 9 processing, rather than only from the
+              README they have not opened (#1125). Inside the consent callout
+              on purpose: next to the obligation, not filed under help. */}
+          {' '}
+          <a
+            href="https://docs.picpeak.app/features/face-recognition"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline font-medium whitespace-nowrap"
+          >
+            {t('admin.faces.consentLearnMore', { defaultValue: 'Read the guidance' })}
+            <ExternalLink size={12} className="inline-block ml-0.5 -mt-0.5" aria-hidden />
+          </a>
         </p>
       </div>
 

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -3158,6 +3158,7 @@
       "title": "Personen in dieser Galerie",
       "subtitle": "Fotos nach den abgebildeten Personen gruppieren, damit Gäste ihre eigenen finden und herunterladen können.",
       "consentNotice": "Erkannte Gesichter sind personenbezogene Daten und gelten in der EU als besondere Kategorie. Sie sind für diese Galerie verantwortlich: Stellen Sie sicher, dass Sie eine Rechtsgrundlage für die abgebildeten Personen haben, bevor Sie dies aktivieren. Nichts verlässt Ihren Server — die Erkennung läuft in Ihrem eigenen Container.",
+      "consentLearnMore": "Hinweise lesen",
       "enable": "Personen in dieser Galerie erkennen",
       "enableHint": "Vorhandene Fotos werden im Hintergrund durchsucht. Gesichter und ihre numerischen Signaturen werden in Ihrer Datenbank gespeichert; sie sind niemals in Backups oder Exporten enthalten.",
       "visible": "Personenleiste für Gäste anzeigen",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -2730,6 +2730,7 @@
       "title": "People in this gallery",
       "subtitle": "Group photos by the people in them, so guests can find and download their own.",
       "consentNotice": "Detected faces are personal data, and in the EU they count as a special category. You are the controller for this gallery: make sure you have a lawful basis for the people in these photos before switching this on. Nothing leaves your server — detection runs in your own container.",
+      "consentLearnMore": "Read the guidance",
       "enable": "Detect people in this gallery",
       "enableHint": "Existing photos are scanned in the background. Faces and their numeric signatures are stored in your database; they are never included in backups or exports.",
       "visible": "Show the people bar to guests",

--- a/ml/README.md
+++ b/ml/README.md
@@ -1,5 +1,10 @@
 # picpeak-ml
 
+> **Looking for how to use the feature?** →
+> [docs.picpeak.app/features/face-recognition](https://docs.picpeak.app/features/face-recognition)
+> covers enabling it, the per-gallery toggle, consent and what guests see.
+> This document is the sidecar's HTTP contract and deployment notes.
+
 Optional face-detection sidecar for PicPeak (#1074). Detects faces in one
 image and returns a bounding box, five landmarks, quality signals and a
 512-d embedding per face.


### PR DESCRIPTION
Closes #1125.

All six pointers, verified against the tracked tree rather than my working copy — which
matters, because the two differ here in a way that changes the fix.

## The `.env.example` path: don't "fix" it by creating the file

The issue is right that `docs/feature-face-recognition.md` does not exist, and right
that `docs/` holds only `migration-to-org.md`, `single-container.md` and the
screenshots. Worth adding *why*, so nobody closes this by writing the file:

```
$ git check-ignore -v docs/feature-external-media.md
.gitignore:89:docs/feature-*.md    docs/feature-external-media.md

$ git ls-files docs/ | wc -l
7
```

`docs/feature-*.md` is **gitignored**. My checkout has eight such files sitting there as
local scaffolding — invisible to anyone who clones. So the reference could never have
resolved for a reader, and creating the file would produce a doc git silently drops. The
absolute URL is the only thing that works.

I also checked whether this was one instance of a wider pattern:

```
$ git grep -nE "docs/(feature-|test-|ENVIRONMENT_VARIABLES|DATABASE_SCHEMA|...)" -- . ':(exclude).gitignore'
.env.example:252: ...
```

One hit — the one reported. No cleanup hiding behind it.

## What changed

| # | Where | |
|---|---|---|
| 1 | `.env.example` | dead path → the docs URL, inside the Art. 9 warning |
| 2 | `README.md` | feature name → docs page; sidecar link kept but made **absolute**, so it survives on the GHCR package page and mirrors |
| 3 | `README.md` | new row in the documentation table |
| 4 | `docs/single-container.md` | the "No face recognition" bullet now says where to read what you would be getting |
| 5 | `ml/README.md` | pointer at the top, so the one face doc the README reached is no longer a dead end in the other direction |
| 6 | `FaceRecognitionCard.tsx` | "Read the guidance" in the consent callout, `en` + `de` |

## On item 6

The checklist marks it optional but the acceptance criteria requires reaching the page
"from the admin card", so I took it as in scope.

Placed **inline at the end of the consent sentence**, not as a separate help link — that
callout is the one screen where someone is about to start Art. 9 processing, and the
link belongs next to the obligation rather than filed under help. `target="_blank"` with
`rel="noopener noreferrer"`.

Screenshot in the first comment.

## Verified

- Both URLs added return **200** (`docs.picpeak.app/features/face-recognition`,
  the absolute `ml/README.md`), checked live by extracting every `https://` added in the
  diff and curling it.
- No tracked file still references a gitignored `docs/` path.
- The rendered link carries the right `href`, `target` and `rel`, read back from the live
  DOM rather than the source.
- Frontend: `tsc` clean, ESLint clean, 198 tests passing, build clean.
- Locale files: one key each, no reformatting of the surrounding JSON.

## Note on merge order

Item 6 touches the consent callout in `FaceRecognitionCard.tsx`, which #1126 also edits
(adding `dark:` variants to that same element). Both are small and in different parts of
the block, so whichever lands second should merge cleanly or need a one-line resolution —
flagging it rather than having you discover it.
