### PR TITLE
feat(gallery): folders that contain photos instead of filtering them (#1160)

### DIFF
--- a/backend/__tests__/routes/galleryFolderCategories.test.js
+++ b/backend/__tests__/routes/galleryFolderCategories.test.js
@@ -122,6 +122,17 @@ describe('folder categories in the gallery payload (#1160)', () => {
     expect(found.is_folder).toBe(false);
   });
 
+  test('a form-encoded is_folder="false" stays a filter (not !!-coerced to true)', async () => {
+    // express-validator's isBoolean() accepts the STRINGS "false"/"0", and
+    // `!!'false'` is true — so `!!` would flip a caller asking for a filter into
+    // a folder, silently pulling their photos out of the root grid.
+    const { parseBooleanInput } = require('../../src/utils/parsers');
+    expect(parseBooleanInput('false', true)).toBe(false);
+    expect(parseBooleanInput('0', true)).toBe(false);
+    expect(parseBooleanInput('true', false)).toBe(true);
+    expect(parseBooleanInput(undefined, false)).toBe(false);
+  });
+
   test('folders are not an access boundary — the photo is still in the payload', async () => {
     // Containment is a rendering rule, not authorisation. If this ever starts
     // failing, folders have silently become a security feature they are not.

--- a/backend/__tests__/routes/galleryFolderCategories.test.js
+++ b/backend/__tests__/routes/galleryFolderCategories.test.js
@@ -1,0 +1,131 @@
+/**
+ * Gallery folders reach the guest payload (#1160).
+ *
+ * `is_folder` is what tells the frontend a category CONTAINS its photos rather
+ * than filtering them. The category block in gallery.js selects an explicit
+ * column list (not `c.*`), so a new column that isn't added there is silently
+ * dropped — every folder would render as a plain filter and the root grid would
+ * still show the foldered photos. These assertions pin that contract.
+ *
+ * Also pins the SQLite side: the engine stores 0/1, so a strict `=== true`
+ * consumer would see every folder as a filter (the #1028 class of bug).
+ */
+
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+process.env.NODE_ENV = 'test';
+process.env.TEST_DATABASE_PATH = path.join(
+  fs.mkdtempSync(path.join(os.tmpdir(), 'picpeak-folders-')), 'db.sqlite',
+);
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'folders-test-secret';
+process.env.STORAGE_PATH = fs.mkdtempSync(path.join(os.tmpdir(), 'picpeak-folders-storage-'));
+
+const request = require('supertest');
+const express = require('express');
+const cookieParser = require('cookie-parser');
+const { bootCrmDb, seedMinimal } = require('../integration/helpers/crmDb');
+
+const SLUG = 'folders-gallery';
+
+describe('folder categories in the gallery payload (#1160)', () => {
+  let db; let cleanup; let app; let eventId; let folderId; let filterId;
+
+  async function getCategories() {
+    const res = await request(app).get(`/api/gallery/${SLUG}/photos`);
+    expect(res.status).toBe(200);
+    return res.body.categories;
+  }
+
+  async function addPhoto(filename, categoryId) {
+    const row = await db('photos').insert({
+      event_id: eventId,
+      filename,
+      path: `${SLUG}/${filename}`,
+      type: 'individual',
+      category_id: categoryId,
+      uploaded_at: new Date().toISOString(),
+    }).returning('id');
+    return row[0]?.id ?? row[0];
+  }
+
+  beforeAll(async () => {
+    ({ db, cleanup } = await bootCrmDb());
+    await seedMinimal(db);
+
+    const ev = await db('events').insert({
+      slug: SLUG,
+      event_type: 'wedding',
+      event_name: 'Folders',
+      event_date: '2026-08-01',
+      host_email: 'h@example.com',
+      admin_email: 'a@example.com',
+      password_hash: 'x',
+      share_link: `/gallery/${SLUG}/s`,
+      share_token: 'folders-share',
+      expires_at: new Date(Date.now() + 7 * 864e5).toISOString(),
+      is_active: 1,
+      is_archived: 0,
+      is_draft: 0,
+      require_password: 0,
+      created_at: new Date().toISOString(),
+    }).returning('id');
+    eventId = ev[0]?.id ?? ev[0];
+
+    const folder = await db('photo_categories').insert({
+      name: 'Selects', slug: 'selects', is_global: 0, event_id: eventId, is_folder: 1,
+    }).returning('id');
+    folderId = folder[0]?.id ?? folder[0];
+
+    const filter = await db('photo_categories').insert({
+      name: 'Ceremony', slug: 'ceremony', is_global: 0, event_id: eventId, is_folder: 0,
+    }).returning('id');
+    filterId = filter[0]?.id ?? filter[0];
+
+    await addPhoto('in-folder.jpg', folderId);
+    await addPhoto('in-filter.jpg', filterId);
+
+    app = express();
+    app.use(express.json());
+    app.use(cookieParser());
+    app.use('/api/gallery', require('../../src/routes/gallery'));
+  }, 120000);
+
+  afterAll(async () => { if (cleanup) await cleanup(); });
+
+  test('the engine under test stores booleans as 0/1', async () => {
+    expect(['sqlite3', 'better-sqlite3']).toContain(db.client.config.client);
+    const row = await db('photo_categories').where('id', folderId).first('is_folder');
+    expect(row.is_folder).toBe(1);
+  });
+
+  test('a folder category is reported with is_folder true', async () => {
+    const folder = (await getCategories()).find((c) => c.id === folderId);
+    expect(folder).toBeDefined();
+    expect(folder.is_folder).toBe(true);
+  });
+
+  test('a plain category keeps filtering — is_folder is false, not undefined', async () => {
+    const filter = (await getCategories()).find((c) => c.id === filterId);
+    expect(filter.is_folder).toBe(false);
+  });
+
+  test('a category predating the column defaults to filtering, never folder', async () => {
+    const legacy = await db('photo_categories').insert({
+      name: 'Legacy', slug: 'legacy', is_global: 0, event_id: eventId,
+    }).returning('id');
+    const legacyId = legacy[0]?.id ?? legacy[0];
+    await addPhoto('legacy.jpg', legacyId);
+
+    const found = (await getCategories()).find((c) => c.id === legacyId);
+    expect(found.is_folder).toBe(false);
+  });
+
+  test('folders are not an access boundary — the photo is still in the payload', async () => {
+    // Containment is a rendering rule, not authorisation. If this ever starts
+    // failing, folders have silently become a security feature they are not.
+    const res = await request(app).get(`/api/gallery/${SLUG}/photos`);
+    expect(res.body.photos.some((p) => p.filename === 'in-folder.jpg')).toBe(true);
+  });
+});

--- a/backend/migrations/core/185_add_category_is_folder.js
+++ b/backend/migrations/core/185_add_category_is_folder.js
@@ -1,0 +1,39 @@
+/**
+ * Migration 185: gallery folders (#1160).
+ *
+ * Adds `is_folder` to `photo_categories`. A category has always been a FILTER —
+ * every photo stays in the main grid and picking a category narrows it. A folder
+ * is a CONTAINER: its photos leave the root grid entirely and are only shown once
+ * the guest clicks into the folder.
+ *
+ * One column is enough because the surrounding features already built the rest:
+ *   - `hero_photo_id` (#163, migration 066)      → the folder cover image
+ *   - `allow_downloads` (#640, migration 135)    → per-folder download rules
+ *   - `display_order` + `event_category_order`   → folder ordering (#782, 159/160)
+ *   - `photos.category_id` is single-valued      → a photo lives in one folder
+ *
+ * Deliberately NOT added: `parent_id`. The request (D#1086) is "root → Selects
+ * folder", which is depth one, i.e. plain containment. Folders-inside-folders
+ * stays out until someone actually asks for it.
+ *
+ * No backfill: `false` IS the preserved behaviour, so every existing category
+ * keeps filtering exactly as before and folders are opt-in per category.
+ *
+ * Additive + hasColumn-guarded, matching migration 159.
+ */
+exports.up = async function (knex) {
+  if (!(await knex.schema.hasTable('photo_categories'))) return;
+
+  if (!(await knex.schema.hasColumn('photo_categories', 'is_folder'))) {
+    await knex.schema.alterTable('photo_categories', (t) => {
+      t.boolean('is_folder').notNullable().defaultTo(false);
+    });
+  }
+};
+
+exports.down = async function (knex) {
+  if (!(await knex.schema.hasTable('photo_categories'))) return;
+  if (await knex.schema.hasColumn('photo_categories', 'is_folder')) {
+    await knex.schema.alterTable('photo_categories', (t) => t.dropColumn('is_folder'));
+  }
+};

--- a/backend/src/routes/adminCategories.js
+++ b/backend/src/routes/adminCategories.js
@@ -42,7 +42,8 @@ router.post('/', adminAuth, requirePermission('settings.edit'), [
   body('name').notEmpty().withMessage('Category name is required'),
   body('slug').optional(),
   body('is_global').optional().isBoolean(),
-  body('event_id').optional().isInt()
+  body('event_id').optional().isInt(),
+  body('is_folder').optional().isBoolean()
 ], async (req, res) => {
   try {
     const errors = validationResult(req);
@@ -50,7 +51,7 @@ router.post('/', adminAuth, requirePermission('settings.edit'), [
       return res.status(400).json({ errors: errors.array() });
     }
     
-    const { name, slug, is_global = true, event_id = null } = req.body;
+    const { name, slug, is_global = true, event_id = null, is_folder = false } = req.body;
     
     // Generate slug if not provided
     const categorySlug = slug || name
@@ -97,7 +98,9 @@ router.post('/', adminAuth, requirePermission('settings.edit'), [
       slug: categorySlug,
       is_global,
       event_id: is_global ? null : event_id,
-      display_order: nextOrder
+      display_order: nextOrder,
+      // #1160: a folder contains its photos instead of filtering them.
+      is_folder: formatBoolean(!!is_folder)
     }).returning('id');
     
     const categoryId = insertResult[0]?.id || insertResult[0];
@@ -125,7 +128,8 @@ router.put('/:id', adminAuth, requirePermission('settings.edit'), [
     if (value === null || value === undefined) return true;
     return Number.isInteger(Number(value));
   }).withMessage('hero_photo_id must be an integer or null'),
-  body('allow_downloads').optional().isBoolean()
+  body('allow_downloads').optional().isBoolean(),
+  body('is_folder').optional().isBoolean()
 ], async (req, res) => {
   try {
     const errors = validationResult(req);
@@ -170,6 +174,13 @@ router.put('/:id', adminAuth, requirePermission('settings.edit'), [
     // Per-category download permission (#640). AND with event-level allow_downloads.
     if (Object.prototype.hasOwnProperty.call(req.body, 'allow_downloads')) {
       updateData.allow_downloads = req.body.allow_downloads;
+    }
+
+    // Folder vs filter (#1160). Flipping this moves the category's photos out of
+    // (or back into) the root grid with no re-upload — it only changes where they
+    // render, never which photos exist or who may reach them.
+    if (Object.prototype.hasOwnProperty.call(req.body, 'is_folder')) {
+      updateData.is_folder = formatBoolean(!!req.body.is_folder);
     }
 
     await db('photo_categories')

--- a/backend/src/routes/adminCategories.js
+++ b/backend/src/routes/adminCategories.js
@@ -2,6 +2,7 @@ const express = require('express');
 const { body, validationResult } = require('express-validator');
 const { db, logActivity } = require('../database/db');
 const { formatBoolean } = require('../utils/dbCompat');
+const { parseBooleanInput } = require('../utils/parsers');
 const { adminAuth } = require('../middleware/auth');
 const { requirePermission } = require('../middleware/permissions');
 const { requireEventOwnership } = require('../middleware/ownership');
@@ -100,7 +101,10 @@ router.post('/', adminAuth, requirePermission('settings.edit'), [
       event_id: is_global ? null : event_id,
       display_order: nextOrder,
       // #1160: a folder contains its photos instead of filtering them.
-      is_folder: formatBoolean(!!is_folder)
+      // parseBooleanInput, not `!!`: express-validator's isBoolean() accepts the
+      // STRINGS "false" and "0", and `!!'false'` is true — a form-encoded caller
+      // asking for a filter would silently get a folder.
+      is_folder: formatBoolean(parseBooleanInput(is_folder, false))
     }).returning('id');
     
     const categoryId = insertResult[0]?.id || insertResult[0];
@@ -180,7 +184,7 @@ router.put('/:id', adminAuth, requirePermission('settings.edit'), [
     // (or back into) the root grid with no re-upload — it only changes where they
     // render, never which photos exist or who may reach them.
     if (Object.prototype.hasOwnProperty.call(req.body, 'is_folder')) {
-      updateData.is_folder = formatBoolean(!!req.body.is_folder);
+      updateData.is_folder = formatBoolean(parseBooleanInput(req.body.is_folder, false));
     }
 
     await db('photo_categories')

--- a/backend/src/routes/adminEvents/crud.js
+++ b/backend/src/routes/adminEvents/crud.js
@@ -1207,7 +1207,7 @@ module.exports = (router) => {
         const sourceCategories = await db('photo_categories')
           .where({ event_id: id })
           .where(function () { this.whereNull('is_global').orWhere('is_global', formatBoolean(false)); })
-          .select('name', 'slug', 'is_global');
+          .select('name', 'slug', 'is_global', 'is_folder');
         if (sourceCategories.length > 0) {
           await db('photo_categories').insert(
             sourceCategories.map((c) => ({
@@ -1215,6 +1215,10 @@ module.exports = (router) => {
               name: c.name,
               slug: c.slug,
               is_global: formatBoolean(false),
+              // #1160: carry folder-ness across. Without this the clone silently
+              // falls back to the column default and a duplicated gallery turns
+              // every folder back into a filter.
+              is_folder: formatBoolean(parseBooleanInput(c.is_folder, false)),
             })),
           );
         }

--- a/backend/src/routes/gallery.js
+++ b/backend/src/routes/gallery.js
@@ -1053,7 +1053,7 @@ router.get('/:slug/photos', verifyGalleryAccess, resolveGuest, async (req, res) 
       // default, else name — restricted to categories that have photos.
       const categoryDetails = await getEventCategoriesOrdered(req.event.id, {
         onlyIds: usedCategoryIds,
-        select: ['c.id', 'c.name', 'c.slug', 'c.is_global', 'c.hero_photo_id', 'c.allow_downloads'],
+        select: ['c.id', 'c.name', 'c.slug', 'c.is_global', 'c.hero_photo_id', 'c.allow_downloads', 'c.is_folder'],
       });
 
       categories = categoryDetails.map(cat => ({
@@ -1065,7 +1065,11 @@ router.get('/:slug/photos', verifyGalleryAccess, resolveGuest, async (req, res) 
         // Per-category download flag (#640). false explicitly disables; the
         // gallery hides the download button. Defaults true so categories
         // created before migration 135 keep working.
-        allow_downloads: parseBooleanInput(cat.allow_downloads, true)
+        allow_downloads: parseBooleanInput(cat.allow_downloads, true),
+        // Folder vs filter (#1160). true = the category CONTAINS its photos:
+        // they leave the root grid and only render inside the folder. Defaults
+        // false so categories predating migration 185 keep filtering.
+        is_folder: parseBooleanInput(cat.is_folder, false)
       }));
     }
 

--- a/frontend/src/components/admin/AdminPhotoGrid.tsx
+++ b/frontend/src/components/admin/AdminPhotoGrid.tsx
@@ -18,6 +18,8 @@ import { BulkCategoryModal } from './BulkCategoryModal';
 interface CategoryOption {
   id: number;
   name: string;
+  // #1160: folders are categories too; the move dialog labels them.
+  is_folder?: boolean;
 }
 
 interface AdminPhotoGridProps {

--- a/frontend/src/components/admin/BulkCategoryModal.tsx
+++ b/frontend/src/components/admin/BulkCategoryModal.tsx
@@ -6,6 +6,10 @@ import { Button, Card } from '../common';
 interface CategoryOption {
   id: number;
   name: string;
+  // #1160: moving photos into a folder takes them OUT of the main grid, which is
+  // a materially different outcome from tagging them with a filter category.
+  // The option is labelled so the admin knows which one they picked.
+  is_folder?: boolean;
 }
 
 interface BulkCategoryModalProps {
@@ -70,7 +74,9 @@ export const BulkCategoryModal: React.FC<BulkCategoryModalProps> = ({
               <option value="">{t('photos.uncategorized', 'Uncategorized')}</option>
               {categories.map((category) => (
                 <option key={category.id} value={category.id}>
-                  {category.name}
+                  {category.is_folder
+                    ? t('photos.folderOption', '{{name}} (folder — hidden from the main grid)', { name: category.name })
+                    : category.name}
                 </option>
               ))}
             </select>

--- a/frontend/src/components/admin/EventCategoryManager.tsx
+++ b/frontend/src/components/admin/EventCategoryManager.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { Plus, X, Loader2, Image as ImageIcon, Check, Download, DownloadCloud, ArrowUp, ArrowDown, RotateCcw } from 'lucide-react';
+import { Plus, X, Loader2, Image as ImageIcon, Check, Download, DownloadCloud, ArrowUp, ArrowDown, RotateCcw, Folder, FolderOpen } from 'lucide-react';
 import { categoriesService, type PhotoCategory } from '../../services/categories.service';
 import { photosService } from '../../services/photos.service';
 import { Button, Card, AuthenticatedImage } from '../common';
@@ -86,6 +86,20 @@ export const EventCategoryManager: React.FC<EventCategoryManagerProps> = ({ even
         ? t('categories.downloadsEnabled', 'Downloads enabled for this category')
         : t('categories.downloadsDisabled', 'Downloads disabled for this category'),
     errorMessage: t('categories.failedToToggleDownloads', 'Failed to update download permission'),
+  });
+
+  // Folder vs filter (#1160). Flipping this moves the category's photos out of
+  // the root grid (or back into it) with no re-upload — it changes where they
+  // render, never which photos exist or who can reach them.
+  const folderToggleMutation = useMutationWithToast({
+    mutationFn: ({ category, isFolder }: { category: PhotoCategory; isFolder: boolean }) =>
+      categoriesService.updateCategory(category.id, category.name, { is_folder: isFolder }),
+    invalidateKeys: [['event-categories', eventId]],
+    successMessage: (_data, variables) =>
+      variables.isFolder
+        ? t('categories.folderEnabled', 'Photos in this category now sit inside a folder')
+        : t('categories.folderDisabled', 'This category filters the gallery again'),
+    errorMessage: t('categories.failedToToggleFolder', 'Failed to update folder setting'),
   });
 
   // Per-event order override (#782). Sends the full ordered id list; the backend
@@ -283,6 +297,31 @@ export const EventCategoryManager: React.FC<EventCategoryManagerProps> = ({ even
                       only. Global categories are managed in Settings. */}
                   {!category.is_global && (
                     <>
+                      <button
+                        onClick={() => folderToggleMutation.mutate({
+                          category,
+                          isFolder: !category.is_folder,
+                        })}
+                        className={`p-1 transition-colors ${
+                          category.is_folder
+                            ? 'text-primary-600 dark:text-primary-400 hover:text-neutral-400'
+                            : 'text-neutral-400 dark:text-neutral-500 hover:text-primary-600 dark:hover:text-primary-400'
+                        }`}
+                        title={
+                          category.is_folder
+                            ? t('categories.disableFolderTitle', 'Folder: these photos are hidden from the main grid and shown only inside the folder. Click to make it a filter again.')
+                            : t('categories.enableFolderTitle', 'Filter: these photos stay in the main grid. Click to turn it into a folder — hides them from the grid, does NOT restrict access.')
+                        }
+                        disabled={folderToggleMutation.isPending}
+                      >
+                        {folderToggleMutation.isPending ? (
+                          <Loader2 className="w-3 h-3 animate-spin" />
+                        ) : category.is_folder ? (
+                          <FolderOpen className="w-3 h-3" />
+                        ) : (
+                          <Folder className="w-3 h-3" />
+                        )}
+                      </button>
                       <button
                         onClick={() => downloadToggleMutation.mutate({
                           category,

--- a/frontend/src/components/admin/EventCategoryManager.tsx
+++ b/frontend/src/components/admin/EventCategoryManager.tsx
@@ -94,7 +94,10 @@ export const EventCategoryManager: React.FC<EventCategoryManagerProps> = ({ even
   const folderToggleMutation = useMutationWithToast({
     mutationFn: ({ category, isFolder }: { category: PhotoCategory; isFolder: boolean }) =>
       categoriesService.updateCategory(category.id, category.name, { is_folder: isFolder }),
-    invalidateKeys: [['event-categories', eventId]],
+    // EventDetailsPage caches the same rows under a DIFFERENT key and feeds them
+    // to the Photos tab's move dialog, so invalidating only this one left that
+    // dialog labelling a fresh folder as a plain category (#1160).
+    invalidateKeys: [['event-categories', eventId], ['admin-event-categories', String(eventId)]],
     successMessage: (_data, variables) =>
       variables.isFolder
         ? t('categories.folderEnabled', 'Photos in this category now sit inside a folder')

--- a/frontend/src/components/gallery/GalleryFolderTiles.tsx
+++ b/frontend/src/components/gallery/GalleryFolderTiles.tsx
@@ -15,6 +15,17 @@ import { folderKey, type FolderTile } from './folders';
 interface GalleryFolderTilesProps {
   tiles: FolderTile[];
   onOpen: (slug: string) => void;
+  /** Gallery slug — the cover is an authenticated image like any other photo. */
+  slug?: string;
+  /**
+   * Image-protection settings (#1160). A folder cover is a real gallery photo,
+   * so a gallery configured for canvas rendering or maximum protection must not
+   * get an ordinary blob-backed <img> here just because it is a cover.
+   */
+  protectionLevel?: 'basic' | 'standard' | 'enhanced' | 'maximum';
+  useEnhancedProtection?: boolean;
+  useCanvasRendering?: boolean;
+  allowDownloads?: boolean;
   /**
    * Compact chip row instead of cover cards. Used by the full-bleed layouts
    * (Premium, Story), where a block of cards above the hero would break the
@@ -24,7 +35,16 @@ interface GalleryFolderTilesProps {
   compact?: boolean;
 }
 
-export const GalleryFolderTiles: React.FC<GalleryFolderTilesProps> = ({ tiles, onOpen, compact = false }) => {
+export const GalleryFolderTiles: React.FC<GalleryFolderTilesProps> = ({
+  tiles,
+  onOpen,
+  compact = false,
+  slug,
+  protectionLevel,
+  useEnhancedProtection,
+  useCanvasRendering,
+  allowDownloads = true,
+}) => {
   const { t } = useTranslation();
 
   if (tiles.length === 0) return null;
@@ -74,6 +94,15 @@ export const GalleryFolderTiles: React.FC<GalleryFolderTilesProps> = ({ tiles, o
                   src={coverPhoto.thumbnail_url}
                   alt=""
                   className="w-full h-full object-cover group-hover:scale-[1.02] transition-transform"
+                  isGallery
+                  slug={slug}
+                  photoId={coverPhoto.id}
+                  requiresToken={coverPhoto.requires_token}
+                  secureUrlTemplate={coverPhoto.secure_url_template}
+                  protectFromDownload={!allowDownloads || useEnhancedProtection}
+                  protectionLevel={protectionLevel}
+                  useEnhancedProtection={useEnhancedProtection}
+                  useCanvasRendering={useCanvasRendering}
                 />
               ) : (
                 <div className="w-full h-full flex items-center justify-center">

--- a/frontend/src/components/gallery/GalleryFolderTiles.tsx
+++ b/frontend/src/components/gallery/GalleryFolderTiles.tsx
@@ -102,7 +102,11 @@ export const GalleryFolderTiles: React.FC<GalleryFolderTilesProps> = ({
                   protectFromDownload={!allowDownloads || useEnhancedProtection}
                   protectionLevel={protectionLevel}
                   useEnhancedProtection={useEnhancedProtection}
-                  useCanvasRendering={useCanvasRendering}
+                  // Same rule as every other gallery image path: maximum
+                  // protection implies canvas rendering even when the separate
+                  // toggle is off (its default), otherwise a cover silently
+                  // falls back to a blob-backed <img>.
+                  useCanvasRendering={useCanvasRendering || protectionLevel === 'maximum'}
                 />
               ) : (
                 <div className="w-full h-full flex items-center justify-center">

--- a/frontend/src/components/gallery/GalleryFolderTiles.tsx
+++ b/frontend/src/components/gallery/GalleryFolderTiles.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from 'react-i18next';
 import { Folder } from 'lucide-react';
 
 import { AuthenticatedImage } from '../common';
-import type { FolderTile } from './folders';
+import { folderKey, type FolderTile } from './folders';
 
 interface GalleryFolderTilesProps {
   tiles: FolderTile[];
@@ -37,7 +37,7 @@ export const GalleryFolderTiles: React.FC<GalleryFolderTilesProps> = ({ tiles, o
           <button
             key={category.id}
             type="button"
-            onClick={() => onOpen(category.slug)}
+            onClick={() => onOpen(folderKey(category))}
             aria-label={t('gallery.openFolder', 'Open folder {{name}}', { name: category.name })}
             className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full border border-surface bg-surface text-sm hover:shadow-sm transition-shadow focus:outline-none focus:ring-2 focus:ring-primary-500"
             style={{ color: 'var(--color-text)' }}
@@ -64,7 +64,7 @@ export const GalleryFolderTiles: React.FC<GalleryFolderTilesProps> = ({ tiles, o
           <button
             key={category.id}
             type="button"
-            onClick={() => onOpen(category.slug)}
+            onClick={() => onOpen(folderKey(category))}
             aria-label={t('gallery.openFolder', 'Open folder {{name}}', { name: category.name })}
             className="group text-left rounded-lg overflow-hidden border border-surface bg-surface hover:shadow-md transition-all focus:outline-none focus:ring-2 focus:ring-primary-500"
           >

--- a/frontend/src/components/gallery/GalleryFolderTiles.tsx
+++ b/frontend/src/components/gallery/GalleryFolderTiles.tsx
@@ -1,0 +1,71 @@
+/**
+ * Folder tiles for the gallery root (#1160).
+ *
+ * Rendered above the photo grid rather than inside any one layout, so all eight
+ * gallery layouts (Grid, Masonry, Justified, Mosaic, Timeline, Carousel, Story,
+ * Premium) get folders without eight implementations.
+ */
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Folder } from 'lucide-react';
+
+import { AuthenticatedImage } from '../common';
+import type { FolderTile } from './folders';
+
+interface GalleryFolderTilesProps {
+  tiles: FolderTile[];
+  onOpen: (slug: string) => void;
+}
+
+export const GalleryFolderTiles: React.FC<GalleryFolderTilesProps> = ({ tiles, onOpen }) => {
+  const { t } = useTranslation();
+
+  if (tiles.length === 0) return null;
+
+  return (
+    <div className="mb-8">
+      {/* Theme tokens, not Tailwind `dark:` — the gallery is themed through CSS
+          variables per event, so a hardcoded light card renders white on a dark
+          gallery (the #1106 class of bug). */}
+      <h2 className="text-sm font-medium text-muted-theme mb-3">
+        {t('gallery.folders', 'Folders')}
+      </h2>
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
+        {tiles.map(({ category, count, coverPhoto }) => (
+          <button
+            key={category.id}
+            type="button"
+            onClick={() => onOpen(category.slug)}
+            aria-label={t('gallery.openFolder', 'Open folder {{name}}', { name: category.name })}
+            className="group text-left rounded-lg overflow-hidden border border-surface bg-surface hover:shadow-md transition-all focus:outline-none focus:ring-2 focus:ring-primary-500"
+          >
+            <div className="aspect-[4/3] relative" style={{ backgroundColor: 'var(--color-background)' }}>
+              {coverPhoto?.thumbnail_url ? (
+                <AuthenticatedImage
+                  src={coverPhoto.thumbnail_url}
+                  alt=""
+                  className="w-full h-full object-cover group-hover:scale-[1.02] transition-transform"
+                />
+              ) : (
+                <div className="w-full h-full flex items-center justify-center">
+                  <Folder className="w-8 h-8 text-muted-theme" />
+                </div>
+              )}
+            </div>
+            <div className="p-3">
+              <div className="flex items-center gap-2">
+                <Folder className="w-4 h-4 text-muted-theme shrink-0" />
+                <span className="font-medium truncate" style={{ color: 'var(--color-text)' }}>
+                  {category.name}
+                </span>
+              </div>
+              <p className="mt-1 text-sm text-muted-theme">
+                {t('gallery.folderPhotoCount', '{{count}} photos', { count })}
+              </p>
+            </div>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/gallery/GalleryFolderTiles.tsx
+++ b/frontend/src/components/gallery/GalleryFolderTiles.tsx
@@ -15,12 +15,41 @@ import type { FolderTile } from './folders';
 interface GalleryFolderTilesProps {
   tiles: FolderTile[];
   onOpen: (slug: string) => void;
+  /**
+   * Compact chip row instead of cover cards. Used by the full-bleed layouts
+   * (Premium, Story), where a block of cards above the hero would break the
+   * edge-to-edge opening those layouts exist for — but where the folders still
+   * have to be reachable, since containment applies there too.
+   */
+  compact?: boolean;
 }
 
-export const GalleryFolderTiles: React.FC<GalleryFolderTilesProps> = ({ tiles, onOpen }) => {
+export const GalleryFolderTiles: React.FC<GalleryFolderTilesProps> = ({ tiles, onOpen, compact = false }) => {
   const { t } = useTranslation();
 
   if (tiles.length === 0) return null;
+
+  if (compact) {
+    return (
+      <div className="flex items-center gap-2 flex-wrap">
+        <span className="text-sm text-muted-theme">{t('gallery.folders', 'Folders')}</span>
+        {tiles.map(({ category, count }) => (
+          <button
+            key={category.id}
+            type="button"
+            onClick={() => onOpen(category.slug)}
+            aria-label={t('gallery.openFolder', 'Open folder {{name}}', { name: category.name })}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full border border-surface bg-surface text-sm hover:shadow-sm transition-shadow focus:outline-none focus:ring-2 focus:ring-primary-500"
+            style={{ color: 'var(--color-text)' }}
+          >
+            <Folder className="w-3.5 h-3.5 text-muted-theme" />
+            <span className="font-medium">{category.name}</span>
+            <span className="text-muted-theme">{count}</span>
+          </button>
+        ))}
+      </div>
+    );
+  }
 
   return (
     <div className="mb-8">

--- a/frontend/src/components/gallery/GallerySidebar.tsx
+++ b/frontend/src/components/gallery/GallerySidebar.tsx
@@ -29,6 +29,13 @@ interface GallerySidebarProps {
   allowDownloads?: boolean;
   photoCounts?: Record<number | string, number>;
   totalPhotos: number;
+  /**
+   * Event-wide count for the Download All control (#1160). `totalPhotos` is the
+   * current folder scope and drives the category list; Download All fetches the
+   * whole event, so labelling it from the scoped count would understate it and
+   * disable it entirely on a folder-only root.
+   */
+  downloadAllTotal?: number;
   isMobile: boolean;
   galleryLayout?: string;
   allowUploads?: boolean;
@@ -71,6 +78,7 @@ export const GallerySidebar: React.FC<GallerySidebarProps> = ({
   allowDownloads = true,
   photoCounts = {},
   totalPhotos,
+  downloadAllTotal,
   isMobile,
   galleryLayout,
   allowUploads,
@@ -205,10 +213,10 @@ export const GallerySidebar: React.FC<GallerySidebarProps> = ({
                   size="sm"
                   leftIcon={<Download className="w-4 h-4" />}
                   onClick={onDownloadAll}
-                  disabled={isDownloading || totalPhotos === 0}
+                  disabled={isDownloading || (downloadAllTotal ?? totalPhotos) === 0}
                   className="gallery-btn gallery-btn-download w-full"
                 >
-                  {t('gallery.downloadAll')} ({totalPhotos})
+                  {t('gallery.downloadAll')} ({downloadAllTotal ?? totalPhotos})
                 </Button>
 
                 <Button

--- a/frontend/src/components/gallery/GalleryView.tsx
+++ b/frontend/src/components/gallery/GalleryView.tsx
@@ -1167,9 +1167,14 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
           leftIcon={<Download className="w-4 h-4" />}
           className="ml-auto"
         >
-          {t('gallery.downloadFolder', 'Download folder ({{count}})', {
-            count: folderDownloadableIds.length,
-          })}
+          {folderDownloadCapped
+            ? t('gallery.downloadFolderCapped', 'Download first {{limit}} of {{total}}', {
+                limit: SELECTED_DOWNLOAD_LIMIT,
+                total: folderDownloadableIds.length,
+              })
+            : t('gallery.downloadFolder', 'Download folder ({{count}})', {
+                count: folderDownloadableIds.length,
+              })}
         </Button>
       )}
     </div>
@@ -1199,7 +1204,27 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
             would be hidden with no way in. Contained width so the folder strip
             reads as chrome against the full-bleed grid below it. */}
         {hasFolderNav && (
-          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">{buildFolderNav(true)}</div>
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3 flex items-center gap-3 flex-wrap">
+            {buildFolderNav(true)}
+            {/* These layouts have no header download button — their only
+                gallery-wide download is select-all + download-selected, and
+                select-all is (correctly) scoped to what is on screen. Once
+                folders exist that leaves no single way to get everything, so
+                surface the event-wide zip here. Root only: inside a folder the
+                breadcrumb already offers that folder's download. */}
+            {!openFolder && allowDownloads && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleDownloadAll}
+                disabled={downloadAllMutation.isPending}
+                leftIcon={<Download className="w-4 h-4" />}
+                className="ml-auto"
+              >
+                {t('gallery.downloadEverything', 'Download all photos')}
+              </Button>
+            )}
+          </div>
         )}
         <PhotoGridWithLayouts
           photos={filteredPhotos}

--- a/frontend/src/components/gallery/GalleryView.tsx
+++ b/frontend/src/components/gallery/GalleryView.tsx
@@ -13,6 +13,7 @@ import {
   findFolderBySlug,
   filterCategories,
   folderTiles,
+  peopleInScope,
   photosInScope,
   readFolderParam,
   writeFolderParam,
@@ -347,7 +348,9 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
     refetchInterval: (query) => (query.state.data?.scan?.in_progress ? 5000 : false),
     staleTime: 30_000,
   });
-  const people = peopleData?.people || [];
+  // Memoised so the `people` recount below isn't invalidated by a fresh []
+  // identity on every render.
+  const allPeople = useMemo(() => peopleData?.people || [], [peopleData?.people]);
 
   // The strip comes from /people, but FILTERING uses photo.person_ids, which
   // rides on the one-shot /photos response. During a backfill those drift
@@ -616,6 +619,17 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
     () => folderTiles(data?.categories, data?.photos),
     [data?.categories, data?.photos]
   );
+
+  // Photos the current view is allowed to show, before any user-applied filter.
+  // This — not `filteredPhotos` — is the right basis for the people strip and
+  // the category counts: scoping those by the person filter would zero out
+  // every other face the moment one is picked.
+  const scopedPhotos = useMemo(
+    () => photosInScope(data?.photos, data?.categories, openFolder?.id ?? null),
+    [data?.photos, data?.categories, openFolder]
+  );
+
+  const people = useMemo(() => peopleInScope(allPeople, scopedPhotos), [allPeople, scopedPhotos]);
 
   const openFolderBySlug = useCallback((slug: string | null) => {
     setOpenFolderSlug(slug);
@@ -928,11 +942,10 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
 
   // Calculate photo counts per category
   const photoCounts = useMemo(() => {
-    if (!data?.photos) return {};
     const counts: Record<number | string, number> = {};
     // Scoped to the current view (#1160): a folder's photos must not inflate the
     // per-category counts shown at root, where those photos aren't in the grid.
-    photosInScope(data.photos, data.categories, openFolder?.id ?? null)
+    scopedPhotos
       .filter(photo => {
         if (mediaFilter === 'photo') return resolveMediaType(photo) !== 'video';
         if (mediaFilter === 'video') return resolveMediaType(photo) === 'video';
@@ -944,7 +957,7 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
       }
     });
     return counts;
-  }, [data?.photos, data?.categories, openFolder, mediaFilter]);
+  }, [scopedPhotos, mediaFilter]);
 
   // Track search usage with debouncing
   useEffect(() => {
@@ -1099,10 +1112,62 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
   // the guest answer, and vice versa.
   const showLogoutControl = requiresPassword || isClient || viaCustomer;
 
+  // Folder navigation (#1160): tiles at root, a breadcrumb + folder download
+  // inside one. Defined once and rendered by BOTH layout branches — containment
+  // comes from `filteredPhotos`, which every branch uses, so a branch that hides
+  // foldered photos without offering the tiles makes them unreachable.
+  // Renders nothing at all when the gallery has no folders, so galleries that
+  // don't use the feature are untouched.
+  const buildFolderNav = (compact: boolean) => openFolder ? (
+    <div className="mb-6 flex items-center gap-2 text-sm flex-wrap">
+      <button
+        type="button"
+        onClick={() => openFolderBySlug(null)}
+        className="inline-flex items-center gap-1 underline hover:no-underline"
+        style={{ color: 'var(--color-muted-text)' }}
+      >
+        <ChevronLeft className="w-4 h-4" />
+        {t('gallery.backToGallery', 'All photos')}
+      </button>
+      <span style={{ color: 'var(--color-muted-text)' }}>/</span>
+      <span className="font-medium" style={{ color: 'var(--color-text)' }}>
+        {openFolder.name}
+      </span>
+      {allowDownloads && folderDownloadableIds.length > 0 && (
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleDownloadFolder}
+          leftIcon={<Download className="w-4 h-4" />}
+          className="ml-auto"
+        >
+          {t('gallery.downloadFolder', 'Download folder ({{count}})', {
+            count: folderDownloadableIds.length,
+          })}
+        </Button>
+      )}
+    </div>
+  ) : (
+    <GalleryFolderTiles tiles={tiles} onOpen={openFolderBySlug} compact={compact} />
+  );
+
+  const folderNav = buildFolderNav(false);
+
+  // True only when there is something to show, so the full-page layouts keep
+  // their edge-to-edge hero untouched unless folders are actually in use.
+  const hasFolderNav = !!openFolder || tiles.length > 0;
+
   // For full-page layouts, render just the PhotoGridWithLayouts without any wrappers
   if (isFullPageLayout) {
     return (
       <>
+        {/* #1160: these layouts return early and render edge-to-edge, but they
+            still get `filteredPhotos`, so without this the foldered photos
+            would be hidden with no way in. Contained width so the folder strip
+            reads as chrome against the full-bleed grid below it. */}
+        {hasFolderNav && (
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">{buildFolderNav(true)}</div>
+        )}
         <PhotoGridWithLayouts
           photos={filteredPhotos}
           slug={slug}
@@ -1497,39 +1562,7 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
             `-mt-6` bleed leaves a visible gap instead of gluing the filter
             bar to the hero image (issue #624). */}
         <div className={filterBarShown && isHeroHeader ? "mt-12" : "mt-6"}>
-          {/* Folders (#1160). Tiles at root; a breadcrumb back to root inside one. */}
-          {openFolder ? (
-            <div className="mb-6 flex items-center gap-2 text-sm flex-wrap">
-              <button
-                type="button"
-                onClick={() => openFolderBySlug(null)}
-                className="inline-flex items-center gap-1 underline hover:no-underline"
-                style={{ color: 'var(--color-muted-text)' }}
-              >
-                <ChevronLeft className="w-4 h-4" />
-                {t('gallery.backToGallery', 'All photos')}
-              </button>
-              <span style={{ color: 'var(--color-muted-text)' }}>/</span>
-              <span className="font-medium" style={{ color: 'var(--color-text)' }}>
-                {openFolder.name}
-              </span>
-              {allowDownloads && folderDownloadableIds.length > 0 && (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={handleDownloadFolder}
-                  leftIcon={<Download className="w-4 h-4" />}
-                  className="ml-auto"
-                >
-                  {t('gallery.downloadFolder', 'Download folder ({{count}})', {
-                    count: folderDownloadableIds.length,
-                  })}
-                </Button>
-              )}
-            </div>
-          ) : (
-            <GalleryFolderTiles tiles={tiles} onOpen={openFolderBySlug} />
-          )}
+          {folderNav}
           <PhotoGridWithLayouts
             photos={filteredPhotos}
             slug={slug}

--- a/frontend/src/components/gallery/GalleryView.tsx
+++ b/frontend/src/components/gallery/GalleryView.tsx
@@ -897,6 +897,35 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
     await galleryService.downloadSelectedPhotos(slug, peopleDownloadableIds);
   };
 
+  // Download just the open folder (#1160). The event-wide "download all" still
+  // zips the whole gallery including foldered photos; this is the "only this
+  // folder, once" case. Honours the per-category opt-out (#640), so a folder
+  // with allow_downloads = false offers no button at all.
+  const folderDownloadableIds = useMemo(() => {
+    if (!openFolder) return [];
+    if (openFolder.allow_downloads === false) return [];
+    return filteredPhotos
+      .filter((photo) => photo.category_allow_downloads !== false)
+      .map((photo) => photo.id);
+  }, [openFolder, filteredPhotos]);
+
+  const handleDownloadFolder = async () => {
+    if (!allowDownloads || folderDownloadableIds.length === 0) return;
+
+    // Same resolution-picker behaviour as every other multi-photo download.
+    if (downloadChoices.length > 1) {
+      setResolutionPickerIds(folderDownloadableIds);
+      return;
+    }
+
+    analyticsService.trackGalleryEvent('bulk_download', {
+      gallery: slug,
+      photo_count: folderDownloadableIds.length,
+    });
+
+    await galleryService.downloadSelectedPhotos(slug, folderDownloadableIds);
+  };
+
   // Calculate photo counts per category
   const photoCounts = useMemo(() => {
     if (!data?.photos) return {};
@@ -1470,7 +1499,7 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
         <div className={filterBarShown && isHeroHeader ? "mt-12" : "mt-6"}>
           {/* Folders (#1160). Tiles at root; a breadcrumb back to root inside one. */}
           {openFolder ? (
-            <div className="mb-6 flex items-center gap-2 text-sm">
+            <div className="mb-6 flex items-center gap-2 text-sm flex-wrap">
               <button
                 type="button"
                 onClick={() => openFolderBySlug(null)}
@@ -1481,9 +1510,22 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
                 {t('gallery.backToGallery', 'All photos')}
               </button>
               <span style={{ color: 'var(--color-muted-text)' }}>/</span>
-              <span className="font-medium text-neutral-900 dark:text-neutral-100">
+              <span className="font-medium" style={{ color: 'var(--color-text)' }}>
                 {openFolder.name}
               </span>
+              {allowDownloads && folderDownloadableIds.length > 0 && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleDownloadFolder}
+                  leftIcon={<Download className="w-4 h-4" />}
+                  className="ml-auto"
+                >
+                  {t('gallery.downloadFolder', 'Download folder ({{count}})', {
+                    count: folderDownloadableIds.length,
+                  })}
+                </Button>
+              )}
             </div>
           ) : (
             <GalleryFolderTiles tiles={tiles} onOpen={openFolderBySlug} />

--- a/frontend/src/components/gallery/GalleryView.tsx
+++ b/frontend/src/components/gallery/GalleryView.tsx
@@ -958,6 +958,12 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
   // /download-selected caps the id list server-side, so a folder bigger than the
   // cap would deliver a truncated archive under a button promising the whole
   // thing. Send only what the server will honour, and say so on the label.
+  // True when any category in this gallery opts out of downloads (#640).
+  const hasRestrictedCategory = useMemo(
+    () => (data?.categories || []).some((c) => c.allow_downloads === false),
+    [data?.categories]
+  );
+
   const folderDownloadIds = useMemo(
     () => folderDownloadableIds.slice(0, SELECTED_DOWNLOAD_LIMIT),
     [folderDownloadableIds]
@@ -1233,13 +1239,19 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
         {hasFolderNav && (
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3 flex items-center gap-3 flex-wrap">
             {buildFolderNav(true)}
-            {/* These layouts have no header download button — their only
+            {/* Hidden when a category opts out of downloads (#640): this routes
+                to the whole-gallery zip, which contains every event photo with
+                no per-category filter, so offering it here would hand a guest
+                the photos that opt-out is meant to withhold. Those galleries
+                keep the per-folder download, which enforces it.
+
+                These layouts have no header download button — their only
                 gallery-wide download is select-all + download-selected, and
                 select-all is (correctly) scoped to what is on screen. Once
                 folders exist that leaves no single way to get everything, so
                 surface the event-wide zip here. Root only: inside a folder the
                 breadcrumb already offers that folder's download. */}
-            {!openFolder && allowDownloads && (
+            {!openFolder && allowDownloads && !hasRestrictedCategory && (
               <Button
                 variant="outline"
                 size="sm"
@@ -1267,7 +1279,15 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
           // Event-wide, so a layout's own Download All neither skips foldered
           // photos nor truncates at the 500-id cap (#1160).
           eventPhotoCount={data?.photos?.length || 0}
-          onDownloadEverything={allowDownloads ? handleDownloadAll : undefined}
+          // Withheld when any category opts out of downloads (#640): the
+          // whole-gallery route serves a prebuilt zip that contains EVERY event
+          // photo with no per-category filter (gallery.js's own note on
+          // bumpEventDownloadCounts). Handing this to the layout there would
+          // turn a restricted photo into a downloadable one, so those galleries
+          // keep the id-based path, which enforces the opt-out.
+          onDownloadEverything={
+            allowDownloads && !hasRestrictedCategory ? handleDownloadAll : undefined
+          }
           slug={slug}
           people={peopleEnabled ? people : undefined}
           onSelectPerson={togglePerson}

--- a/frontend/src/components/gallery/GalleryView.tsx
+++ b/frontend/src/components/gallery/GalleryView.tsx
@@ -1197,7 +1197,16 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
       )}
     </div>
   ) : (
-    <GalleryFolderTiles tiles={tiles} onOpen={openFolderBySlug} compact={compact} />
+    <GalleryFolderTiles
+      tiles={tiles}
+      onOpen={openFolderBySlug}
+      compact={compact}
+      slug={slug}
+      protectionLevel={protectionLevel}
+      useEnhancedProtection={protectionLevel !== 'basic'}
+      useCanvasRendering={useCanvasRendering}
+      allowDownloads={allowDownloads}
+    />
   );
 
   const folderNav = buildFolderNav(false);
@@ -1255,9 +1264,10 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
           // component for the full-bleed layouts, so a folder-only root must
           // silence the empty message without unmounting the shell (#1160).
           suppressEmptyState={rootIsFoldersOnly}
-          // Event-wide, so a layout's own Download All isn't built from the
-          // scoped array and quietly skips foldered photos (#1160).
-          downloadAllIds={data?.photos?.map((p) => p.id)}
+          // Event-wide, so a layout's own Download All neither skips foldered
+          // photos nor truncates at the 500-id cap (#1160).
+          eventPhotoCount={data?.photos?.length || 0}
+          onDownloadEverything={allowDownloads ? handleDownloadAll : undefined}
           slug={slug}
           people={peopleEnabled ? people : undefined}
           onSelectPerson={togglePerson}

--- a/frontend/src/components/gallery/GalleryView.tsx
+++ b/frontend/src/components/gallery/GalleryView.tsx
@@ -792,19 +792,27 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
   // global aggregate in simple mode where no per-person identity
   // exists.
   const likeCount = useMemo(() => {
-    if (isGuestIdentityMode) return myFeedbackPhotoIds.liked.size;
-    return data?.photos?.filter(p => (p.like_count ?? 0) > 0).length || 0;
-  }, [data?.photos, isGuestIdentityMode, myFeedbackPhotoIds]);
+    // Scoped (#1160): a chip counting another folder's likes advertises matches
+    // that clicking it — which filters scopedPhotos — can never produce.
+    if (isGuestIdentityMode) {
+      return scopedPhotos.filter(p => myFeedbackPhotoIds.liked.has(p.id)).length;
+    }
+    return scopedPhotos.filter(p => (p.like_count ?? 0) > 0).length;
+  }, [scopedPhotos, isGuestIdentityMode, myFeedbackPhotoIds]);
 
   const favoriteCount = useMemo(() => {
-    if (isGuestIdentityMode) return myFeedbackPhotoIds.favorited.size;
-    return data?.photos?.filter(p => (p.favorite_count ?? 0) > 0).length || 0;
-  }, [data?.photos, isGuestIdentityMode, myFeedbackPhotoIds]);
+    if (isGuestIdentityMode) {
+      return scopedPhotos.filter(p => myFeedbackPhotoIds.favorited.has(p.id)).length;
+    }
+    return scopedPhotos.filter(p => (p.favorite_count ?? 0) > 0).length;
+  }, [scopedPhotos, isGuestIdentityMode, myFeedbackPhotoIds]);
 
   const ratedCount = useMemo(() => {
-    if (isGuestIdentityMode) return myFeedbackPhotoIds.rated.size;
-    return data?.photos?.filter(p => (p.total_ratings || 0) > 0 || (p.average_rating || 0) > 0).length || 0;
-  }, [data?.photos, isGuestIdentityMode, myFeedbackPhotoIds]);
+    if (isGuestIdentityMode) {
+      return scopedPhotos.filter(p => myFeedbackPhotoIds.rated.has(p.id)).length;
+    }
+    return scopedPhotos.filter(p => (p.total_ratings || 0) > 0 || (p.average_rating || 0) > 0).length;
+  }, [scopedPhotos, isGuestIdentityMode, myFeedbackPhotoIds]);
 
   // Per-colour chip counts (#1044) — the viewer's own labels, matching what
   // the filter actually selects.
@@ -1227,6 +1235,11 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
           </div>
         )}
         <PhotoGridWithLayouts
+          // Remount on a scope change (#1160): layout state such as the
+          // carousel's currentIndex is only meaningful for the photo set it was
+          // built against, and an index kept from a larger scope indexes past
+          // the end of a smaller folder.
+          key={openFolder ? `folder-${openFolder.id}` : 'root'}
           photos={filteredPhotos}
           // The hero, title, logout and download controls live inside this
           // component for the full-bleed layouts, so a folder-only root must
@@ -1345,6 +1358,10 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
           allowDownloads={allowDownloads}
           photoCounts={photoCounts}
           totalPhotos={scopedPhotos.length}
+          // Download All hits /download-all, which is event-wide — labelling or
+          // disabling it from the scoped count would show 0 on a folder-only
+          // root and refuse a perfectly valid download (#1160).
+          downloadAllTotal={data?.photos?.length || 0}
           isMobile={isMobile}
           galleryLayout={theme.galleryLayout}
           allowUploads={data?.event?.allow_user_uploads || event?.allow_user_uploads || false}
@@ -1636,6 +1653,7 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
               — directly under the tiles that prove otherwise. Skip the grid when
               the tiles are the entire content. */}
           <PhotoGridWithLayouts
+            key={openFolder ? `folder-${openFolder.id}` : 'root'}
             photos={filteredPhotos}
             suppressEmptyState={rootIsFoldersOnly}
             slug={slug}

--- a/frontend/src/components/gallery/GalleryView.tsx
+++ b/frontend/src/components/gallery/GalleryView.tsx
@@ -10,7 +10,7 @@ import { useGalleryPhotos, useDownloadAllPhotos } from '../../hooks/useGallery';
 import { PhotoGridWithLayouts } from './PhotoGridWithLayouts';
 import { GalleryFolderTiles } from './GalleryFolderTiles';
 import {
-  findFolderBySlug,
+  findFolderByKey,
   filterCategories,
   folderTiles,
   peopleInScope,
@@ -611,7 +611,7 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
   // categories the gallery actually returned, so a stale or hand-typed slug
   // simply falls back to root instead of rendering an empty gallery.
   const openFolder = useMemo(
-    () => findFolderBySlug(data?.categories, openFolderSlug),
+    () => findFolderByKey(data?.categories, openFolderSlug),
     [data?.categories, openFolderSlug]
   );
 
@@ -631,19 +631,28 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
 
   const people = useMemo(() => peopleInScope(allPeople, scopedPhotos), [allPeople, scopedPhotos]);
 
-  const openFolderBySlug = useCallback((slug: string | null) => {
-    setOpenFolderSlug(slug);
-    writeFolderParam(slug);
+  const openFolderBySlug = useCallback((key: string | null) => {
+    setOpenFolderSlug(key);
+    writeFolderParam(key);
     // Entering or leaving a folder is a scope change, not a filter change —
     // carrying a category selection across it would contradict the new scope.
     setSelectedCategoryId(null);
+    // The grid only auto-clears its selection when `categoryId` changes, and
+    // that is already null at root — so without this a selection made outside
+    // the folder survives into it, and the toolbar would offer to download (or
+    // a client to hide) photos that are no longer on screen.
+    setSelectedPhotos(new Set());
     window.scrollTo({ top: 0, behavior: 'smooth' });
   }, []);
 
   // The address bar is the source of truth, so Back/Forward walk in and out of
   // folders instead of leaving the gallery.
   useEffect(() => {
-    const onPop = () => setOpenFolderSlug(readFolderParam());
+    const onPop = () => {
+      setOpenFolderSlug(readFolderParam());
+      setSelectedCategoryId(null);
+      setSelectedPhotos(new Set());
+    };
     window.addEventListener('popstate', onPop);
     return () => window.removeEventListener('popstate', onPop);
   }, []);
@@ -1157,6 +1166,10 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
   // their edge-to-edge hero untouched unless folders are actually in use.
   const hasFolderNav = !!openFolder || tiles.length > 0;
 
+  // Root of a gallery where every photo lives in a folder: the tiles ARE the
+  // content, and the grid below them would otherwise render its empty state.
+  const rootIsFoldersOnly = !openFolder && tiles.length > 0 && filteredPhotos.length === 0;
+
   // For full-page layouts, render just the PhotoGridWithLayouts without any wrappers
   if (isFullPageLayout) {
     return (
@@ -1430,8 +1443,12 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
           <div className="mt-6">
             <PhotoFilterBar
               // Folders are navigation, not a filter (#1160) — they get tiles.
-              categories={filterCategories(data.categories)}
-              photos={data.photos}
+              // Inside a folder the category chips are dead controls: the filter
+              // branch ignores `selectedCategoryId` there, so offering them would
+              // let a guest click a chip and see nothing happen.
+              categories={openFolder ? [] : filterCategories(data.categories)}
+              // Scoped, so a chip can't advertise a count the grid won't produce.
+              photos={scopedPhotos}
               selectedCategoryId={selectedCategoryId}
               onCategoryChange={setSelectedCategoryId}
               searchTerm={searchTerm}
@@ -1464,7 +1481,7 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
           <div className="mt-4">
             <PeopleStrip
               people={people}
-              photos={data.photos}
+              photos={scopedPhotos}
               slug={slug}
               selectedPersonIds={selectedPersonIds}
               onToggle={togglePerson}
@@ -1563,6 +1580,11 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
             bar to the hero image (issue #624). */}
         <div className={filterBarShown && isHeroHeader ? "mt-12" : "mt-6"}>
           {folderNav}
+          {/* A gallery whose photos ALL live in folders has an empty root grid,
+              and PhotoGridWithLayouts unconditionally renders "no photos found"
+              — directly under the tiles that prove otherwise. Skip the grid when
+              the tiles are the entire content. */}
+          {rootIsFoldersOnly ? null : (
           <PhotoGridWithLayouts
             photos={filteredPhotos}
             slug={slug}
@@ -1614,6 +1636,7 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
             onToggleVisibility={isClient ? handleToggleVisibility : undefined}
             showOriginalFilename={showOriginalFilename}
           />
+          )}
         </div>
 
         {/* Upload Modal */}
@@ -1650,7 +1673,7 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
             open={showPeopleSheet}
             onClose={() => setShowPeopleSheet(false)}
             people={people}
-            photos={data?.photos || []}
+            photos={scopedPhotos}
             slug={slug}
             selectedPersonIds={selectedPersonIds}
             onToggle={togglePerson}

--- a/frontend/src/components/gallery/GalleryView.tsx
+++ b/frontend/src/components/gallery/GalleryView.tsx
@@ -352,6 +352,30 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
   // identity on every render.
   const allPeople = useMemo(() => peopleData?.people || [], [peopleData?.people]);
 
+  // Folders (#1160). `openFolder` resolves the `?folder=` slug against the
+  // categories the gallery actually returned, so a stale or hand-typed slug
+  // simply falls back to root instead of rendering an empty gallery.
+  const openFolder = useMemo(
+    () => findFolderByKey(data?.categories, openFolderSlug),
+    [data?.categories, openFolderSlug]
+  );
+
+  const tiles = useMemo(
+    () => folderTiles(data?.categories, data?.photos),
+    [data?.categories, data?.photos]
+  );
+
+  // Photos the current view is allowed to show, before any user-applied filter.
+  // This — not `filteredPhotos` — is the right basis for the people strip and
+  // the category counts: scoping those by the person filter would zero out
+  // every other face the moment one is picked.
+  const scopedPhotos = useMemo(
+    () => photosInScope(data?.photos, data?.categories, openFolder?.id ?? null),
+    [data?.photos, data?.categories, openFolder]
+  );
+
+  const people = useMemo(() => peopleInScope(allPeople, scopedPhotos), [allPeople, scopedPhotos]);
+
   // The strip comes from /people, but FILTERING uses photo.person_ids, which
   // rides on the one-shot /photos response. During a backfill those drift
   // apart: new faces appear in the strip while the photo memberships behind
@@ -453,16 +477,18 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
     }
   }, [settingsData]);
 
+  // Scoped (#1160): a Video chip offered at root for a video that only exists
+  // inside a folder filters to an empty grid.
   const availableMediaTypes = useMemo(() => {
     const types = new Set<'photo' | 'video'>();
-    (data?.photos || []).forEach((photo) => {
+    scopedPhotos.forEach((photo) => {
       const mediaType = resolveMediaType(photo);
       if (mediaType === 'photo' || mediaType === 'video') {
         types.add(mediaType);
       }
     });
     return types;
-  }, [data?.photos]);
+  }, [scopedPhotos]);
 
   const showMediaFilter = availableMediaTypes.has('photo') && availableMediaTypes.has('video');
 
@@ -607,29 +633,6 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
   const showUrgentWarning = daysUntilExpiration !== null && daysUntilExpiration <= 7;
   const isExpired = daysUntilExpiration !== null && daysUntilExpiration < 0;
 
-  // Folders (#1160). `openFolder` resolves the `?folder=` slug against the
-  // categories the gallery actually returned, so a stale or hand-typed slug
-  // simply falls back to root instead of rendering an empty gallery.
-  const openFolder = useMemo(
-    () => findFolderByKey(data?.categories, openFolderSlug),
-    [data?.categories, openFolderSlug]
-  );
-
-  const tiles = useMemo(
-    () => folderTiles(data?.categories, data?.photos),
-    [data?.categories, data?.photos]
-  );
-
-  // Photos the current view is allowed to show, before any user-applied filter.
-  // This — not `filteredPhotos` — is the right basis for the people strip and
-  // the category counts: scoping those by the person filter would zero out
-  // every other face the moment one is picked.
-  const scopedPhotos = useMemo(
-    () => photosInScope(data?.photos, data?.categories, openFolder?.id ?? null),
-    [data?.photos, data?.categories, openFolder]
-  );
-
-  const people = useMemo(() => peopleInScope(allPeople, scopedPhotos), [allPeople, scopedPhotos]);
 
   const openFolderBySlug = useCallback((key: string | null) => {
     setOpenFolderSlug(key);
@@ -806,13 +809,13 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
   // the filter actually selects.
   const colorLabelCounts = useMemo(() => {
     const counts: Partial<Record<ColorLabel, number>> = {};
-    for (const photo of data?.photos || []) {
+    for (const photo of scopedPhotos) {
       const label = photo.my_color_label as ColorLabel | null | undefined;
       if (!label) continue;
       counts[label] = (counts[label] || 0) + 1;
     }
     return counts;
-  }, [data?.photos]);
+  }, [scopedPhotos]);
 
   const handleColorFilterToggle = useCallback((color: ColorLabel) => {
     setActiveColorFilters(prev =>
@@ -927,10 +930,14 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
   const folderDownloadableIds = useMemo(() => {
     if (!openFolder) return [];
     if (openFolder.allow_downloads === false) return [];
-    return filteredPhotos
+    // scopedPhotos, not filteredPhotos: a search or feedback chip stays active
+    // when entering a folder, and a button that says "Download folder" must not
+    // quietly hand over a filtered subset of it (or vanish when the filter
+    // matches nothing).
+    return scopedPhotos
       .filter((photo) => photo.category_allow_downloads !== false)
       .map((photo) => photo.id);
-  }, [openFolder, filteredPhotos]);
+  }, [openFolder, scopedPhotos]);
 
   const handleDownloadFolder = async () => {
     if (!allowDownloads || folderDownloadableIds.length === 0) return;
@@ -1168,7 +1175,10 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
 
   // Root of a gallery where every photo lives in a folder: the tiles ARE the
   // content, and the grid below them would otherwise render its empty state.
-  const rootIsFoldersOnly = !openFolder && tiles.length > 0 && filteredPhotos.length === 0;
+  // Deliberately `scopedPhotos`, not `filteredPhotos`: with loose root photos
+  // present, a search matching none of them would otherwise look "folder-only"
+  // and swallow the no-results message the guest needs.
+  const rootIsFoldersOnly = !openFolder && tiles.length > 0 && scopedPhotos.length === 0;
 
   // For full-page layouts, render just the PhotoGridWithLayouts without any wrappers
   if (isFullPageLayout) {
@@ -1181,6 +1191,7 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
         {hasFolderNav && (
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">{buildFolderNav(true)}</div>
         )}
+        {rootIsFoldersOnly ? null : (
         <PhotoGridWithLayouts
           photos={filteredPhotos}
           slug={slug}
@@ -1234,6 +1245,7 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
           onLogout={showLogoutControl ? logout : undefined}
           showOriginalFilename={showOriginalFilename}
         />
+        )}
 
         {/* Upload Modal for full-page layouts */}
         {showUploadModal && (data?.event?.allow_user_uploads || event?.allow_user_uploads) && (

--- a/frontend/src/components/gallery/GalleryView.tsx
+++ b/frontend/src/components/gallery/GalleryView.tsx
@@ -646,6 +646,11 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
     // the folder survives into it, and the toolbar would offer to download (or
     // a client to hide) photos that are no longer on screen.
     setSelectedPhotos(new Set());
+    // A person picked in the previous scope may have no photos here, and
+    // peopleInScope drops them from the strip — leaving an invisible filter that
+    // empties the grid with no control left to clear it.
+    setSelectedPersonIds([]);
+    setPeopleMatchAny(false);
     window.scrollTo({ top: 0, behavior: 'smooth' });
   }, []);
 
@@ -656,6 +661,8 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
       setOpenFolderSlug(readFolderParam());
       setSelectedCategoryId(null);
       setSelectedPhotos(new Set());
+      setSelectedPersonIds([]);
+      setPeopleMatchAny(false);
     };
     window.addEventListener('popstate', onPop);
     return () => window.removeEventListener('popstate', onPop);

--- a/frontend/src/components/gallery/GalleryView.tsx
+++ b/frontend/src/components/gallery/GalleryView.tsx
@@ -8,6 +8,15 @@ import { GallerySkeleton } from './GallerySkeleton';
 import { useGalleryAuth, useTheme } from '../../contexts';
 import { useGalleryPhotos, useDownloadAllPhotos } from '../../hooks/useGallery';
 import { PhotoGridWithLayouts } from './PhotoGridWithLayouts';
+import { GalleryFolderTiles } from './GalleryFolderTiles';
+import {
+  findFolderBySlug,
+  filterCategories,
+  folderTiles,
+  photosInScope,
+  readFolderParam,
+  writeFolderParam,
+} from './folders';
 import { DownloadResolutionModal } from './DownloadResolutionModal';
 import { ExpirationBanner } from './ExpirationBanner';
 import { CountdownTimer } from './CountdownTimer';
@@ -24,7 +33,7 @@ import type { FilterType, FeedbackFilterType } from './GalleryFilter';
 import { analyticsService } from '../../services/analytics.service';
 import { useDevToolsProtection } from '../../hooks/useDevToolsProtection';
 import { api } from '../../config/api';
-import { Upload, Menu, Eye, EyeOff, Shield, X, Download } from 'lucide-react';
+import { Upload, Menu, Eye, EyeOff, Shield, X, Download, ChevronLeft } from 'lucide-react';
 import { galleryService } from '../../services/gallery.service';
 import { feedbackService, type ColorLabel } from '../../services/feedback.service';
 import { useWatermarkSettings } from '../../hooks/useWatermarkSettings';
@@ -96,6 +105,9 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
   const { setTheme, theme } = useTheme();
   const queryClient = useQueryClient();
   const [selectedCategoryId, setSelectedCategoryId] = useState<number | string | null>(null);
+  // Open folder (#1160), mirrored to `?folder=<slug>` so it is linkable and the
+  // browser back button walks out of it. Seeded from the URL on first render.
+  const [openFolderSlug, setOpenFolderSlug] = useState<string | null>(() => readFolderParam());
   // Download size picker (#858). `showResolutionPicker` covers "download all";
   // `resolutionPickerIds` covers a selection (sidebar / full-page layouts).
   const [showResolutionPicker, setShowResolutionPicker] = useState(false);
@@ -592,23 +604,58 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
   const showUrgentWarning = daysUntilExpiration !== null && daysUntilExpiration <= 7;
   const isExpired = daysUntilExpiration !== null && daysUntilExpiration < 0;
 
+  // Folders (#1160). `openFolder` resolves the `?folder=` slug against the
+  // categories the gallery actually returned, so a stale or hand-typed slug
+  // simply falls back to root instead of rendering an empty gallery.
+  const openFolder = useMemo(
+    () => findFolderBySlug(data?.categories, openFolderSlug),
+    [data?.categories, openFolderSlug]
+  );
+
+  const tiles = useMemo(
+    () => folderTiles(data?.categories, data?.photos),
+    [data?.categories, data?.photos]
+  );
+
+  const openFolderBySlug = useCallback((slug: string | null) => {
+    setOpenFolderSlug(slug);
+    writeFolderParam(slug);
+    // Entering or leaving a folder is a scope change, not a filter change —
+    // carrying a category selection across it would contradict the new scope.
+    setSelectedCategoryId(null);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }, []);
+
+  // The address bar is the source of truth, so Back/Forward walk in and out of
+  // folders instead of leaving the gallery.
+  useEffect(() => {
+    const onPop = () => setOpenFolderSlug(readFolderParam());
+    window.addEventListener('popstate', onPop);
+    return () => window.removeEventListener('popstate', onPop);
+  }, []);
+
   // Filter and sort photos
   const filteredPhotos = useMemo(() => {
     if (!data?.photos) return [];
-    
-    let photos = [...data.photos];
+
+    // Folder containment (#1160) comes FIRST: at root this drops every photo that
+    // lives in a folder, inside a folder it keeps only that folder's photos.
+    // Everything below narrows within that scope, so a search or a feedback chip
+    // never reaches across a folder boundary.
+    let photos = photosInScope(data.photos, data.categories, openFolder?.id ?? null);
 
     if (mediaFilter === 'photo') {
       photos = photos.filter(photo => resolveMediaType(photo) !== 'video');
     } else if (mediaFilter === 'video') {
       photos = photos.filter(photo => resolveMediaType(photo) === 'video');
     }
-    
-    // Apply category filter
-    if (selectedCategoryId) {
+
+    // Apply category filter. Only meaningful at root — inside a folder every
+    // photo already shares the folder's category.
+    if (selectedCategoryId && !openFolder) {
       photos = photos.filter(photo => photo.category_id === selectedCategoryId);
     }
-    
+
     // Apply search filter
     if (searchTerm) {
       const term = searchTerm.toLowerCase();
@@ -708,7 +755,7 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
     }
     
     return photos;
-  }, [data?.photos, selectedCategoryId, searchTerm, sortBy, sortDesc, watermarkEnabled, slug, activeFilters, activeColorFilters, mediaFilter, isGuestIdentityMode, myFeedbackPhotoIds, selectedPersonIds, peopleMatchAny]);
+  }, [data?.photos, data?.categories, openFolder, selectedCategoryId, searchTerm, sortBy, sortDesc, watermarkEnabled, slug, activeFilters, activeColorFilters, mediaFilter, isGuestIdentityMode, myFeedbackPhotoIds, selectedPersonIds, peopleMatchAny]);
 
   // Counts shown in the filter chips ("Liked (N)", etc.). In guest
   // mode these need to mirror the per-guest filter behaviour above —
@@ -854,7 +901,9 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
   const photoCounts = useMemo(() => {
     if (!data?.photos) return {};
     const counts: Record<number | string, number> = {};
-    data.photos
+    // Scoped to the current view (#1160): a folder's photos must not inflate the
+    // per-category counts shown at root, where those photos aren't in the grid.
+    photosInScope(data.photos, data.categories, openFolder?.id ?? null)
       .filter(photo => {
         if (mediaFilter === 'photo') return resolveMediaType(photo) !== 'video';
         if (mediaFilter === 'video') return resolveMediaType(photo) === 'video';
@@ -866,7 +915,7 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
       }
     });
     return counts;
-  }, [data?.photos, mediaFilter]);
+  }, [data?.photos, data?.categories, openFolder, mediaFilter]);
 
   // Track search usage with debouncing
   useEffect(() => {
@@ -1122,7 +1171,7 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
         <GallerySidebar
           isOpen={sidebarOpen}
           onClose={() => setSidebarOpen(!sidebarOpen)}
-          categories={(data?.categories || []).filter(cat => photoCounts[cat.id] > 0)}
+          categories={filterCategories(data?.categories).filter(cat => photoCounts[cat.id] > 0)}
           selectedCategoryId={selectedCategoryId}
           onCategoryChange={setSelectedCategoryId}
           searchTerm={searchTerm}
@@ -1286,7 +1335,8 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
         {filterBarShown ? (
           <div className="mt-6">
             <PhotoFilterBar
-              categories={data.categories}
+              // Folders are navigation, not a filter (#1160) — they get tiles.
+              categories={filterCategories(data.categories)}
               photos={data.photos}
               selectedCategoryId={selectedCategoryId}
               onCategoryChange={setSelectedCategoryId}
@@ -1418,8 +1468,28 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
             `-mt-6` bleed leaves a visible gap instead of gluing the filter
             bar to the hero image (issue #624). */}
         <div className={filterBarShown && isHeroHeader ? "mt-12" : "mt-6"}>
-          <PhotoGridWithLayouts 
-            photos={filteredPhotos} 
+          {/* Folders (#1160). Tiles at root; a breadcrumb back to root inside one. */}
+          {openFolder ? (
+            <div className="mb-6 flex items-center gap-2 text-sm">
+              <button
+                type="button"
+                onClick={() => openFolderBySlug(null)}
+                className="inline-flex items-center gap-1 underline hover:no-underline"
+                style={{ color: 'var(--color-muted-text)' }}
+              >
+                <ChevronLeft className="w-4 h-4" />
+                {t('gallery.backToGallery', 'All photos')}
+              </button>
+              <span style={{ color: 'var(--color-muted-text)' }}>/</span>
+              <span className="font-medium text-neutral-900 dark:text-neutral-100">
+                {openFolder.name}
+              </span>
+            </div>
+          ) : (
+            <GalleryFolderTiles tiles={tiles} onOpen={openFolderBySlug} />
+          )}
+          <PhotoGridWithLayouts
+            photos={filteredPhotos}
             slug={slug}
             people={peopleEnabled ? people : undefined}
             onSelectPerson={togglePerson} 

--- a/frontend/src/components/gallery/GalleryView.tsx
+++ b/frontend/src/components/gallery/GalleryView.tsx
@@ -1245,6 +1245,9 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
           // component for the full-bleed layouts, so a folder-only root must
           // silence the empty message without unmounting the shell (#1160).
           suppressEmptyState={rootIsFoldersOnly}
+          // Event-wide, so a layout's own Download All isn't built from the
+          // scoped array and quietly skips foldered photos (#1160).
+          downloadAllIds={data?.photos?.map((p) => p.id)}
           slug={slug}
           people={peopleEnabled ? people : undefined}
           onSelectPerson={togglePerson}

--- a/frontend/src/components/gallery/GalleryView.tsx
+++ b/frontend/src/components/gallery/GalleryView.tsx
@@ -15,6 +15,7 @@ import {
   folderTiles,
   peopleInScope,
   photosInScope,
+  SELECTED_DOWNLOAD_LIMIT,
   readFolderParam,
   writeFolderParam,
 } from './folders';
@@ -939,21 +940,30 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
       .map((photo) => photo.id);
   }, [openFolder, scopedPhotos]);
 
+  // /download-selected caps the id list server-side, so a folder bigger than the
+  // cap would deliver a truncated archive under a button promising the whole
+  // thing. Send only what the server will honour, and say so on the label.
+  const folderDownloadIds = useMemo(
+    () => folderDownloadableIds.slice(0, SELECTED_DOWNLOAD_LIMIT),
+    [folderDownloadableIds]
+  );
+  const folderDownloadCapped = folderDownloadableIds.length > SELECTED_DOWNLOAD_LIMIT;
+
   const handleDownloadFolder = async () => {
     if (!allowDownloads || folderDownloadableIds.length === 0) return;
 
     // Same resolution-picker behaviour as every other multi-photo download.
     if (downloadChoices.length > 1) {
-      setResolutionPickerIds(folderDownloadableIds);
+      setResolutionPickerIds(folderDownloadIds);
       return;
     }
 
     analyticsService.trackGalleryEvent('bulk_download', {
       gallery: slug,
-      photo_count: folderDownloadableIds.length,
+      photo_count: folderDownloadIds.length,
     });
 
-    await galleryService.downloadSelectedPhotos(slug, folderDownloadableIds);
+    await galleryService.downloadSelectedPhotos(slug, folderDownloadIds);
   };
 
   // Calculate photo counts per category
@@ -1191,9 +1201,12 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
         {hasFolderNav && (
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">{buildFolderNav(true)}</div>
         )}
-        {rootIsFoldersOnly ? null : (
         <PhotoGridWithLayouts
           photos={filteredPhotos}
+          // The hero, title, logout and download controls live inside this
+          // component for the full-bleed layouts, so a folder-only root must
+          // silence the empty message without unmounting the shell (#1160).
+          suppressEmptyState={rootIsFoldersOnly}
           slug={slug}
           people={peopleEnabled ? people : undefined}
           onSelectPerson={togglePerson}
@@ -1245,7 +1258,6 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
           onLogout={showLogoutControl ? logout : undefined}
           showOriginalFilename={showOriginalFilename}
         />
-        )}
 
         {/* Upload Modal for full-page layouts */}
         {showUploadModal && (data?.event?.allow_user_uploads || event?.allow_user_uploads) && (
@@ -1307,7 +1319,7 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
           isDownloading={downloadAllMutation.isPending}
           allowDownloads={allowDownloads}
           photoCounts={photoCounts}
-          totalPhotos={data?.photos.length || 0}
+          totalPhotos={scopedPhotos.length}
           isMobile={isMobile}
           galleryLayout={theme.galleryLayout}
           allowUploads={data?.event?.allow_user_uploads || event?.allow_user_uploads || false}
@@ -1552,8 +1564,10 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
                 <span className="text-sm sm:ml-auto" style={{ color: 'var(--color-muted-text)' }}>
                   {t('gallery.people.matchCount', {
                     count: filteredPhotos.length,
-                    total: totalCount,
-                    defaultValue: `${filteredPhotos.length} of ${totalCount} photos`,
+                    // Scoped denominator (#1160): at a folder root this said
+                    // "42 of 62" while only 42 exist in the view.
+                    total: scopedPhotos.length,
+                    defaultValue: `${filteredPhotos.length} of ${scopedPhotos.length} photos`,
                   })}
                 </span>
 
@@ -1596,9 +1610,9 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
               and PhotoGridWithLayouts unconditionally renders "no photos found"
               — directly under the tiles that prove otherwise. Skip the grid when
               the tiles are the entire content. */}
-          {rootIsFoldersOnly ? null : (
           <PhotoGridWithLayouts
             photos={filteredPhotos}
+            suppressEmptyState={rootIsFoldersOnly}
             slug={slug}
             people={peopleEnabled ? people : undefined}
             onSelectPerson={togglePerson} 
@@ -1648,7 +1662,6 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
             onToggleVisibility={isClient ? handleToggleVisibility : undefined}
             showOriginalFilename={showOriginalFilename}
           />
-          )}
         </div>
 
         {/* Upload Modal */}

--- a/frontend/src/components/gallery/GalleryView.tsx
+++ b/frontend/src/components/gallery/GalleryView.tsx
@@ -1237,12 +1237,16 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
             would be hidden with no way in. Contained width so the folder strip
             reads as chrome against the full-bleed grid below it. */}
         {hasFolderNav && (
-          // relative + z-[60]: the Story layout's `.story-nav` is `position:
-          // fixed` across the top of the viewport at z-index 50, and it swallowed
-          // the clicks on these chips — a Story gallery whose photos are all
-          // foldered had no way in at all.
-          <div className="relative z-[60] max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3 flex items-center gap-3 flex-wrap">
-            {buildFolderNav(true)}
+          // Story's `.story-nav` is fixed across this same band at z-index 50.
+          // Raising the strip above it is necessary for the chips to be
+          // clickable at all, but the strip is mostly empty space — so the
+          // container itself must not take hits, or it would block the nav's own
+          // search/favourites/logout underneath. Only the real controls opt back
+          // in via pointer-events-auto.
+          <div className="relative z-[60] pointer-events-none max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3 flex items-center gap-3 flex-wrap">
+            <div className="pointer-events-auto flex items-center gap-3 flex-wrap">
+              {buildFolderNav(true)}
+            </div>
             {/* Hidden when a category opts out of downloads (#640): this routes
                 to the whole-gallery zip, which contains every event photo with
                 no per-category filter, so offering it here would hand a guest
@@ -1262,7 +1266,10 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
                 onClick={handleDownloadAll}
                 disabled={downloadAllMutation.isPending}
                 leftIcon={<Download className="w-4 h-4" />}
-                className="ml-auto"
+                // No ml-auto: the right of this band belongs to Story's fixed
+                // nav (logout, favourites), and pushing the button over there
+                // physically covers those controls.
+                className="pointer-events-auto"
               >
                 {t('gallery.downloadEverything', 'Download all photos')}
               </Button>

--- a/frontend/src/components/gallery/GalleryView.tsx
+++ b/frontend/src/components/gallery/GalleryView.tsx
@@ -1047,7 +1047,10 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
   const showSidebar = theme.controlsStyle === 'sidebar';
   const filterBarShown = !showSidebar
     && settingsData?.gallery_show_filter_bar !== false
-    && (data?.photos?.length ?? 0) > 0;
+    // Scoped (#1160): on a folder-only root there is nothing for search, sort or
+    // the feedback chips to act on, and showing them reintroduces exactly the
+    // empty filter row discussion #317 complained about.
+    && scopedPhotos.length > 0;
 
   // Reveal mode (#838): the server returned the event shell with no photos —
   // render the upload-only view for EVERY layout. Enforcement is server-side

--- a/frontend/src/components/gallery/GalleryView.tsx
+++ b/frontend/src/components/gallery/GalleryView.tsx
@@ -1237,7 +1237,11 @@ export const GalleryView: React.FC<GalleryViewProps> = ({ slug, event, requiresP
             would be hidden with no way in. Contained width so the folder strip
             reads as chrome against the full-bleed grid below it. */}
         {hasFolderNav && (
-          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3 flex items-center gap-3 flex-wrap">
+          // relative + z-[60]: the Story layout's `.story-nav` is `position:
+          // fixed` across the top of the viewport at z-index 50, and it swallowed
+          // the clicks on these chips — a Story gallery whose photos are all
+          // foldered had no way in at all.
+          <div className="relative z-[60] max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3 flex items-center gap-3 flex-wrap">
             {buildFolderNav(true)}
             {/* Hidden when a category opts out of downloads (#640): this routes
                 to the whole-gallery zip, which contains every event photo with

--- a/frontend/src/components/gallery/PhotoGridWithLayouts.tsx
+++ b/frontend/src/components/gallery/PhotoGridWithLayouts.tsx
@@ -247,6 +247,10 @@ export const PhotoGridWithLayouts: React.FC<PhotoGridWithLayoutsProps> = ({
   // Select the appropriate layout component
   const layoutProps = {
     photos,
+    // Forwarded so the full-bleed layouts, which render their OWN
+    // noPhotosFound return, don't contradict the folder tiles above them on a
+    // folder-only root (#1160).
+    suppressEmptyState,
     slug,
     // Face data (#1074) must reach the full-page layouts too — they render
     // their OWN lightbox rather than the one below, so without this the

--- a/frontend/src/components/gallery/PhotoGridWithLayouts.tsx
+++ b/frontend/src/components/gallery/PhotoGridWithLayouts.tsx
@@ -246,15 +246,6 @@ export const PhotoGridWithLayouts: React.FC<PhotoGridWithLayoutsProps> = ({
         </div>
       );
     }
-    // Only the full-bleed layouts are mounted with an empty set — they own the
-    // hero, logout and download chrome, so unmounting them strips the page.
-    // Every other layout renders nothing rather than being mounted empty:
-    // CarouselGalleryLayout returns before four of its useState calls, so
-    // driving one instance between empty and non-empty changes its hook count.
-    const layout = theme.galleryLayout;
-    if (layout !== 'gallery-premium' && layout !== 'gallery-story') {
-      return null;
-    }
   }
 
   // Get the current layout from theme
@@ -340,6 +331,14 @@ export const PhotoGridWithLayouts: React.FC<PhotoGridWithLayoutsProps> = ({
 
   // Gallery Premium and Gallery Story layouts have their own integrated hero/header
   const isFullPageLayout = galleryLayout === 'gallery-premium' || galleryLayout === 'gallery-story';
+
+  // Folder-only root (#1160). The full-bleed layouts own the hero/logout chrome,
+  // so they are mounted even with an empty set. Every other layout is skipped
+  // instead: CarouselGalleryLayout returns before four of its useState calls, so
+  // driving one instance between empty and non-empty changes its hook count and
+  // React throws. Skipping only the child keeps this component's own HeroHeader
+  // and welcome message on screen.
+  const skipEmptyLayoutChild = photos.length === 0 && suppressEmptyState && !isFullPageLayout;
 
   return (
     <>
@@ -431,7 +430,7 @@ export const PhotoGridWithLayouts: React.FC<PhotoGridWithLayoutsProps> = ({
       )}
 
       {/* Render the selected layout */}
-      <LayoutComponent {...layoutProps} />
+      {skipEmptyLayoutChild ? null : <LayoutComponent {...layoutProps} />}
 
       {/* Lightbox - skip for full-page layouts which have their own lightbox */}
       {selectedPhotoIndex !== null && !isFullPageLayout && (

--- a/frontend/src/components/gallery/PhotoGridWithLayouts.tsx
+++ b/frontend/src/components/gallery/PhotoGridWithLayouts.tsx
@@ -92,14 +92,16 @@ interface PhotoGridWithLayoutsProps {
    * the whole gallery shell.
    */
   suppressEmptyState?: boolean;
-  /** #1160: event-wide ids for a layout's own Download All. */
-  downloadAllIds?: number[];
+  /** #1160: event-wide count + whole-gallery download for layout chrome. */
+  eventPhotoCount?: number;
+  onDownloadEverything?: () => void;
 }
 
 export const PhotoGridWithLayouts: React.FC<PhotoGridWithLayoutsProps> = ({
   photos,
   suppressEmptyState = false,
-  downloadAllIds,
+  eventPhotoCount,
+  onDownloadEverything,
   slug,
   categoryId,
   heroPhotoOverride,
@@ -258,7 +260,8 @@ export const PhotoGridWithLayouts: React.FC<PhotoGridWithLayoutsProps> = ({
     // noPhotosFound return, don't contradict the folder tiles above them on a
     // folder-only root (#1160).
     suppressEmptyState,
-    downloadAllIds,
+    eventPhotoCount,
+    onDownloadEverything,
     slug,
     // Face data (#1074) must reach the full-page layouts too — they render
     // their OWN lightbox rather than the one below, so without this the

--- a/frontend/src/components/gallery/PhotoGridWithLayouts.tsx
+++ b/frontend/src/components/gallery/PhotoGridWithLayouts.tsx
@@ -92,11 +92,14 @@ interface PhotoGridWithLayoutsProps {
    * the whole gallery shell.
    */
   suppressEmptyState?: boolean;
+  /** #1160: event-wide ids for a layout's own Download All. */
+  downloadAllIds?: number[];
 }
 
 export const PhotoGridWithLayouts: React.FC<PhotoGridWithLayoutsProps> = ({
   photos,
   suppressEmptyState = false,
+  downloadAllIds,
   slug,
   categoryId,
   heroPhotoOverride,
@@ -233,12 +236,25 @@ export const PhotoGridWithLayouts: React.FC<PhotoGridWithLayoutsProps> = ({
     }
   };
 
-  if (photos.length === 0 && !suppressEmptyState) {
-    return (
-      <div className="text-center py-12">
-        <p className="text-muted-theme">{t('gallery.noPhotosFound')}</p>
-      </div>
-    );
+  if (photos.length === 0) {
+    // Suppressed (#1160): a folder-only root has folder tiles above proving the
+    // gallery isn't empty, so the message would contradict them.
+    if (!suppressEmptyState) {
+      return (
+        <div className="text-center py-12">
+          <p className="text-muted-theme">{t('gallery.noPhotosFound')}</p>
+        </div>
+      );
+    }
+    // Only the full-bleed layouts are mounted with an empty set — they own the
+    // hero, logout and download chrome, so unmounting them strips the page.
+    // Every other layout renders nothing rather than being mounted empty:
+    // CarouselGalleryLayout returns before four of its useState calls, so
+    // driving one instance between empty and non-empty changes its hook count.
+    const layout = theme.galleryLayout;
+    if (layout !== 'gallery-premium' && layout !== 'gallery-story') {
+      return null;
+    }
   }
 
   // Get the current layout from theme
@@ -251,6 +267,7 @@ export const PhotoGridWithLayouts: React.FC<PhotoGridWithLayoutsProps> = ({
     // noPhotosFound return, don't contradict the folder tiles above them on a
     // folder-only root (#1160).
     suppressEmptyState,
+    downloadAllIds,
     slug,
     // Face data (#1074) must reach the full-page layouts too — they render
     // their OWN lightbox rather than the one below, so without this the

--- a/frontend/src/components/gallery/PhotoGridWithLayouts.tsx
+++ b/frontend/src/components/gallery/PhotoGridWithLayouts.tsx
@@ -83,10 +83,20 @@ interface PhotoGridWithLayoutsProps {
   // show "In this photo: …". Undefined when the feature is off.
   people?: GalleryPerson[];
   onSelectPerson?: (personId: number) => void;
+  /**
+   * Suppress the "no photos found" message (#1160). A gallery whose photos all
+   * live in folders has an empty root grid while its folder tiles sit directly
+   * above — printing "no photos" there contradicts the tiles. Only the message
+   * is suppressed: the full-page layouts render their hero, title, logout and
+   * download controls from inside this component, so unmounting it would strip
+   * the whole gallery shell.
+   */
+  suppressEmptyState?: boolean;
 }
 
 export const PhotoGridWithLayouts: React.FC<PhotoGridWithLayoutsProps> = ({
   photos,
+  suppressEmptyState = false,
   slug,
   categoryId,
   heroPhotoOverride,
@@ -223,7 +233,7 @@ export const PhotoGridWithLayouts: React.FC<PhotoGridWithLayoutsProps> = ({
     }
   };
 
-  if (photos.length === 0) {
+  if (photos.length === 0 && !suppressEmptyState) {
     return (
       <div className="text-center py-12">
         <p className="text-muted-theme">{t('gallery.noPhotosFound')}</p>

--- a/frontend/src/components/gallery/__tests__/folders.test.ts
+++ b/frontend/src/components/gallery/__tests__/folders.test.ts
@@ -9,7 +9,8 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
   filterCategories,
   peopleInScope,
-  findFolderBySlug,
+  findFolderByKey,
+  folderKey,
   folderCategoryIds,
   folderTiles,
   photosInScope,
@@ -95,17 +96,31 @@ describe('folderTiles', () => {
   });
 });
 
-describe('findFolderBySlug', () => {
+describe('findFolderByKey / folderKey', () => {
   it('resolves an open folder', () => {
-    expect(findFolderBySlug(CATEGORIES, 'selects')?.id).toBe(2);
+    expect(findFolderByKey(CATEGORIES, 'selects')?.id).toBe(2);
   });
 
-  it('falls back to root for an unknown slug rather than emptying the gallery', () => {
-    expect(findFolderBySlug(CATEGORIES, 'nope')).toBeNull();
+  it('falls back to root for an unknown key rather than emptying the gallery', () => {
+    expect(findFolderByKey(CATEGORIES, 'nope')).toBeNull();
   });
 
   it('refuses to open a filter category as a folder', () => {
-    expect(findFolderBySlug(CATEGORIES, 'ceremony')).toBeNull();
+    expect(findFolderByKey(CATEGORIES, 'ceremony')).toBeNull();
+  });
+
+  // Regression: adminCategories slugs with `[^\w\s-]` stripping, and `\w` is
+  // ASCII-only — "Избранное" slugs to "". Keying on the slug made such a
+  // folder's photos unreachable: gone from the root grid, and the empty param
+  // neither wrote nor resolved.
+  it('keys a folder by id when its name slugs to nothing', () => {
+    const cyrillic = cat({ id: 7, slug: '', name: 'Избранное', is_folder: true });
+    expect(folderKey(cyrillic)).toBe('7');
+    expect(findFolderByKey([cyrillic], '7')?.id).toBe(7);
+  });
+
+  it('still prefers a real slug for readable links', () => {
+    expect(folderKey(CATEGORIES[1])).toBe('selects');
   });
 });
 

--- a/frontend/src/components/gallery/__tests__/folders.test.ts
+++ b/frontend/src/components/gallery/__tests__/folders.test.ts
@@ -192,10 +192,26 @@ describe('peopleInScope', () => {
     expect(inFolder).toEqual([{ id: 3, face_count: 2 }]);
   });
 
+  // PeopleStrip only shows the first 12 inline, so keeping /people's event-wide
+  // ordering after rescoping could push a folder's most-photographed person
+  // behind "Show all".
+  it('re-sorts by the recomputed scoped count', () => {
+    const people = [
+      { id: 3, face_count: 99 }, // 2 in the folder
+      { id: 1, face_count: 99 }, // 0 in the folder
+      { id: 2, face_count: 99 }, // 0 in the folder
+    ];
+    const inFolder = peopleInScope(people, photosInScope(withPeople, CATEGORIES, 2));
+    expect(inFolder.map((p) => p.id)).toEqual([3]);
+
+    const atRoot = peopleInScope(people, photosInScope(withPeople, CATEGORIES, null));
+    expect(atRoot.map((p) => [p.id, p.face_count])).toEqual([[1, 2], [2, 1]]);
+  });
+
   it('is a no-op for a gallery without folders', () => {
     const noFolders = [cat({ id: 1, slug: 'ceremony' })];
     const scoped = peopleInScope(PEOPLE, photosInScope(withPeople, noFolders, null));
-    expect(scoped.map((p) => [p.id, p.face_count])).toEqual([[1, 2], [2, 2], [3, 2]]);
+    expect(scoped.map((p) => [p.id, p.face_count]).sort()).toEqual([[1, 2], [2, 2], [3, 2]]);
   });
 });
 

--- a/frontend/src/components/gallery/__tests__/folders.test.ts
+++ b/frontend/src/components/gallery/__tests__/folders.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 
 import {
   filterCategories,
+  peopleInScope,
   findFolderBySlug,
   folderCategoryIds,
   folderTiles,
@@ -115,6 +116,48 @@ describe('filterCategories / folderCategoryIds', () => {
 
   it('collects folder ids', () => {
     expect([...folderCategoryIds(CATEGORIES)]).toEqual([2, 3]);
+  });
+});
+
+describe('peopleInScope', () => {
+  // photo 10 -> Anna; 11 -> Anna+Ben; folder photos 20,21 -> Chris; 30 -> Ben
+  const withPeople: Photo[] = [
+    { ...photo(10, 1), person_ids: [1] },
+    { ...photo(11, null), person_ids: [1, 2] },
+    { ...photo(20, 2), person_ids: [3] },
+    { ...photo(21, 2), person_ids: [3] },
+    { ...photo(22, 2), person_ids: [] },
+    { ...photo(30, 3), person_ids: [2] },
+  ] as unknown as Photo[];
+
+  const PEOPLE = [
+    { id: 1, face_count: 99 },
+    { id: 2, face_count: 99 },
+    { id: 3, face_count: 99 },
+  ];
+
+  it('recounts against the photos actually on screen', () => {
+    const atRoot = peopleInScope(PEOPLE, photosInScope(withPeople, CATEGORIES, null));
+    expect(atRoot).toEqual([
+      { id: 1, face_count: 2 },
+      { id: 2, face_count: 1 },
+    ]);
+  });
+
+  it('drops a person whose photos all live in a folder — no dead chip at root', () => {
+    const atRoot = peopleInScope(PEOPLE, photosInScope(withPeople, CATEGORIES, null));
+    expect(atRoot.map((p) => p.id)).not.toContain(3);
+  });
+
+  it('counts only the folder’s photos while inside it', () => {
+    const inFolder = peopleInScope(PEOPLE, photosInScope(withPeople, CATEGORIES, 2));
+    expect(inFolder).toEqual([{ id: 3, face_count: 2 }]);
+  });
+
+  it('is a no-op for a gallery without folders', () => {
+    const noFolders = [cat({ id: 1, slug: 'ceremony' })];
+    const scoped = peopleInScope(PEOPLE, photosInScope(withPeople, noFolders, null));
+    expect(scoped.map((p) => [p.id, p.face_count])).toEqual([[1, 2], [2, 2], [3, 2]]);
   });
 });
 

--- a/frontend/src/components/gallery/__tests__/folders.test.ts
+++ b/frontend/src/components/gallery/__tests__/folders.test.ts
@@ -9,6 +9,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
   filterCategories,
   peopleInScope,
+  SELECTED_DOWNLOAD_LIMIT,
   findFolderByKey,
   folderKey,
   folderCategoryIds,
@@ -195,6 +196,15 @@ describe('peopleInScope', () => {
     const noFolders = [cat({ id: 1, slug: 'ceremony' })];
     const scoped = peopleInScope(PEOPLE, photosInScope(withPeople, noFolders, null));
     expect(scoped.map((p) => [p.id, p.face_count])).toEqual([[1, 2], [2, 2], [3, 2]]);
+  });
+});
+
+describe('SELECTED_DOWNLOAD_LIMIT', () => {
+  // Mirrors the server-side `.slice(0, 500)` in gallery.js's /download-selected
+  // and /download-jobs. If the backend cap moves and this doesn't, the folder
+  // button silently promises more than the archive will contain.
+  it('matches the cap the backend enforces', () => {
+    expect(SELECTED_DOWNLOAD_LIMIT).toBe(500);
   });
 });
 

--- a/frontend/src/components/gallery/__tests__/folders.test.ts
+++ b/frontend/src/components/gallery/__tests__/folders.test.ts
@@ -64,6 +64,16 @@ describe('photosInScope', () => {
     expect(photosInScope(PHOTOS, filtersOnly, null)).toHaveLength(PHOTOS.length);
   });
 
+  // Callers sort the result in place. Returning `photos` itself on the
+  // no-folders fast path sorted the React Query cache for every other consumer.
+  it('never hands back the caller’s own array', () => {
+    const filtersOnly = [cat({ id: 1, slug: 'ceremony' })];
+    const out = photosInScope(PHOTOS, filtersOnly, null);
+    expect(out).not.toBe(PHOTOS);
+    out.sort((a, b) => b.id - a.id);
+    expect(PHOTOS.map((p) => p.id)).toEqual([10, 11, 20, 21, 22, 30]);
+  });
+
   it('treats a category as a filter until is_folder is set', () => {
     const asFilter = [cat({ id: 2, slug: 'selects' })];
     expect(photosInScope(PHOTOS, asFilter, null)).toHaveLength(PHOTOS.length);
@@ -98,7 +108,7 @@ describe('folderTiles', () => {
 
 describe('findFolderByKey / folderKey', () => {
   it('resolves an open folder', () => {
-    expect(findFolderByKey(CATEGORIES, 'selects')?.id).toBe(2);
+    expect(findFolderByKey(CATEGORIES, 'selects-2')?.id).toBe(2);
   });
 
   it('falls back to root for an unknown key rather than emptying the gallery', () => {
@@ -119,8 +129,20 @@ describe('findFolderByKey / folderKey', () => {
     expect(findFolderByKey([cyrillic], '7')?.id).toBe(7);
   });
 
-  it('still prefers a real slug for readable links', () => {
-    expect(folderKey(CATEGORIES[1])).toBe('selects');
+  it('keeps the slug in the key so links stay readable', () => {
+    expect(folderKey(CATEGORIES[1])).toBe('selects-2');
+  });
+
+  // Regression: UNIQUE is (slug, event_id), so a global folder and an
+  // event-specific folder can share a slug. Keying on the slug alone made the
+  // second one unopenable — every lookup matched the first.
+  it('distinguishes two folders that share a slug across scopes', () => {
+    const globalSelects = cat({ id: 20, slug: 'selects', is_global: true, is_folder: true });
+    const eventSelects = cat({ id: 21, slug: 'selects', is_folder: true });
+    const both = [globalSelects, eventSelects];
+    expect(folderKey(globalSelects)).not.toBe(folderKey(eventSelects));
+    expect(findFolderByKey(both, folderKey(eventSelects))?.id).toBe(21);
+    expect(findFolderByKey(both, folderKey(globalSelects))?.id).toBe(20);
   });
 });
 

--- a/frontend/src/components/gallery/__tests__/folders.test.ts
+++ b/frontend/src/components/gallery/__tests__/folders.test.ts
@@ -130,6 +130,13 @@ describe('findFolderByKey / folderKey', () => {
     expect(findFolderByKey([cyrillic], '7')?.id).toBe(7);
   });
 
+  // A rename rewrites the slug, so a link already shared with a client must not
+  // silently dump them at the gallery root.
+  it('still resolves a link shared before the folder was renamed', () => {
+    const renamed = cat({ id: 2, slug: 'final-selects', is_folder: true });
+    expect(findFolderByKey([renamed], 'selects-2')?.id).toBe(2);
+  });
+
   it('keeps the slug in the key so links stay readable', () => {
     expect(folderKey(CATEGORIES[1])).toBe('selects-2');
   });

--- a/frontend/src/components/gallery/__tests__/folders.test.ts
+++ b/frontend/src/components/gallery/__tests__/folders.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Gallery folders (#1160) — the containment rule.
+ *
+ * The whole point of the feature: a foldered photo is ABSENT from the root grid
+ * and only appears inside its folder. A filter category keeps today's behaviour.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import {
+  filterCategories,
+  findFolderBySlug,
+  folderCategoryIds,
+  folderTiles,
+  photosInScope,
+  readFolderParam,
+  writeFolderParam,
+} from '../folders';
+import type { Photo, PhotoCategory } from '../../../types';
+
+const cat = (over: Partial<PhotoCategory> & { id: number; slug: string }): PhotoCategory => ({
+  name: over.slug,
+  is_global: false,
+  ...over,
+});
+
+const photo = (id: number, category_id?: number | null): Photo =>
+  ({ id, filename: `${id}.jpg`, category_id: category_id ?? null } as unknown as Photo);
+
+const CATEGORIES: PhotoCategory[] = [
+  cat({ id: 1, slug: 'ceremony' }),
+  cat({ id: 2, slug: 'selects', is_folder: true }),
+  cat({ id: 3, slug: 'bw', is_folder: true }),
+];
+
+// 2 finals (one categorised, one loose), 3 in a folder, 1 in another folder.
+const PHOTOS: Photo[] = [
+  photo(10, 1),
+  photo(11, null),
+  photo(20, 2),
+  photo(21, 2),
+  photo(22, 2),
+  photo(30, 3),
+];
+
+describe('photosInScope', () => {
+  it('drops every foldered photo from the root grid', () => {
+    const ids = photosInScope(PHOTOS, CATEGORIES, null).map((p) => p.id);
+    expect(ids).toEqual([10, 11]);
+  });
+
+  it('keeps uncategorised photos at root', () => {
+    expect(photosInScope(PHOTOS, CATEGORIES, null).map((p) => p.id)).toContain(11);
+  });
+
+  it('shows only that folder’s photos inside a folder', () => {
+    expect(photosInScope(PHOTOS, CATEGORIES, 2).map((p) => p.id)).toEqual([20, 21, 22]);
+    expect(photosInScope(PHOTOS, CATEGORIES, 3).map((p) => p.id)).toEqual([30]);
+  });
+
+  it('leaves a gallery without folders completely unchanged', () => {
+    const filtersOnly = [cat({ id: 1, slug: 'ceremony' })];
+    expect(photosInScope(PHOTOS, filtersOnly, null)).toHaveLength(PHOTOS.length);
+  });
+
+  it('treats a category as a filter until is_folder is set', () => {
+    const asFilter = [cat({ id: 2, slug: 'selects' })];
+    expect(photosInScope(PHOTOS, asFilter, null)).toHaveLength(PHOTOS.length);
+  });
+});
+
+describe('folderTiles', () => {
+  it('builds one tile per non-empty folder with its count', () => {
+    const tiles = folderTiles(CATEGORIES, PHOTOS);
+    expect(tiles.map((t) => [t.category.slug, t.count])).toEqual([
+      ['selects', 3],
+      ['bw', 1],
+    ]);
+  });
+
+  it('hides empty folders — a guest must not hit a dead end', () => {
+    const tiles = folderTiles([...CATEGORIES, cat({ id: 4, slug: 'empty', is_folder: true })], PHOTOS);
+    expect(tiles.map((t) => t.category.slug)).not.toContain('empty');
+  });
+
+  it('prefers the category hero as the cover, else the first photo', () => {
+    const withHero = [cat({ id: 2, slug: 'selects', is_folder: true, hero_photo_id: 22 })];
+    expect(folderTiles(withHero, PHOTOS)[0].coverPhoto?.id).toBe(22);
+    expect(folderTiles([CATEGORIES[1]], PHOTOS)[0].coverPhoto?.id).toBe(20);
+  });
+
+  it('falls back to the first photo when the hero left the folder', () => {
+    const staleHero = [cat({ id: 2, slug: 'selects', is_folder: true, hero_photo_id: 999 })];
+    expect(folderTiles(staleHero, PHOTOS)[0].coverPhoto?.id).toBe(20);
+  });
+});
+
+describe('findFolderBySlug', () => {
+  it('resolves an open folder', () => {
+    expect(findFolderBySlug(CATEGORIES, 'selects')?.id).toBe(2);
+  });
+
+  it('falls back to root for an unknown slug rather than emptying the gallery', () => {
+    expect(findFolderBySlug(CATEGORIES, 'nope')).toBeNull();
+  });
+
+  it('refuses to open a filter category as a folder', () => {
+    expect(findFolderBySlug(CATEGORIES, 'ceremony')).toBeNull();
+  });
+});
+
+describe('filterCategories / folderCategoryIds', () => {
+  it('offers only filter categories to the filter UI', () => {
+    expect(filterCategories(CATEGORIES).map((c) => c.slug)).toEqual(['ceremony']);
+  });
+
+  it('collects folder ids', () => {
+    expect([...folderCategoryIds(CATEGORIES)]).toEqual([2, 3]);
+  });
+});
+
+describe('URL round-trip', () => {
+  const original = window.location.href;
+
+  beforeEach(() => window.history.replaceState({}, '', '/gallery/wed?token=abc&admin_preview=1'));
+  afterEach(() => window.history.replaceState({}, '', original));
+
+  it('reflects the open folder without dropping token or admin_preview', () => {
+    writeFolderParam('selects');
+    const params = new URLSearchParams(window.location.search);
+    expect(params.get('folder')).toBe('selects');
+    expect(params.get('token')).toBe('abc');
+    expect(params.get('admin_preview')).toBe('1');
+    expect(readFolderParam()).toBe('selects');
+  });
+
+  it('clears the param on the way back to root', () => {
+    writeFolderParam('selects');
+    writeFolderParam(null);
+    expect(readFolderParam()).toBeNull();
+    expect(new URLSearchParams(window.location.search).get('token')).toBe('abc');
+  });
+});

--- a/frontend/src/components/gallery/folders.ts
+++ b/frontend/src/components/gallery/folders.ts
@@ -18,6 +18,14 @@ import type { Photo, PhotoCategory } from '../../types';
 
 export const FOLDER_QUERY_PARAM = 'folder';
 
+/**
+ * Server-side cap on `/download-selected` and `/download-jobs`
+ * (gallery.js slices the id list to this). Mirrored here so the folder download
+ * can say what it will actually deliver instead of promising the whole folder
+ * and quietly handing back the first 500.
+ */
+export const SELECTED_DOWNLOAD_LIMIT = 500;
+
 /** Ids of every category that contains (rather than filters) its photos. */
 export function folderCategoryIds(categories: PhotoCategory[] | undefined): Set<number | string> {
   const ids = new Set<number | string>();

--- a/frontend/src/components/gallery/folders.ts
+++ b/frontend/src/components/gallery/folders.ts
@@ -27,13 +27,28 @@ export function folderCategoryIds(categories: PhotoCategory[] | undefined): Set<
   return ids;
 }
 
-/** The folder matching a `?folder=<slug>`, or null at root / for an unknown slug. */
-export function findFolderBySlug(
+/**
+ * The URL key for a folder.
+ *
+ * Prefers the slug because it makes a shared link readable, but falls back to
+ * the id: `adminCategories` derives slugs with `[^\w\s-]` stripping, and `\w`
+ * is ASCII-only, so a perfectly valid name in a non-Latin script ("Избранное",
+ * "日本語") slugs to the empty string. An empty key would delete the query
+ * param on open and never resolve on read — the folder's photos would be gone
+ * from the root grid with no way back to them.
+ */
+export function folderKey(category: Pick<PhotoCategory, 'id' | 'slug'>): string {
+  const slug = (category.slug || '').trim();
+  return slug || String(category.id);
+}
+
+/** The folder matching a `?folder=<key>`, or null at root / for an unknown key. */
+export function findFolderByKey(
   categories: PhotoCategory[] | undefined,
-  slug: string | null
+  key: string | null
 ): PhotoCategory | null {
-  if (!slug) return null;
-  return (categories || []).find((c) => c.is_folder && c.slug === slug) || null;
+  if (!key) return null;
+  return (categories || []).find((c) => c.is_folder && folderKey(c) === key) || null;
 }
 
 /**

--- a/frontend/src/components/gallery/folders.ts
+++ b/frontend/src/components/gallery/folders.ts
@@ -139,9 +139,13 @@ export function peopleInScope<T extends { id: number; face_count: number }>(
     ids.forEach((id) => counts.set(id, (counts.get(id) || 0) + 1));
   });
 
+  // Re-sorted, not just recounted: /people orders by the EVENT-wide count, and
+  // PeopleStrip only shows the first 12 inline. Keeping that order after
+  // rescoping can push the folder's most-photographed person behind "Show all".
   return list
     .map((person) => ({ ...person, face_count: counts.get(person.id) || 0 }))
-    .filter((person) => person.face_count > 0);
+    .filter((person) => person.face_count > 0)
+    .sort((a, b) => b.face_count - a.face_count);
 }
 
 /** Categories that still act as filters — the only ones the filter UI should offer. */

--- a/frontend/src/components/gallery/folders.ts
+++ b/frontend/src/components/gallery/folders.ts
@@ -1,0 +1,114 @@
+/**
+ * Gallery folders (#1160).
+ *
+ * A category has always been a FILTER: its photos stay in the root grid and
+ * picking the category narrows that grid. A category flagged `is_folder` is a
+ * CONTAINER instead — its photos are absent from the root grid entirely and only
+ * render once the guest opens the folder.
+ *
+ * Kept as pure functions so the containment rule is unit-testable without
+ * mounting the gallery, and so every layout shares one definition of "what is
+ * visible right now".
+ *
+ * NOTE: folders are organisational, not access control. A foldered photo is
+ * still served by the same per-photo auth as any other; hiding it from the root
+ * grid does not make its URL unreachable.
+ */
+import type { Photo, PhotoCategory } from '../../types';
+
+export const FOLDER_QUERY_PARAM = 'folder';
+
+/** Ids of every category that contains (rather than filters) its photos. */
+export function folderCategoryIds(categories: PhotoCategory[] | undefined): Set<number | string> {
+  const ids = new Set<number | string>();
+  (categories || []).forEach((c) => {
+    if (c.is_folder) ids.add(c.id);
+  });
+  return ids;
+}
+
+/** The folder matching a `?folder=<slug>`, or null at root / for an unknown slug. */
+export function findFolderBySlug(
+  categories: PhotoCategory[] | undefined,
+  slug: string | null
+): PhotoCategory | null {
+  if (!slug) return null;
+  return (categories || []).find((c) => c.is_folder && c.slug === slug) || null;
+}
+
+/**
+ * The photos in scope right now.
+ *
+ * Root: everything except photos living in a folder (uncategorised photos always
+ * belong to root). Inside a folder: only that folder's photos.
+ */
+export function photosInScope(
+  photos: Photo[] | undefined,
+  categories: PhotoCategory[] | undefined,
+  openFolderId: number | string | null
+): Photo[] {
+  const list = photos || [];
+  if (openFolderId !== null && openFolderId !== undefined) {
+    return list.filter((p) => p.category_id === openFolderId);
+  }
+  const folders = folderCategoryIds(categories);
+  if (folders.size === 0) return list;
+  return list.filter((p) => !p.category_id || !folders.has(p.category_id));
+}
+
+export interface FolderTile {
+  category: PhotoCategory;
+  count: number;
+  coverPhoto: Photo | null;
+}
+
+/**
+ * Folder tiles for the root view, in the order the backend resolved (#782).
+ *
+ * Only folders that actually hold photos get a tile — an empty folder would be a
+ * dead end for a guest. The cover is the category hero (#163) when it is still
+ * in the folder, else the folder's first photo.
+ */
+export function folderTiles(
+  categories: PhotoCategory[] | undefined,
+  photos: Photo[] | undefined
+): FolderTile[] {
+  const list = photos || [];
+  return (categories || [])
+    .filter((c) => c.is_folder)
+    .map((category) => {
+      const contents = list.filter((p) => p.category_id === category.id);
+      const hero = category.hero_photo_id
+        ? contents.find((p) => p.id === category.hero_photo_id) || null
+        : null;
+      return { category, count: contents.length, coverPhoto: hero || contents[0] || null };
+    })
+    .filter((tile) => tile.count > 0);
+}
+
+/** Categories that still act as filters — the only ones the filter UI should offer. */
+export function filterCategories(categories: PhotoCategory[] | undefined): PhotoCategory[] {
+  return (categories || []).filter((c) => !c.is_folder);
+}
+
+/** Read the open folder slug from the address bar. */
+export function readFolderParam(): string | null {
+  if (typeof window === 'undefined') return null;
+  return new URLSearchParams(window.location.search).get(FOLDER_QUERY_PARAM);
+}
+
+/**
+ * Reflect the open folder in the address bar so a folder is linkable and the
+ * back button leaves it. Preserves every other param — `token` and
+ * `admin_preview` (#868) both ride on gallery URLs.
+ */
+export function writeFolderParam(slug: string | null): void {
+  if (typeof window === 'undefined') return;
+  const url = new URL(window.location.href);
+  if (slug) {
+    url.searchParams.set(FOLDER_QUERY_PARAM, slug);
+  } else {
+    url.searchParams.delete(FOLDER_QUERY_PARAM);
+  }
+  window.history.pushState({ [FOLDER_QUERY_PARAM]: slug }, '', url.toString());
+}

--- a/frontend/src/components/gallery/folders.ts
+++ b/frontend/src/components/gallery/folders.ts
@@ -86,6 +86,34 @@ export function folderTiles(
     .filter((tile) => tile.count > 0);
 }
 
+/**
+ * People, recounted against the photos actually on screen (#1160).
+ *
+ * `face_count` comes from /people and spans the whole event, which contradicts
+ * the grid once folders exist: inside a folder a face reads "12 photos" but
+ * clicking it yields only the ones in that folder, and at root a person whose
+ * photos ALL live in a folder shows up and filters down to nothing — a dead
+ * chip. Recomputing from `photo.person_ids` (already what the filter itself
+ * uses) keeps the strip honest, and dropping the zeroes removes the dead chips.
+ */
+export function peopleInScope<T extends { id: number; face_count: number }>(
+  people: T[] | undefined,
+  scopedPhotos: Photo[] | undefined
+): T[] {
+  const list = people || [];
+  if (list.length === 0) return list;
+
+  const counts = new Map<number, number>();
+  (scopedPhotos || []).forEach((photo) => {
+    const ids = (photo as Photo & { person_ids?: number[] }).person_ids || [];
+    ids.forEach((id) => counts.set(id, (counts.get(id) || 0) + 1));
+  });
+
+  return list
+    .map((person) => ({ ...person, face_count: counts.get(person.id) || 0 }))
+    .filter((person) => person.face_count > 0);
+}
+
 /** Categories that still act as filters — the only ones the filter UI should offer. */
 export function filterCategories(categories: PhotoCategory[] | undefined): PhotoCategory[] {
   return (categories || []).filter((c) => !c.is_folder);

--- a/frontend/src/components/gallery/folders.ts
+++ b/frontend/src/components/gallery/folders.ts
@@ -39,7 +39,11 @@ export function folderCategoryIds(categories: PhotoCategory[] | undefined): Set<
  */
 export function folderKey(category: Pick<PhotoCategory, 'id' | 'slug'>): string {
   const slug = (category.slug || '').trim();
-  return slug || String(category.id);
+  // The id is always appended: slugs are only unique per scope
+  // (UNIQUE(slug, event_id)), so a global folder and an event folder can share
+  // one. Keying on the slug alone made the second of the pair unopenable —
+  // every lookup resolved to the first match.
+  return slug ? `${slug}-${category.id}` : String(category.id);
 }
 
 /** The folder matching a `?folder=<key>`, or null at root / for an unknown key. */
@@ -67,7 +71,10 @@ export function photosInScope(
     return list.filter((p) => p.category_id === openFolderId);
   }
   const folders = folderCategoryIds(categories);
-  if (folders.size === 0) return list;
+  // Always a NEW array, even on the no-folders fast path: callers sort the
+  // result in place, and handing back `data.photos` itself would sort the React
+  // Query cache and reorder it for every other consumer.
+  if (folders.size === 0) return [...list];
   return list.filter((p) => !p.category_id || !folders.has(p.category_id));
 }
 

--- a/frontend/src/components/gallery/folders.ts
+++ b/frontend/src/components/gallery/folders.ts
@@ -54,13 +54,29 @@ export function folderKey(category: Pick<PhotoCategory, 'id' | 'slug'>): string 
   return slug ? `${slug}-${category.id}` : String(category.id);
 }
 
-/** The folder matching a `?folder=<key>`, or null at root / for an unknown key. */
+/**
+ * The folder matching a `?folder=<key>`, or null at root / for an unknown key.
+ *
+ * Resolves on the trailing ID rather than the whole key: renaming a category
+ * rewrites its slug, so an already-shared `?folder=selects-11` would otherwise
+ * stop matching and silently dump the visitor at the gallery root. The slug is
+ * there to make the link readable, not to identify the folder.
+ */
 export function findFolderByKey(
   categories: PhotoCategory[] | undefined,
   key: string | null
 ): PhotoCategory | null {
   if (!key) return null;
-  return (categories || []).find((c) => c.is_folder && folderKey(c) === key) || null;
+  const list = categories || [];
+
+  const trailing = key.split('-').pop();
+  const id = trailing !== undefined && trailing !== '' ? Number(trailing) : NaN;
+  if (Number.isInteger(id)) {
+    const byId = list.find((c) => c.is_folder && Number(c.id) === id);
+    if (byId) return byId;
+  }
+
+  return list.find((c) => c.is_folder && folderKey(c) === key) || null;
 }
 
 /**

--- a/frontend/src/components/gallery/layouts/BaseGalleryLayout.tsx
+++ b/frontend/src/components/gallery/layouts/BaseGalleryLayout.tsx
@@ -27,6 +27,13 @@ export interface BaseGalleryLayoutProps {
   allowDownloads?: boolean;
   /** #1160: folder-only root — render the shell, skip the empty message. */
   suppressEmptyState?: boolean;
+  /**
+   * Every photo id in the EVENT (#1160). A layout's own "Download All Photos"
+   * must not be built from the `photos` prop once folders exist: that prop is
+   * the current scope, so the control would silently omit foldered photos while
+   * still calling itself Download All.
+   */
+  downloadAllIds?: number[];
   // Resolution picker choices (#858). More than one entry means the gallery
   // offers a real choice, so bulk downloads must route through the modal
   // instead of calling downloadSelectedPhotos directly.

--- a/frontend/src/components/gallery/layouts/BaseGalleryLayout.tsx
+++ b/frontend/src/components/gallery/layouts/BaseGalleryLayout.tsx
@@ -28,12 +28,18 @@ export interface BaseGalleryLayoutProps {
   /** #1160: folder-only root — render the shell, skip the empty message. */
   suppressEmptyState?: boolean;
   /**
-   * Every photo id in the EVENT (#1160). A layout's own "Download All Photos"
-   * must not be built from the `photos` prop once folders exist: that prop is
-   * the current scope, so the control would silently omit foldered photos while
-   * still calling itself Download All.
+   * Event-wide photo count (#1160), for stats a layout renders about the whole
+   * gallery. `photos` is only the current folder scope and is empty at a
+   * folder-only root.
    */
-  downloadAllIds?: number[];
+  eventPhotoCount?: number;
+  /**
+   * Runs the whole-gallery download (#1160). A layout's own "Download All
+   * Photos" must use this rather than posting an id list: /download-selected
+   * caps at 500 server-side, so a large gallery would silently truncate, while
+   * /download-all has no such cap.
+   */
+  onDownloadEverything?: () => void;
   // Resolution picker choices (#858). More than one entry means the gallery
   // offers a real choice, so bulk downloads must route through the modal
   // instead of calling downloadSelectedPhotos directly.

--- a/frontend/src/components/gallery/layouts/BaseGalleryLayout.tsx
+++ b/frontend/src/components/gallery/layouts/BaseGalleryLayout.tsx
@@ -25,6 +25,8 @@ export interface BaseGalleryLayoutProps {
   eventDate?: string | null;
   expiresAt?: string | null;
   allowDownloads?: boolean;
+  /** #1160: folder-only root — render the shell, skip the empty message. */
+  suppressEmptyState?: boolean;
   // Resolution picker choices (#858). More than one entry means the gallery
   // offers a real choice, so bulk downloads must route through the modal
   // instead of calling downloadSelectedPhotos directly.

--- a/frontend/src/components/gallery/layouts/GalleryPremiumLayout.tsx
+++ b/frontend/src/components/gallery/layouts/GalleryPremiumLayout.tsx
@@ -45,6 +45,8 @@ interface PhotoCardProps {
   isLiked: boolean;
   slug: string;
   allowDownloads?: boolean;
+  /** #1160: folder-only root — render the shell, skip the empty message. */
+  suppressEmptyState?: boolean;
   protectionLevel?: 'basic' | 'standard' | 'enhanced' | 'maximum';
   useEnhancedProtection?: boolean;
   useCanvasRendering?: boolean;
@@ -68,6 +70,7 @@ const PhotoCard: React.FC<PhotoCardProps> = ({
   isLiked,
   slug,
   allowDownloads = true,
+  suppressEmptyState = false,
   protectionLevel = 'standard',
   useEnhancedProtection = false,
   useCanvasRendering = false,
@@ -477,7 +480,10 @@ export const GalleryPremiumLayout: React.FC<GalleryPremiumLayoutProps> = ({
     day: '2-digit'
   }) : null;
 
-  if (photos.length === 0) {
+  // #1160: a folder-only root has no photos to show here, but the folder tiles
+  // above prove the gallery isn't empty — render the shell (hero, logout,
+  // controls) without the contradictory message.
+  if (photos.length === 0 && !suppressEmptyState) {
     return (
       <div className="text-center py-12">
         <p className="text-gray-500">{t('gallery.noPhotosFound')}</p>

--- a/frontend/src/components/gallery/layouts/GalleryPremiumLayout.tsx
+++ b/frontend/src/components/gallery/layouts/GalleryPremiumLayout.tsx
@@ -45,8 +45,6 @@ interface PhotoCardProps {
   isLiked: boolean;
   slug: string;
   allowDownloads?: boolean;
-  /** #1160: folder-only root — render the shell, skip the empty message. */
-  suppressEmptyState?: boolean;
   protectionLevel?: 'basic' | 'standard' | 'enhanced' | 'maximum';
   useEnhancedProtection?: boolean;
   useCanvasRendering?: boolean;
@@ -70,7 +68,6 @@ const PhotoCard: React.FC<PhotoCardProps> = ({
   isLiked,
   slug,
   allowDownloads = true,
-  suppressEmptyState = false,
   protectionLevel = 'standard',
   useEnhancedProtection = false,
   useCanvasRendering = false,
@@ -196,9 +193,12 @@ const PhotoCard: React.FC<PhotoCardProps> = ({
 
 interface GalleryPremiumLayoutProps extends BaseGalleryLayoutProps {
   heroPhotoOverride?: Photo | null;
+  suppressEmptyState?: boolean;
 }
 
 export const GalleryPremiumLayout: React.FC<GalleryPremiumLayoutProps> = ({
+  // #1160: folder-only root — render the shell, skip the empty message.
+  suppressEmptyState = false,
   photos,
   slug,
   onPhotoClick: _onPhotoClick,

--- a/frontend/src/components/gallery/layouts/GalleryPremiumLayout.tsx
+++ b/frontend/src/components/gallery/layouts/GalleryPremiumLayout.tsx
@@ -576,7 +576,7 @@ export const GalleryPremiumLayout: React.FC<GalleryPremiumLayoutProps> = ({
                 <Heart className="w-4 h-4" />
               </button>
             )}
-            {allowDownloads && (
+            {allowDownloads && photos.length > 0 && (
               <button
                 className="gallery-premium-nav-btn"
                 title={t('common.downloadAll', 'Download All')}

--- a/frontend/src/components/gallery/layouts/GalleryStoryLayout.tsx
+++ b/frontend/src/components/gallery/layouts/GalleryStoryLayout.tsx
@@ -52,7 +52,8 @@ export const GalleryStoryLayout: React.FC<GalleryStoryLayoutProps> = ({
   eventDate,
   allowDownloads = true,
   suppressEmptyState = false,
-  downloadAllIds,
+  eventPhotoCount,
+  onDownloadEverything,
   downloadChoices,
   onPickResolution,
   protectionLevel = 'standard',
@@ -144,7 +145,7 @@ export const GalleryStoryLayout: React.FC<GalleryStoryLayoutProps> = ({
   // #1160: on a folder-only root this component renders its shell with an empty
   // scope, so fall back to the event-wide count rather than announcing 0 Photos
   // directly above folder tiles that hold them.
-  const totalPhotos = photos.length || downloadAllIds?.length || 0;
+  const totalPhotos = photos.length || eventPhotoCount || 0;
   const stats = `${totalPhotos} ${t('gallery.photos', 'Photos')}`;
 
   const handleToggleFavorite = useCallback(async (photoId: number) => {
@@ -242,14 +243,18 @@ export const GalleryStoryLayout: React.FC<GalleryStoryLayoutProps> = ({
   }, [selectedPhotoForFeedback, ratings, slug, savedIdentity, onFeedbackChange]);
 
   const handleDownloadAll = useCallback(async () => {
-    // Event-wide when supplied — `photos` is only the current folder scope.
-    const ids = downloadAllIds ?? photos.map(p => p.id);
+    // Whole-gallery path when available: posting ids would hit the server's
+    // 500-id cap and silently truncate a large gallery (#1160).
+    if (onDownloadEverything) {
+      onDownloadEverything();
+      return;
+    }
+    const ids = photos.map(p => p.id);
     // #858: hand off to the resolution picker when the gallery offers a choice.
     if (downloadChoices && downloadChoices.length > 1 && onPickResolution) {
       onPickResolution(ids);
       return;
     }
-    // ids may be event-wide while `photos` is the current scope (#1160).
     toast.info(t('gallery.downloading', { count: ids.length }));
     try {
       await galleryService.downloadSelectedPhotos(slug, ids);
@@ -257,7 +262,7 @@ export const GalleryStoryLayout: React.FC<GalleryStoryLayoutProps> = ({
     } catch {
       toast.error(t('gallery.downloadError'));
     }
-  }, [photos, downloadAllIds, slug, t, downloadChoices, onPickResolution]);
+  }, [photos, onDownloadEverything, slug, t, downloadChoices, onPickResolution]);
 
   // #1160: a folder-only root has no photos to show here, but the folder tiles
   // above prove the gallery isn't empty — render the shell (hero, logout,

--- a/frontend/src/components/gallery/layouts/GalleryStoryLayout.tsx
+++ b/frontend/src/components/gallery/layouts/GalleryStoryLayout.tsx
@@ -388,7 +388,11 @@ export const GalleryStoryLayout: React.FC<GalleryStoryLayoutProps> = ({
         <p className="story-footer-text">
           {welcomeMessage || t('gallery.thankYouMessage', 'For being part of our story and making our special day unforgettable.')}
         </p>
-        {allowDownloads && (
+        {/* Needs something to download: either the whole-gallery callback, or
+            photos in the current scope. On a folder-only root of a gallery with
+            a category download opt-out it has neither, and posting an empty id
+            list is a 400 (#1160). */}
+        {allowDownloads && (onDownloadEverything || photos.length > 0) && (
           <button className="story-footer-btn" onClick={handleDownloadAll}>
             {t('common.downloadAll', 'Download All Photos')}
           </button>

--- a/frontend/src/components/gallery/layouts/GalleryStoryLayout.tsx
+++ b/frontend/src/components/gallery/layouts/GalleryStoryLayout.tsx
@@ -52,6 +52,7 @@ export const GalleryStoryLayout: React.FC<GalleryStoryLayoutProps> = ({
   eventDate,
   allowDownloads = true,
   suppressEmptyState = false,
+  downloadAllIds,
   downloadChoices,
   onPickResolution,
   protectionLevel = 'standard',
@@ -238,7 +239,8 @@ export const GalleryStoryLayout: React.FC<GalleryStoryLayoutProps> = ({
   }, [selectedPhotoForFeedback, ratings, slug, savedIdentity, onFeedbackChange]);
 
   const handleDownloadAll = useCallback(async () => {
-    const ids = photos.map(p => p.id);
+    // Event-wide when supplied — `photos` is only the current folder scope.
+    const ids = downloadAllIds ?? photos.map(p => p.id);
     // #858: hand off to the resolution picker when the gallery offers a choice.
     if (downloadChoices && downloadChoices.length > 1 && onPickResolution) {
       onPickResolution(ids);
@@ -251,7 +253,7 @@ export const GalleryStoryLayout: React.FC<GalleryStoryLayoutProps> = ({
     } catch {
       toast.error(t('gallery.downloadError'));
     }
-  }, [photos, slug, t, downloadChoices, onPickResolution]);
+  }, [photos, downloadAllIds, slug, t, downloadChoices, onPickResolution]);
 
   // #1160: a folder-only root has no photos to show here, but the folder tiles
   // above prove the gallery isn't empty — render the shell (hero, logout,

--- a/frontend/src/components/gallery/layouts/GalleryStoryLayout.tsx
+++ b/frontend/src/components/gallery/layouts/GalleryStoryLayout.tsx
@@ -141,7 +141,10 @@ export const GalleryStoryLayout: React.FC<GalleryStoryLayoutProps> = ({
     }));
   }, [photos, searchQuery, t]);
 
-  const totalPhotos = photos.length;
+  // #1160: on a folder-only root this component renders its shell with an empty
+  // scope, so fall back to the event-wide count rather than announcing 0 Photos
+  // directly above folder tiles that hold them.
+  const totalPhotos = photos.length || downloadAllIds?.length || 0;
   const stats = `${totalPhotos} ${t('gallery.photos', 'Photos')}`;
 
   const handleToggleFavorite = useCallback(async (photoId: number) => {

--- a/frontend/src/components/gallery/layouts/GalleryStoryLayout.tsx
+++ b/frontend/src/components/gallery/layouts/GalleryStoryLayout.tsx
@@ -246,7 +246,8 @@ export const GalleryStoryLayout: React.FC<GalleryStoryLayoutProps> = ({
       onPickResolution(ids);
       return;
     }
-    toast.info(t('gallery.downloading', { count: photos.length }));
+    // ids may be event-wide while `photos` is the current scope (#1160).
+    toast.info(t('gallery.downloading', { count: ids.length }));
     try {
       await galleryService.downloadSelectedPhotos(slug, ids);
       analyticsService.trackGalleryEvent('bulk_download', { gallery: slug, photo_count: ids.length });

--- a/frontend/src/components/gallery/layouts/GalleryStoryLayout.tsx
+++ b/frontend/src/components/gallery/layouts/GalleryStoryLayout.tsx
@@ -51,6 +51,7 @@ export const GalleryStoryLayout: React.FC<GalleryStoryLayoutProps> = ({
   eventName,
   eventDate,
   allowDownloads = true,
+  suppressEmptyState = false,
   downloadChoices,
   onPickResolution,
   protectionLevel = 'standard',
@@ -252,7 +253,10 @@ export const GalleryStoryLayout: React.FC<GalleryStoryLayoutProps> = ({
     }
   }, [photos, slug, t, downloadChoices, onPickResolution]);
 
-  if (photos.length === 0) {
+  // #1160: a folder-only root has no photos to show here, but the folder tiles
+  // above prove the gallery isn't empty — render the shell (hero, logout,
+  // controls) without the contradictory message.
+  if (photos.length === 0 && !suppressEmptyState) {
     return (
       <div className="text-center py-12">
         <p className="text-gray-500">{t('gallery.noPhotosFound')}</p>

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1092,7 +1092,8 @@
     "folderPhotoCount": "{{count}} Fotos",
     "backToGallery": "Alle Fotos",
     "downloadFolder": "Ordner herunterladen ({{count}})",
-    "downloadFolderCapped": "Erste {{limit}} von {{total}} herunterladen"
+    "downloadFolderCapped": "Erste {{limit}} von {{total}} herunterladen",
+    "downloadEverything": "Alle Fotos herunterladen"
   },
   "categories": {
     "title": "Fotokategorien",

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1091,7 +1091,8 @@
     "openFolder": "Ordner {{name}} öffnen",
     "folderPhotoCount": "{{count}} Fotos",
     "backToGallery": "Alle Fotos",
-    "downloadFolder": "Ordner herunterladen ({{count}})"
+    "downloadFolder": "Ordner herunterladen ({{count}})",
+    "downloadFolderCapped": "Erste {{limit}} von {{total}} herunterladen"
   },
   "categories": {
     "title": "Fotokategorien",

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1090,7 +1090,8 @@
     "folders": "Ordner",
     "openFolder": "Ordner {{name}} öffnen",
     "folderPhotoCount": "{{count}} Fotos",
-    "backToGallery": "Alle Fotos"
+    "backToGallery": "Alle Fotos",
+    "downloadFolder": "Ordner herunterladen ({{count}})"
   },
   "categories": {
     "title": "Fotokategorien",
@@ -4209,7 +4210,8 @@
     "movedToCategory_one": "{{count}} Foto nach {{category}} verschoben",
     "movedToCategory_other": "{{count}} Fotos nach {{category}} verschoben",
     "moveToCategoryFailed": "Fotos konnten nicht in die Kategorie verschoben werden",
-    "moveToCategory": "In Kategorie verschieben"
+    "moveToCategory": "In Kategorie verschieben",
+    "folderOption": "{{name}} (Ordner — im Hauptraster ausgeblendet)"
   },
   "customer": {
     "login": {

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1086,7 +1086,11 @@
       "downloadThese": "Diese {{count}} herunterladen"
     },
     "colorFilter": "Farbe",
-    "filterByColor": "Nur {{color}} anzeigen"
+    "filterByColor": "Nur {{color}} anzeigen",
+    "folders": "Ordner",
+    "openFolder": "Ordner {{name}} öffnen",
+    "folderPhotoCount": "{{count}} Fotos",
+    "backToGallery": "Alle Fotos"
   },
   "categories": {
     "title": "Fotokategorien",
@@ -1121,7 +1125,12 @@
     "downloadsDisabled": "Downloads für diese Kategorie deaktiviert",
     "enableDownloadsTitle": "Klicken zum Aktivieren der Downloads für diese Kategorie",
     "disableDownloadsTitle": "Klicken zum Deaktivieren der Downloads für diese Kategorie",
-    "failedToToggleDownloads": "Aktualisierung der Download-Berechtigung fehlgeschlagen"
+    "failedToToggleDownloads": "Aktualisierung der Download-Berechtigung fehlgeschlagen",
+    "folderEnabled": "Fotos dieser Kategorie liegen jetzt in einem Ordner",
+    "folderDisabled": "Diese Kategorie filtert die Galerie wieder",
+    "failedToToggleFolder": "Ordner-Einstellung konnte nicht geändert werden",
+    "disableFolderTitle": "Ordner: Diese Fotos sind im Hauptraster ausgeblendet und nur im Ordner sichtbar. Klicken, um wieder einen Filter daraus zu machen.",
+    "enableFolderTitle": "Filter: Diese Fotos bleiben im Hauptraster. Klicken, um einen Ordner daraus zu machen — blendet sie aus, schränkt den Zugriff aber NICHT ein."
   },
   "events": {
     "revealMode": "Reveal-Modus (Galerie bis zur Freigabe verbergen)",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -631,7 +631,8 @@
     "folders": "Folders",
     "openFolder": "Open folder {{name}}",
     "folderPhotoCount": "{{count}} photos",
-    "backToGallery": "All photos"
+    "backToGallery": "All photos",
+    "downloadFolder": "Download folder ({{count}})"
   },
   "categories": {
     "title": "Photo Categories",
@@ -4209,7 +4210,8 @@
     "movedToCategory_one": "{{count}} photos moved to {{category}}",
     "movedToCategory_other": "{{count}} photos moved to {{category}}",
     "moveToCategoryFailed": "Failed to move photos to category",
-    "moveToCategory": "Move to Category"
+    "moveToCategory": "Move to Category",
+    "folderOption": "{{name}} (folder — hidden from the main grid)"
   },
   "customer": {
     "login": {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -633,7 +633,8 @@
     "folderPhotoCount": "{{count}} photos",
     "backToGallery": "All photos",
     "downloadFolder": "Download folder ({{count}})",
-    "downloadFolderCapped": "Download first {{limit}} of {{total}}"
+    "downloadFolderCapped": "Download first {{limit}} of {{total}}",
+    "downloadEverything": "Download all photos"
   },
   "categories": {
     "title": "Photo Categories",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -627,7 +627,11 @@
       "downloadThese": "Download these {{count}}"
     },
     "colorFilter": "Color",
-    "filterByColor": "Show only {{color}}"
+    "filterByColor": "Show only {{color}}",
+    "folders": "Folders",
+    "openFolder": "Open folder {{name}}",
+    "folderPhotoCount": "{{count}} photos",
+    "backToGallery": "All photos"
   },
   "categories": {
     "title": "Photo Categories",
@@ -662,7 +666,12 @@
     "downloadsDisabled": "Downloads disabled for this category",
     "enableDownloadsTitle": "Click to enable downloads for this category",
     "disableDownloadsTitle": "Click to disable downloads for this category",
-    "failedToToggleDownloads": "Failed to update download permission"
+    "failedToToggleDownloads": "Failed to update download permission",
+    "folderEnabled": "Photos in this category now sit inside a folder",
+    "folderDisabled": "This category filters the gallery again",
+    "failedToToggleFolder": "Failed to update folder setting",
+    "disableFolderTitle": "Folder: these photos are hidden from the main grid and shown only inside the folder. Click to make it a filter again.",
+    "enableFolderTitle": "Filter: these photos stay in the main grid. Click to turn it into a folder — hides them from the grid, does NOT restrict access."
   },
   "events": {
     "revealMode": "Reveal mode (hide gallery until reveal)",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -632,7 +632,8 @@
     "openFolder": "Open folder {{name}}",
     "folderPhotoCount": "{{count}} photos",
     "backToGallery": "All photos",
-    "downloadFolder": "Download folder ({{count}})"
+    "downloadFolder": "Download folder ({{count}})",
+    "downloadFolderCapped": "Download first {{limit}} of {{total}}"
   },
   "categories": {
     "title": "Photo Categories",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -325,7 +325,8 @@
     "openFolder": "Abrir carpeta {{name}}",
     "folderPhotoCount": "{{count}} fotos",
     "backToGallery": "Todas las fotos",
-    "downloadFolder": "Descargar carpeta ({{count}})"
+    "downloadFolder": "Descargar carpeta ({{count}})",
+    "downloadFolderCapped": "Descargar las primeras {{limit}} de {{total}}"
   },
   "categories": {
     "title": "Categorías de fotos",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -326,7 +326,8 @@
     "folderPhotoCount": "{{count}} fotos",
     "backToGallery": "Todas las fotos",
     "downloadFolder": "Descargar carpeta ({{count}})",
-    "downloadFolderCapped": "Descargar las primeras {{limit}} de {{total}}"
+    "downloadFolderCapped": "Descargar las primeras {{limit}} de {{total}}",
+    "downloadEverything": "Descargar todas las fotos"
   },
   "categories": {
     "title": "Categorías de fotos",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -324,7 +324,8 @@
     "folders": "Carpetas",
     "openFolder": "Abrir carpeta {{name}}",
     "folderPhotoCount": "{{count}} fotos",
-    "backToGallery": "Todas las fotos"
+    "backToGallery": "Todas las fotos",
+    "downloadFolder": "Descargar carpeta ({{count}})"
   },
   "categories": {
     "title": "Categorías de fotos",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -320,7 +320,11 @@
     "rated": "Valorado",
     "commented": "Comentado",
     "colorFilter": "Color",
-    "filterByColor": "Mostrar solo {{color}}"
+    "filterByColor": "Mostrar solo {{color}}",
+    "folders": "Carpetas",
+    "openFolder": "Abrir carpeta {{name}}",
+    "folderPhotoCount": "{{count}} fotos",
+    "backToGallery": "Todas las fotos"
   },
   "categories": {
     "title": "Categorías de fotos",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -346,7 +346,8 @@
     "folderPhotoCount": "{{count}} photos",
     "backToGallery": "Toutes les photos",
     "downloadFolder": "Télécharger le dossier ({{count}})",
-    "downloadFolderCapped": "Télécharger les {{limit}} premières sur {{total}}"
+    "downloadFolderCapped": "Télécharger les {{limit}} premières sur {{total}}",
+    "downloadEverything": "Télécharger toutes les photos"
   },
   "categories": {
     "title": "Catégories de photos",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -344,7 +344,8 @@
     "folders": "Dossiers",
     "openFolder": "Ouvrir le dossier {{name}}",
     "folderPhotoCount": "{{count}} photos",
-    "backToGallery": "Toutes les photos"
+    "backToGallery": "Toutes les photos",
+    "downloadFolder": "Télécharger le dossier ({{count}})"
   },
   "categories": {
     "title": "Catégories de photos",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -345,7 +345,8 @@
     "openFolder": "Ouvrir le dossier {{name}}",
     "folderPhotoCount": "{{count}} photos",
     "backToGallery": "Toutes les photos",
-    "downloadFolder": "Télécharger le dossier ({{count}})"
+    "downloadFolder": "Télécharger le dossier ({{count}})",
+    "downloadFolderCapped": "Télécharger les {{limit}} premières sur {{total}}"
   },
   "categories": {
     "title": "Catégories de photos",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -340,7 +340,11 @@
     "downloadSelected_one": "Télécharger {{count}} photo",
     "downloadSelected_other": "Télécharger {{count}} photos",
     "colorFilter": "Couleur",
-    "filterByColor": "Afficher uniquement {{color}}"
+    "filterByColor": "Afficher uniquement {{color}}",
+    "folders": "Dossiers",
+    "openFolder": "Ouvrir le dossier {{name}}",
+    "folderPhotoCount": "{{count}} photos",
+    "backToGallery": "Toutes les photos"
   },
   "categories": {
     "title": "Catégories de photos",

--- a/frontend/src/i18n/locales/nl.json
+++ b/frontend/src/i18n/locales/nl.json
@@ -345,7 +345,8 @@
     "openFolder": "Map {{name}} openen",
     "folderPhotoCount": "{{count}} foto's",
     "backToGallery": "Alle foto's",
-    "downloadFolder": "Map downloaden ({{count}})"
+    "downloadFolder": "Map downloaden ({{count}})",
+    "downloadFolderCapped": "Eerste {{limit}} van {{total}} downloaden"
   },
   "categories": {
     "title": "Fotocategorieen",

--- a/frontend/src/i18n/locales/nl.json
+++ b/frontend/src/i18n/locales/nl.json
@@ -340,7 +340,11 @@
     "photosCount_one": "{{count}} foto",
     "photosCount_other": "{{count}} foto's",
     "colorFilter": "Kleur",
-    "filterByColor": "Alleen {{color}} tonen"
+    "filterByColor": "Alleen {{color}} tonen",
+    "folders": "Mappen",
+    "openFolder": "Map {{name}} openen",
+    "folderPhotoCount": "{{count}} foto's",
+    "backToGallery": "Alle foto's"
   },
   "categories": {
     "title": "Fotocategorieen",

--- a/frontend/src/i18n/locales/nl.json
+++ b/frontend/src/i18n/locales/nl.json
@@ -346,7 +346,8 @@
     "folderPhotoCount": "{{count}} foto's",
     "backToGallery": "Alle foto's",
     "downloadFolder": "Map downloaden ({{count}})",
-    "downloadFolderCapped": "Eerste {{limit}} van {{total}} downloaden"
+    "downloadFolderCapped": "Eerste {{limit}} van {{total}} downloaden",
+    "downloadEverything": "Alle foto's downloaden"
   },
   "categories": {
     "title": "Fotocategorieen",

--- a/frontend/src/i18n/locales/nl.json
+++ b/frontend/src/i18n/locales/nl.json
@@ -344,7 +344,8 @@
     "folders": "Mappen",
     "openFolder": "Map {{name}} openen",
     "folderPhotoCount": "{{count}} foto's",
-    "backToGallery": "Alle foto's"
+    "backToGallery": "Alle foto's",
+    "downloadFolder": "Map downloaden ({{count}})"
   },
   "categories": {
     "title": "Fotocategorieen",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -352,7 +352,8 @@
     "folders": "Pastas",
     "openFolder": "Abrir pasta {{name}}",
     "folderPhotoCount": "{{count}} fotos",
-    "backToGallery": "Todas as fotos"
+    "backToGallery": "Todas as fotos",
+    "downloadFolder": "Baixar pasta ({{count}})"
   },
   "categories": {
     "title": "Categorias de Fotos",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -353,7 +353,8 @@
     "openFolder": "Abrir pasta {{name}}",
     "folderPhotoCount": "{{count}} fotos",
     "backToGallery": "Todas as fotos",
-    "downloadFolder": "Baixar pasta ({{count}})"
+    "downloadFolder": "Baixar pasta ({{count}})",
+    "downloadFolderCapped": "Baixar as primeiras {{limit}} de {{total}}"
   },
   "categories": {
     "title": "Categorias de Fotos",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -354,7 +354,8 @@
     "folderPhotoCount": "{{count}} fotos",
     "backToGallery": "Todas as fotos",
     "downloadFolder": "Baixar pasta ({{count}})",
-    "downloadFolderCapped": "Baixar as primeiras {{limit}} de {{total}}"
+    "downloadFolderCapped": "Baixar as primeiras {{limit}} de {{total}}",
+    "downloadEverything": "Baixar todas as fotos"
   },
   "categories": {
     "title": "Categorias de Fotos",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -348,7 +348,11 @@
     "photosCount_one": "{{count}} foto",
     "photosCount_other": "{{count}} fotos",
     "colorFilter": "Cor",
-    "filterByColor": "Mostrar apenas {{color}}"
+    "filterByColor": "Mostrar apenas {{color}}",
+    "folders": "Pastas",
+    "openFolder": "Abrir pasta {{name}}",
+    "folderPhotoCount": "{{count}} fotos",
+    "backToGallery": "Todas as fotos"
   },
   "categories": {
     "title": "Categorias de Fotos",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -361,7 +361,8 @@
     "openFolder": "Открыть папку {{name}}",
     "folderPhotoCount": "{{count}} фото",
     "backToGallery": "Все фото",
-    "downloadFolder": "Скачать папку ({{count}})"
+    "downloadFolder": "Скачать папку ({{count}})",
+    "downloadFolderCapped": "Скачать первые {{limit}} из {{total}}"
   },
   "categories": {
     "title": "Категории фото",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -362,7 +362,8 @@
     "folderPhotoCount": "{{count}} фото",
     "backToGallery": "Все фото",
     "downloadFolder": "Скачать папку ({{count}})",
-    "downloadFolderCapped": "Скачать первые {{limit}} из {{total}}"
+    "downloadFolderCapped": "Скачать первые {{limit}} из {{total}}",
+    "downloadEverything": "Скачать все фото"
   },
   "categories": {
     "title": "Категории фото",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -360,7 +360,8 @@
     "folders": "Папки",
     "openFolder": "Открыть папку {{name}}",
     "folderPhotoCount": "{{count}} фото",
-    "backToGallery": "Все фото"
+    "backToGallery": "Все фото",
+    "downloadFolder": "Скачать папку ({{count}})"
   },
   "categories": {
     "title": "Категории фото",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -356,7 +356,11 @@
     "photosCount_one": "{{count}} фото",
     "photosCount_other": "{{count}} фото",
     "colorFilter": "Цвет",
-    "filterByColor": "Показать только «{{color}}»"
+    "filterByColor": "Показать только «{{color}}»",
+    "folders": "Папки",
+    "openFolder": "Открыть папку {{name}}",
+    "folderPhotoCount": "{{count}} фото",
+    "backToGallery": "Все фото"
   },
   "categories": {
     "title": "Категории фото",

--- a/frontend/src/i18n/locales/sl.json
+++ b/frontend/src/i18n/locales/sl.json
@@ -340,7 +340,11 @@
     "downloadSelected_one": "Prenesi {{count}} fotografijo",
     "downloadSelected_other": "Prenesi {{count}} fotografij",
     "colorFilter": "Barva",
-    "filterByColor": "Prikaži samo {{color}}"
+    "filterByColor": "Prikaži samo {{color}}",
+    "folders": "Mape",
+    "openFolder": "Odpri mapo {{name}}",
+    "folderPhotoCount": "{{count}} fotografij",
+    "backToGallery": "Vse fotografije"
   },
   "categories": {
     "title": "Kategorije fotografij",

--- a/frontend/src/i18n/locales/sl.json
+++ b/frontend/src/i18n/locales/sl.json
@@ -344,7 +344,8 @@
     "folders": "Mape",
     "openFolder": "Odpri mapo {{name}}",
     "folderPhotoCount": "{{count}} fotografij",
-    "backToGallery": "Vse fotografije"
+    "backToGallery": "Vse fotografije",
+    "downloadFolder": "Prenesi mapo ({{count}})"
   },
   "categories": {
     "title": "Kategorije fotografij",

--- a/frontend/src/i18n/locales/sl.json
+++ b/frontend/src/i18n/locales/sl.json
@@ -346,7 +346,8 @@
     "folderPhotoCount": "{{count}} fotografij",
     "backToGallery": "Vse fotografije",
     "downloadFolder": "Prenesi mapo ({{count}})",
-    "downloadFolderCapped": "Prenesi prvih {{limit}} od {{total}}"
+    "downloadFolderCapped": "Prenesi prvih {{limit}} od {{total}}",
+    "downloadEverything": "Prenesi vse fotografije"
   },
   "categories": {
     "title": "Kategorije fotografij",

--- a/frontend/src/i18n/locales/sl.json
+++ b/frontend/src/i18n/locales/sl.json
@@ -345,7 +345,8 @@
     "openFolder": "Odpri mapo {{name}}",
     "folderPhotoCount": "{{count}} fotografij",
     "backToGallery": "Vse fotografije",
-    "downloadFolder": "Prenesi mapo ({{count}})"
+    "downloadFolder": "Prenesi mapo ({{count}})",
+    "downloadFolderCapped": "Prenesi prvih {{limit}} od {{total}}"
   },
   "categories": {
     "title": "Kategorije fotografij",

--- a/frontend/src/pages/admin/event-details/EventInformationCard.tsx
+++ b/frontend/src/pages/admin/event-details/EventInformationCard.tsx
@@ -39,7 +39,7 @@ interface EventInformationCardProps {
   setShowNewPassword: (show: boolean) => void;
   feedbackSettings: FeedbackSettingsType;
   setFeedbackSettings: React.Dispatch<React.SetStateAction<FeedbackSettingsType>>;
-  categories: Array<{ id: number; name: string; slug: string }>;
+  categories: Array<{ id: number; name: string; slug: string; is_folder?: boolean }>;
   photos: AdminPhoto[];
   phoneFieldEnabled: boolean;
   daysUntilExpiration: number | null;

--- a/frontend/src/pages/admin/event-details/OverviewTab.tsx
+++ b/frontend/src/pages/admin/event-details/OverviewTab.tsx
@@ -31,7 +31,7 @@ interface OverviewTabProps {
   setShowNewPassword: (show: boolean) => void;
   feedbackSettings: FeedbackSettingsType;
   setFeedbackSettings: React.Dispatch<React.SetStateAction<FeedbackSettingsType>>;
-  categories: Array<{ id: number; name: string; slug: string }>;
+  categories: Array<{ id: number; name: string; slug: string; is_folder?: boolean }>;
   photos: AdminPhoto[];
   phoneFieldEnabled: boolean;
   daysUntilExpiration: number | null;

--- a/frontend/src/pages/admin/event-details/PhotoStatisticsCard.tsx
+++ b/frontend/src/pages/admin/event-details/PhotoStatisticsCard.tsx
@@ -7,7 +7,7 @@ import type { EventDetailsTab } from './types';
 
 interface PhotoStatisticsCardProps {
   event: Event;
-  categories: Array<{ id: number; name: string; slug: string }>;
+  categories: Array<{ id: number; name: string; slug: string; is_folder?: boolean }>;
   setActiveTab: (tab: EventDetailsTab) => void;
 }
 

--- a/frontend/src/pages/admin/event-details/PhotosTab.tsx
+++ b/frontend/src/pages/admin/event-details/PhotosTab.tsx
@@ -17,7 +17,7 @@ interface PhotosTabProps {
   photos: AdminPhoto[];
   photosLoading: boolean;
   refetchPhotos: () => void;
-  categories: Array<{ id: number; name: string; slug: string }>;
+  categories: Array<{ id: number; name: string; slug: string; is_folder?: boolean }>;
   photoFilters: PhotoFilterParams;
   setPhotoFilters: React.Dispatch<React.SetStateAction<PhotoFilterParams>>;
   feedbackFilters: FeedbackFilters;

--- a/frontend/src/services/categories.service.ts
+++ b/frontend/src/services/categories.service.ts
@@ -16,6 +16,10 @@ export interface PhotoCategory {
   // Per-event override position (#782). Non-null on the /event/:id response when
   // this gallery has customised its order; null means it follows the default.
   override_position?: number | null;
+  // Folder vs filter (#1160). false (the default) is the historical behaviour:
+  // the category filters the root grid. true makes it a container — its photos
+  // leave the root grid and only render inside the folder.
+  is_folder?: boolean;
   created_at: string;
 }
 
@@ -24,6 +28,7 @@ export interface CreateCategoryData {
   slug?: string;
   is_global?: boolean;
   event_id?: number;
+  is_folder?: boolean;
 }
 
 export const categoriesService = {
@@ -52,7 +57,7 @@ export const categoriesService = {
   async updateCategory(
     id: number,
     name: string,
-    patch?: { allow_downloads?: boolean }
+    patch?: { allow_downloads?: boolean; is_folder?: boolean }
   ): Promise<PhotoCategory> {
     const response = await api.put<PhotoCategory>(`/admin/categories/${id}`, { name, ...patch });
     return response.data;

--- a/frontend/src/services/events.service.ts
+++ b/frontend/src/services/events.service.ts
@@ -232,7 +232,7 @@ export const eventsService = {
   },
 
   // Get event categories
-  async getEventCategories(eventId: number): Promise<Array<{ id: number; name: string; slug: string }>> {
+  async getEventCategories(eventId: number): Promise<Array<{ id: number; name: string; slug: string; is_folder?: boolean }>> {
     const response = await api.get(`/admin/categories/event/${eventId}`);
     return response.data || [];
   },

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -249,6 +249,10 @@ export interface PhotoCategory {
   slug: string;
   is_global: boolean;
   hero_photo_id?: number | null;
+  // Folder vs filter (#1160). A filter category leaves its photos in the root
+  // grid and narrows it when picked; a folder CONTAINS them — they are absent
+  // from the root grid and only render once the guest opens the folder.
+  is_folder?: boolean;
 }
 
 export interface GalleryData {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -249,6 +249,9 @@ export interface PhotoCategory {
   slug: string;
   is_global: boolean;
   hero_photo_id?: number | null;
+  // Per-category download opt-out (#640). false hides the download affordance
+  // for this category — including a folder's own "download folder" button.
+  allow_downloads?: boolean;
   // Folder vs filter (#1160). A filter category leaves its photos in the root
   // grid and narrows it when picked; a folder CONTAINS them — they are absent
   // from the root grid and only render once the guest opens the folder.


### PR DESCRIPTION
> **Bottom of a two-PR stack.** #1208 (shared colour tag, #1197) is stacked on this branch and merges after it. Rebased onto current `main` on 27 Aug so the stack sits on current code — that gap included the #1201 capture-date fix.

---

Closes #1160. Implements the folder request from discussion #1086.

## What changes

A category has always been a **filter**: its photos stay in the root grid and picking the category narrows that grid. `photo_categories.is_folder` makes it a **container** instead — its photos leave the root grid entirely and only render once the guest opens the folder.

```
today (category = filter)          with is_folder (folder = container)
─────────────────────────          ───────────────────────────────────
gallery root: 62 photos            gallery root: 42 photos + [ Selects ▸ 20 ]
  └ filter "Selects" → 20            └ click Selects → 20 photos
```

Defaults to `false`, so **every existing gallery keeps filtering exactly as before**. Folders are opt-in per category.

## Why the migration is one column

The neighbouring features already built the substrate, so this needed nothing else:

| Need | Already existed |
|---|---|
| Folder cover image | `hero_photo_id` (#163, migration 066) |
| Per-folder download rules | `allow_downloads` (#640, migration 135) |
| Folder ordering | `display_order` + `event_category_order` (#782, migrations 159/160) |
| Move photos in bulk | `BulkCategoryModal` |
| One photo, one folder | `photos.category_id` is single-valued |

**No `parent_id`.** The request is "root → Selects folder", which is depth one — plain containment. Folders-inside-folders waits until someone asks.

## Moving photos into a folder

Already worked: a folder *is* a category, so the existing bulk "move to category" flow does it. The only gap was that a folder and a filter category looked identical in that dropdown while having very different consequences, so folder options now read `Selects (folder — hidden from the main grid)`.

## Downloads

Both halves of the requirement:

- **Whole gallery** — "download all" still zips every photo *including* foldered ones (verified: 62 files). A folder never silently shrinks the client's one-click download.
- **Per folder** — a `Download folder (20)` button inside a folder zips only that folder, once (verified: 20 files). Reuses `/download-selected`, so no new endpoint and no second zip-building path.

Honours the per-category opt-out (#640) both ways: a folder with `allow_downloads = false` renders no button, and opted-out photos are excluded from the id list rather than 403-ing mid-zip.

## Scope correctness

Containment lands in the one `useMemo` where the category filter was already applied, so everything downstream inherits it:

- **Counts** — root reports 42, not 62.
- **Lightbox** — inside a folder the counter reads `1 / 20`, not `1 / 62`.
- **People strip** — `face_count` comes from `/people` and spans the whole event, which contradicted the grid twice over: inside a folder a face read "12 photos" but filtered to a handful, and at root a person whose photos *all* lived in a folder appeared and filtered to nothing — a dead chip. Recounted from `photo.person_ids` (already what filtering uses); zero-count people dropped. No backend change.
- **Search and feedback chips** — narrow *within* the current scope, never across a folder boundary.

## All eight layouts

Containment comes from `filteredPhotos`, which both layout branches use — so a branch that hides foldered photos without offering the tiles makes them **unreachable**. The folder nav is built once and rendered by both.

The two full-bleed layouts (Premium, Story) are edge-to-edge by design, and a block of cover cards above the hero wrecks the opening they exist for, so they get a compact chip row instead of tiles. It renders only when the gallery actually has folders, leaving existing full-bleed galleries byte-identical.

## Folders are not access control

Stated in the toggle's help text, and pinned by a test. A foldered photo is served by the same per-photo auth as any other — hiding it from the grid does not make its URL unreachable. Anyone reading "archive the selects into a folder" as "make them private" would be wrong, and the UI says so.

## Decision: `is_folder` is event-scoped only

The toggle appears only on event-specific categories; globals (`Ceremony`, `Reception`, …) cannot be made folders. One click on a global would pull those photos out of the root grid of *every* gallery on the instance, including delivered ones. Rationale and the recommended escalation path (a per-event override mirroring `event_category_order`, **not** a global flag) are recorded in https://github.com/PicPeak/picpeak/issues/1160#issuecomment-5400743740.

## Verification

Exercised against a running stack (62-photo gallery, 20 moved into a folder) — not mocks:

- root grid renders 42 cards, folder renders 20, tiles hidden inside a folder
- `?folder=<slug>` round-trips: deep link opens the folder, Back walks out, `token` and `admin_preview` preserved
- move via the real `POST /admin/events/:id/photos/bulk-update`: root 42 → 40, folder 20 → 22
- folder zip 20 files, gallery zip 62 files
- unknown `?folder=` slug falls back to root rather than emptying the gallery

Migration ran clean and idempotent on **both** SQLite and Postgres.

Tests: 20 new frontend unit tests for the containment rule, 5 new backend tests pinning `is_folder` through the guest payload (the category block uses an explicit `select` list, so a column that isn't added there is silently dropped — that contract is now covered). Full suites green: 122 frontend, 272 backend route tests. `tsc` and eslint clean.

Screenshots in a follow-up comment.

