### PR TITLE
fix(admin): gate the dimension repair as system maintenance

### DIFF
--- a/backend/src/routes/adminPhotoDimensions.js
+++ b/backend/src/routes/adminPhotoDimensions.js
@@ -126,9 +126,12 @@ router.post('/repair-dimensions', adminAuth, requirePermission('system.manage'),
 
 // Get dimension repair status
 //
-// Matches the POST: no point advertising a backlog to someone who cannot act on
-// it. StatusTab guards on the payload, so the card simply stays hidden.
-router.get('/repair-dimensions/status', adminAuth, requirePermission('system.view'), async (req, res) => {
+// The same permission as the POST, not the read-only system.view. The two are
+// independent grants, and StatusTab has no permission gate of its own — a
+// successful status payload is what renders the card and its enabled button
+// (StatusTab.tsx:558). system.view alone would therefore show a live Repair
+// button whose every click 403s with no error surfaced.
+router.get('/repair-dimensions/status', adminAuth, requirePermission('system.manage'), async (req, res) => {
   try {
     const totalPhotos = await db('photos')
       .where(function () {

--- a/backend/src/routes/adminPhotoDimensions.js
+++ b/backend/src/routes/adminPhotoDimensions.js
@@ -15,7 +15,14 @@ let repairProgress = {
 };
 
 // Repair photo dimensions (background job)
-router.post('/repair-dimensions', adminAuth, requirePermission('photos.edit'), async (req, res) => {
+//
+// system.manage, not photos.edit: the query below is unscoped, so this walks
+// every event in the install, reads every original off S3 or the NAS mount, and
+// rewrites their metadata. photos.edit is held by the team_photographer preset
+// (175_granular_permissions_and_presets.js:106), which exists for a contributing
+// second shooter — someone who should be able to edit the photos they work on,
+// not start a whole-library scan or touch another owner's events.
+router.post('/repair-dimensions', adminAuth, requirePermission('system.manage'), async (req, res) => {
   try {
     if (repairProgress.isRunning) {
       return res.status(409).json({ error: 'Repair is already running' });
@@ -118,7 +125,10 @@ router.post('/repair-dimensions', adminAuth, requirePermission('photos.edit'), a
 });
 
 // Get dimension repair status
-router.get('/repair-dimensions/status', adminAuth, requirePermission('photos.view'), async (req, res) => {
+//
+// Matches the POST: no point advertising a backlog to someone who cannot act on
+// it. StatusTab guards on the payload, so the card simply stays hidden.
+router.get('/repair-dimensions/status', adminAuth, requirePermission('system.view'), async (req, res) => {
   try {
     const totalPhotos = await db('photos')
       .where(function () {

--- a/frontend/src/features/settings/tabs/StatusTab.tsx
+++ b/frontend/src/features/settings/tabs/StatusTab.tsx
@@ -562,7 +562,11 @@ export const StatusTab: React.FC<StatusTabProps> = ({
       )}
 
       {/* Photo Dimensions */}
-      {dimensionStatus && (
+      {/* canManageSystem as well as the payload: TanStack keeps the cached
+          status after `enabled` flips false, so without it a lower-privileged
+          admin logging in behind a system.manage user inside the cache lifetime
+          would still be shown the card and a button whose POST 403s. */}
+      {dimensionStatus && canManageSystem && (
         <Card padding="md">
           <h2 className="text-lg font-semibold text-neutral-900 dark:text-neutral-100 mb-4 flex items-center gap-2">
             <Ruler className="w-5 h-5" />

--- a/frontend/src/features/settings/tabs/StatusTab.tsx
+++ b/frontend/src/features/settings/tabs/StatusTab.tsx
@@ -65,7 +65,13 @@ export const StatusTab: React.FC<StatusTabProps> = ({
   // never starts the poll. Without this the card would poll a 403 every ten
   // seconds for anyone who can open the Status tab but cannot run the repair,
   // filling the logs with denials for a panel they were never shown.
-  const canManageSystem = usePermission('system.manage');
+  //
+  // Named for the card it gates rather than for the permission, because #1179
+  // adds a second system.manage-gated card to this same component. Two flags
+  // with one name merge without a conflict and then fail to compile
+  // (TS2451) — and since each PR is green on its own, nothing catches it until
+  // main's build breaks. Once both have landed these can collapse into one.
+  const canRepairDimensions = usePermission('system.manage');
 
   const { data: dimensionStatus } = useQuery({
     queryKey: ['photo-dimension-status'],
@@ -73,7 +79,7 @@ export const StatusTab: React.FC<StatusTabProps> = ({
       const res = await api.get('/admin/photos/repair-dimensions/status');
       return res.data;
     },
-    enabled: isActive && canManageSystem,
+    enabled: isActive && canRepairDimensions,
     refetchInterval: 10000,
   });
 
@@ -562,11 +568,11 @@ export const StatusTab: React.FC<StatusTabProps> = ({
       )}
 
       {/* Photo Dimensions */}
-      {/* canManageSystem as well as the payload: TanStack keeps the cached
+      {/* canRepairDimensions as well as the payload: TanStack keeps the cached
           status after `enabled` flips false, so without it a lower-privileged
           admin logging in behind a system.manage user inside the cache lifetime
           would still be shown the card and a button whose POST 403s. */}
-      {dimensionStatus && canManageSystem && (
+      {dimensionStatus && canRepairDimensions && (
         <Card padding="md">
           <h2 className="text-lg font-semibold text-neutral-900 dark:text-neutral-100 mb-4 flex items-center gap-2">
             <Ruler className="w-5 h-5" />

--- a/frontend/src/features/settings/tabs/StatusTab.tsx
+++ b/frontend/src/features/settings/tabs/StatusTab.tsx
@@ -17,6 +17,7 @@ import { settingsService } from '../../../services/settings.service';
 import { useStatusTab } from '../hooks/useStatusTab';
 import { UpdateNotificationSettings } from '../components/UpdateNotificationSettings';
 import { useLocalizedDate } from '../../../hooks/useLocalizedDate';
+import { usePermission } from '../../../hooks/usePermission';
 
 const BYTES_PER_GB = 1024 * 1024 * 1024;
 
@@ -60,13 +61,19 @@ export const StatusTab: React.FC<StatusTabProps> = ({
   const { storageInfo, systemStatus } = useStatusTab(isActive);
   const queryClient = useQueryClient();
 
+  // Gated on the same permission the endpoint requires, so a role without it
+  // never starts the poll. Without this the card would poll a 403 every ten
+  // seconds for anyone who can open the Status tab but cannot run the repair,
+  // filling the logs with denials for a panel they were never shown.
+  const canManageSystem = usePermission('system.manage');
+
   const { data: dimensionStatus } = useQuery({
     queryKey: ['photo-dimension-status'],
     queryFn: async () => {
       const res = await api.get('/admin/photos/repair-dimensions/status');
       return res.data;
     },
-    enabled: isActive,
+    enabled: isActive && canManageSystem,
     refetchInterval: 10000,
   });
 


### PR DESCRIPTION
## What

`POST /api/admin/photos/repair-dimensions` required `photos.edit`. Its candidate query is unscoped — it walks every event in the install, reads every original off S3 or the NAS mount, and rewrites their metadata.

`photos.edit` is held by the built-in **team_photographer** preset (`175_granular_permissions_and_presets.js:106`), which exists for a contributing second/festival shooter: someone who should be able to edit the photos they work on, not start a whole-library scan or write metadata across other owners' events.

Changed to `system.manage`, whose seeded description is already *"Configure update notifications and run system maintenance actions"* (`175:76`). The status endpoint moves to `system.view` to match — `StatusTab.tsx:558` guards the card on the payload, so it simply stays hidden rather than erroring.

## Who is affected

Nobody who should have it loses it:

| Role | Before | After |
|---|---|---|
| `super_admin` | ✅ | ✅ — granted all permissions (`permissions.js:43,56`) |
| `solo_photographer` | ✅ | ✅ — preset is `permissions: 'ALL'` |
| any `settings.edit` holder | ✅ | ✅ — migration 175 projects `settings.edit` forward onto `system.manage` on upgrade (`175:161-170`) |
| `team_photographer` | ✅ | ❌ — intended |

## Why now, separately

Found while reviewing #1179, which gates the new capture-date sweep the same way. The two jobs sit in the same file and were deliberately written to the same shape; leaving one on `photos.edit` and the other on `system.manage` is worse than either state. Kept out of #1179 so the bugfix there stays reviewable on its own.

The remaining difference between the two — process-local run state, which breaks status reporting and allows duplicate scans on multi-replica installs — is tracked in #1181 for both jobs together.

## Verification

- Directly inspected: the preset permission lists, the `settings.edit` → `system.manage` upgrade projection, super_admin's blanket grant, and the `StatusTab` payload guard.
- `npx eslint src/routes/adminPhotoDimensions.js` — clean.
- No test change: the existing suites for this route mock `requirePermission` to a no-op, so they neither cover nor break on this. The change is verified by inspection of the permission model, not by test.

## Stable

No twin needed. `stable` has no `system.manage` permission, no `team_photographer` preset, and its migration 175 is an unrelated CSS fix — the escalation path this closes does not exist there.
