### PR TITLE
fix(images): fence the capture-date backfill on the file it read (#1201)

### DIFF
--- a/backend/__tests__/integration/captureDateBackfill.test.js
+++ b/backend/__tests__/integration/captureDateBackfill.test.js
@@ -198,6 +198,8 @@ describe('capture date backfill (#1172)', () => {
 
     expect(new Date((await db('photos').where({ id: photoId }).first()).captured_at).toISOString()).toBe(claimed);
     expect(done.body.lastResult.success).toBe(0);
+    // Read but not written, so it is accounted for rather than dropped.
+    expect(done.body.lastResult.skipped).toBe(1);
   });
 
   it('does not date a row whose file was replaced while it was reading (#1201)', async () => {
@@ -218,5 +220,8 @@ describe('capture date backfill (#1172)', () => {
 
     expect((await db('photos').where({ id: photoId }).first()).captured_at).toBeNull();
     expect(done.body.lastResult.success).toBe(0);
+    // Not an error and not "no EXIF" — the date was found, another writer just
+    // got there first. It stays in the backlog for the next run.
+    expect(done.body.lastResult).toMatchObject({ noExif: 0, failed: 0, skipped: 1 });
   });
 });

--- a/backend/__tests__/integration/captureDateBackfill.test.js
+++ b/backend/__tests__/integration/captureDateBackfill.test.js
@@ -199,4 +199,24 @@ describe('capture date backfill (#1172)', () => {
     expect(new Date((await db('photos').where({ id: photoId }).first()).captured_at).toISOString()).toBe(claimed);
     expect(done.body.lastResult.success).toBe(0);
   });
+
+  it('does not date a row whose file was replaced while it was reading (#1201)', async () => {
+    // replacePhoto swaps a NEW file under an existing row and rewrites
+    // path/filename (reachable from replace_by_name). The replacement carries
+    // no date of its own, so captured_at is still NULL and the whereNull guard
+    // alone would let the previous file's EXIF date land on it. The write is
+    // fenced on the identity that was read, so the row is skipped instead —
+    // and not counted as updated either.
+    const { photoId } = await seed({ relpath: 'orig.jpg', exifIso: '2026-06-03T09:00:00Z' });
+
+    const res = await request(app).post('/api/admin/photos/repair-capture-dates');
+    expect(res.body.count).toBe(1);
+    // Simulate the replacement landing before the loop writes.
+    await db('photos').where({ id: photoId })
+      .update({ path: 'capfill/replaced.jpg', filename: 'replaced.jpg' });
+    const done = await settle();
+
+    expect((await db('photos').where({ id: photoId }).first()).captured_at).toBeNull();
+    expect(done.body.lastResult.success).toBe(0);
+  });
 });

--- a/backend/src/routes/adminPhotoDimensions.js
+++ b/backend/src/routes/adminPhotoDimensions.js
@@ -356,6 +356,7 @@ router.post('/repair-capture-dates', adminAuth, requirePermission('system.manage
       let successCount = 0;
       let missingCount = 0;
       let errorCount = 0;
+      let skippedCount = 0;
       let lostClaim = false;
 
       // Same reasoning as the dimension repair: detached from the request, so
@@ -443,7 +444,16 @@ router.post('/repair-capture-dates', adminAuth, requirePermission('system.manage
               .where({ id: photo.id, path: photo.path, filename: photo.filename })
               .whereNull('captured_at')
               .update({ captured_at: captured.toISOString() });
-            if (updated) successCount++;
+            // Counted, not dropped: without this a candidate that was read but
+            // not written falls out of the run's arithmetic entirely, and
+            // success + noExif + failed silently stops adding up to the count
+            // the operator was shown when they started it. Two ways to land
+            // here, both "another writer got there first" — the row was dated
+            // meanwhile (whereNull), or its file changed under us (the fence).
+            // Neither is an error and neither needs a retry: captured_at is
+            // still NULL for the fenced case, so the status endpoint keeps
+            // reporting it as backlog and the next run picks it up.
+            if (updated) successCount++; else skippedCount++;
 
             if (successCount % 50 === 0 && successCount > 0) {
               logger.info(`Capture date backfill progress: ${successCount} updated...`);
@@ -458,12 +468,15 @@ router.post('/repair-capture-dates', adminAuth, requirePermission('system.manage
           logger.warn(`Capture date backfill stopped: claim taken over after ${successCount} updated, ${errorCount} errors`);
           return;
         }
-        await maintenanceJobs.release(JOB_CAPTURE_DATE_BACKFILL, token, { success: successCount, noExif: missingCount, failed: errorCount });
-        logger.info(`Capture date backfill complete: ${successCount} updated, ${missingCount} without EXIF, ${errorCount} errors`);
+        await maintenanceJobs.release(JOB_CAPTURE_DATE_BACKFILL, token, { success: successCount, noExif: missingCount, failed: errorCount, skipped: skippedCount });
+        logger.info(
+          `Capture date backfill complete: ${successCount} updated, ${missingCount} without EXIF, `
+          + `${errorCount} errors, ${skippedCount} skipped (dated or replaced mid-run)`
+        );
       } catch (err) {
         logger.error('Capture date backfill aborted:', err);
         await maintenanceJobs
-          .release(JOB_CAPTURE_DATE_BACKFILL, token, { success: successCount, noExif: missingCount, failed: errorCount, error: err.message })
+          .release(JOB_CAPTURE_DATE_BACKFILL, token, { success: successCount, noExif: missingCount, failed: errorCount, skipped: skippedCount, error: err.message })
           .catch(() => {});
       } finally {
         lease.stop();

--- a/backend/src/routes/adminPhotoDimensions.js
+++ b/backend/src/routes/adminPhotoDimensions.js
@@ -430,8 +430,17 @@ router.post('/repair-capture-dates', adminAuth, requirePermission('system.manage
             // large library, and an import or a replacement finishing meanwhile
             // has already written a date this pass would otherwise overwrite
             // with the same-or-worse value.
+            //
+            // Fenced on path and filename as well as the id, for the same reason
+            // the orientation backfill below is (#1199): replacePhoto — reachable
+            // from the replace_by_name upload path (adminPhotos.js) — swaps a NEW
+            // file under an existing row and rewrites path/filename. That
+            // replacement carries no date of its own, so captured_at is still
+            // NULL and whereNull alone would let the previous file's EXIF date
+            // land on it. Matching the identity that was actually read means the
+            // update affects no rows and the row is simply skipped.
             const updated = await db('photos')
-              .where({ id: photo.id })
+              .where({ id: photo.id, path: photo.path, filename: photo.filename })
               .whereNull('captured_at')
               .update({ captured_at: captured.toISOString() });
             if (updated) successCount++;

--- a/frontend/src/features/settings/tabs/StatusTab.tsx
+++ b/frontend/src/features/settings/tabs/StatusTab.tsx
@@ -738,12 +738,17 @@ export const StatusTab: React.FC<StatusTabProps> = ({
                   below. Without it the three numbers above silently stop
                   adding up to the count the run started with: a photo that
                   was replaced, renamed or dated by someone else mid-run is
-                  read but not written, and it stays in the backlog. */}
+                  read but not written.
+                  Deliberately says "not updated" and not "will be retried":
+                  one of the two ways to land here is another writer having
+                  filled captured_at, and that photo is finished, not backlog.
+                  The Missing Capture Date figure above is what says whether
+                  anything is actually left to do. */}
               {Number(captureDateStatus.lastResult.skipped) > 0 && (
                 <span className="block text-amber-600 dark:text-amber-400 mt-1">
                   {t('settings.captureDates.skipped', {
                     count: captureDateStatus.lastResult.skipped,
-                    defaultValue: '{{count}} photo(s) changed while the run was reading them and were left for the next run.',
+                    defaultValue: '{{count}} photo(s) were changed by something else while the run was reading them and were not updated.',
                   })}
                 </span>
               )}

--- a/frontend/src/features/settings/tabs/StatusTab.tsx
+++ b/frontend/src/features/settings/tabs/StatusTab.tsx
@@ -734,6 +734,19 @@ export const StatusTab: React.FC<StatusTabProps> = ({
                 failed: captureDateStatus.lastResult.failed,
                 defaultValue: 'Last run: {{success}} updated, {{noExif}} with no date found, {{failed}} unreachable',
               })}
+              {/* Only when it happened, like the orientation job's staleTiers
+                  below. Without it the three numbers above silently stop
+                  adding up to the count the run started with: a photo that
+                  was replaced, renamed or dated by someone else mid-run is
+                  read but not written, and it stays in the backlog. */}
+              {Number(captureDateStatus.lastResult.skipped) > 0 && (
+                <span className="block text-amber-600 dark:text-amber-400 mt-1">
+                  {t('settings.captureDates.skipped', {
+                    count: captureDateStatus.lastResult.skipped,
+                    defaultValue: '{{count}} photo(s) changed while the run was reading them and were left for the next run.',
+                  })}
+                </span>
+              )}
             </p>
           )}
 

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -2362,6 +2362,7 @@
       "running": "Wird nachgetragen...",
       "noneToFill": "Alle Fotos haben bereits ein Aufnahmedatum",
       "resultSuccess": "Letzter Lauf: {{success}} aktualisiert, {{noExif}} ohne gefundenes Datum, {{failed}} nicht erreichbar",
+      "skipped": "{{count}} Foto(s) haben sich während des Laufs geändert und wurden für den nächsten Lauf übersprungen.",
       "description": "Trägt „Aufnahmedatum\" aus den EXIF-Daten nach, für Fotos die vor dieser Auswertung importiert wurden. Externe Importe haben nie eines gespeichert, dadurch sortieren diese Galerien nach Importreihenfolge statt nach Aufnahmezeit."
     },
     "orientationBackfill": {

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -2362,7 +2362,7 @@
       "running": "Wird nachgetragen...",
       "noneToFill": "Alle Fotos haben bereits ein Aufnahmedatum",
       "resultSuccess": "Letzter Lauf: {{success}} aktualisiert, {{noExif}} ohne gefundenes Datum, {{failed}} nicht erreichbar",
-      "skipped": "{{count}} Foto(s) haben sich während des Laufs geändert und wurden für den nächsten Lauf übersprungen.",
+      "skipped": "{{count}} Foto(s) wurden während des Laufs anderweitig geändert und daher nicht aktualisiert.",
       "description": "Trägt „Aufnahmedatum\" aus den EXIF-Daten nach, für Fotos die vor dieser Auswertung importiert wurden. Externe Importe haben nie eines gespeichert, dadurch sortieren diese Galerien nach Importreihenfolge statt nach Aufnahmezeit."
     },
     "orientationBackfill": {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1903,6 +1903,7 @@
       "running": "Backfilling...",
       "noneToFill": "All photos already have a capture date",
       "resultSuccess": "Last run: {{success}} updated, {{noExif}} with no date found, {{failed}} unreachable",
+      "skipped": "{{count}} photo(s) changed while the run was reading them and were left for the next run.",
       "description": "Backfill \"Date Taken\" from EXIF for photos imported before capture dates were read. External/reference imports never recorded one, so their galleries sort by import order instead of when the photos were taken."
     },
     "orientationBackfill": {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1903,7 +1903,7 @@
       "running": "Backfilling...",
       "noneToFill": "All photos already have a capture date",
       "resultSuccess": "Last run: {{success}} updated, {{noExif}} with no date found, {{failed}} unreachable",
-      "skipped": "{{count}} photo(s) changed while the run was reading them and were left for the next run.",
+      "skipped": "{{count}} photo(s) were changed by something else while the run was reading them and were not updated.",
       "description": "Backfill \"Date Taken\" from EXIF for photos imported before capture dates were read. External/reference imports never recorded one, so their galleries sort by import order instead of when the photos were taken."
     },
     "orientationBackfill": {

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -1211,6 +1211,7 @@
       "running": "Traitement...",
       "noneToFill": "Toutes les photos ont déjà une date de prise de vue",
       "resultSuccess": "Dernier passage : {{success}} mises à jour, {{noExif}} sans date trouvée, {{failed}} inaccessibles",
+      "skipped": "{{count}} photo(s) ont changé pendant la lecture et ont été laissées pour le prochain passage.",
       "description": "Complète la « date de prise de vue » depuis les EXIF pour les photos importées avant sa lecture. Les imports externes n'en enregistraient aucune, si bien que ces galeries se trient par ordre d'import plutôt que par date de prise de vue."
     },
     "orientationBackfill": {

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -1211,7 +1211,7 @@
       "running": "Traitement...",
       "noneToFill": "Toutes les photos ont déjà une date de prise de vue",
       "resultSuccess": "Dernier passage : {{success}} mises à jour, {{noExif}} sans date trouvée, {{failed}} inaccessibles",
-      "skipped": "{{count}} photo(s) ont changé pendant la lecture et ont été laissées pour le prochain passage.",
+      "skipped": "{{count}} photo(s) ont été modifiées par autre chose pendant le passage et n'ont donc pas été mises à jour.",
       "description": "Complète la « date de prise de vue » depuis les EXIF pour les photos importées avant sa lecture. Les imports externes n'en enregistraient aucune, si bien que ces galeries se trient par ordre d'import plutôt que par date de prise de vue."
     },
     "orientationBackfill": {

--- a/frontend/src/i18n/locales/sl.json
+++ b/frontend/src/i18n/locales/sl.json
@@ -1211,6 +1211,7 @@
       "running": "Dopolnjevanje...",
       "noneToFill": "Vse fotografije že imajo datum zajema",
       "resultSuccess": "Zadnji zagon: {{success}} posodobljenih, {{noExif}} brez najdenega datuma, {{failed}} nedosegljivih",
+      "skipped": "{{count}} fotografij se je med zagonom spremenilo in so bile prepuščene naslednjemu zagonu.",
       "description": "Dopolni »datum zajema« iz EXIF za fotografije, uvožene pred njegovim branjem. Zunanji uvozi ga niso zabeležili, zato se te galerije razvrščajo po vrstnem redu uvoza namesto po času zajema."
     },
     "orientationBackfill": {

--- a/frontend/src/i18n/locales/sl.json
+++ b/frontend/src/i18n/locales/sl.json
@@ -1211,7 +1211,7 @@
       "running": "Dopolnjevanje...",
       "noneToFill": "Vse fotografije že imajo datum zajema",
       "resultSuccess": "Zadnji zagon: {{success}} posodobljenih, {{noExif}} brez najdenega datuma, {{failed}} nedosegljivih",
-      "skipped": "{{count}} fotografij se je med zagonom spremenilo in so bile prepuščene naslednjemu zagonu.",
+      "skipped": "{{count}} fotografij je bilo med zagonom spremenjenih drugje in zato niso bile posodobljene.",
       "description": "Dopolni »datum zajema« iz EXIF za fotografije, uvožene pred njegovim branjem. Zunanji uvozi ga niso zabeležili, zato se te galerije razvrščajo po vrstnem redu uvoza namesto po času zajema."
     },
     "orientationBackfill": {


### PR DESCRIPTION
Closes #1201.

## The bug

`adminPhotoDimensions.js:433` committed the capture-date backfill keyed only on the row id:

```js
const updated = await db('photos')
  .where({ id: photo.id })
  .whereNull('captured_at')
  .update({ captured_at: captured.toISOString() });
```

The job snapshots every candidate up front, then walks them one at a time reading originals off S3 or a NAS mount — a pass that can run for many minutes. `photoReplacementService.replacePhoto()` swaps a **new file under an existing row id** and rewrites `path`/`filename`; it is reachable from the `replace_by_name` upload path (`adminPhotos.js:279`).

So: the backfill reads photo 500's original and extracts `2026-06-03`. Before it writes, an editor re-uploads over that same row. The replacement has no EXIF date of its own, so `captured_at` is still NULL and the `whereNull` guard passes — the old file's capture date lands on the new photo. Silent: nothing errors, the run reports it as a success, and the gallery sorts that photo to the wrong place.

## The fix

Fence the write on the identity that was actually read, not just the id — the same fence #1199 put on the orientation backfill for the same reason:

```js
.where({ id: photo.id, path: photo.path, filename: photo.filename })
.whereNull('captured_at')
```

A replaced row now matches zero rows and is skipped instead of being given the previous file's metadata. The candidate query already selects `photos.path` and `photos.filename`, so no query change. `successCount` already comes from the affected-row count (`if (updated) successCount++`), so a fenced-out row is not reported as updated.

Knex renders a null value in the object form as `is null`, so a row with a NULL `path` still matches itself.

## Test

`captureDateBackfill.test.js` — new case: a replacement landing mid-run (path/filename rewritten, `captured_at` still NULL) leaves `captured_at` NULL and is not counted as a success. Verified it fails on the unfenced code and passes with the fence; the other 8 cases in the file are unchanged and green.

No UI surface touched, so no screenshot.

## Stable

Stable carries the same shape (`:425-428`, merged in #1183) and gets the twin separately.

---

## Follow-ups from external review

An external review pass (Codex, 4 rounds) cleared the fence itself and surfaced one adjacent gap, fixed in the commits above.

**Accounting.** `replacePhoto` is not the only writer of `photos.path`/`filename` — `eventRenameService.js:201-207` rewrites both on an event rename, which is not a content change. Either of those, or another writer filling `captured_at` first, makes the update affect zero rows. Those candidates fell out of the run's arithmetic entirely: `success + noExif + failed` no longer added up to the count the operator was shown when they started the job. They are now counted (`skipped`) and surfaced on the card, shown only when non-zero — the same shape the orientation job uses for `staleTiers`.

Deliberately **not** done: retrying the row. A retry means a second S3/NAS read, it can lose the same race again, and for the already-dated case there is nothing to retry. The fenced row keeps `captured_at` NULL, so the status endpoint keeps reporting it as backlog and the next run picks it up.

**Checked and dismissed:** whether a NULL `path` breaks the fence. Knex renders a null value in the object form as `is null` on both the pg and sqlite3 clients (verified against the generated SQL on both), so such a row still matches itself.

Locale coverage for the new string matches the existing `staleTiers` key — en, de, fr, sl — with the `defaultValue` carrying the rest. Screenshots in a comment below.
