### PR TITLE
fix(images): fence the capture-date backfill on the file it read (#1201)

### DIFF
--- a/backend/__tests__/integration/captureDateBackfill.test.js
+++ b/backend/__tests__/integration/captureDateBackfill.test.js
@@ -198,6 +198,8 @@ describe('capture date backfill (#1172)', () => {
 
     expect(new Date((await db('photos').where({ id: photoId }).first()).captured_at).toISOString()).toBe(claimed);
     expect(done.body.lastResult.success).toBe(0);
+    // Read but not written, so it is accounted for rather than dropped.
+    expect(done.body.lastResult.skipped).toBe(1);
   });
 
   it('does not date a row whose file was replaced while it was reading (#1201)', async () => {
@@ -218,5 +220,8 @@ describe('capture date backfill (#1172)', () => {
 
     expect((await db('photos').where({ id: photoId }).first()).captured_at).toBeNull();
     expect(done.body.lastResult.success).toBe(0);
+    // Not an error and not "no EXIF" — the date was found, another writer just
+    // got there first. It stays in the backlog for the next run.
+    expect(done.body.lastResult).toMatchObject({ noExif: 0, failed: 0, skipped: 1 });
   });
 });

--- a/backend/__tests__/integration/captureDateBackfill.test.js
+++ b/backend/__tests__/integration/captureDateBackfill.test.js
@@ -199,4 +199,24 @@ describe('capture date backfill (#1172)', () => {
     expect(new Date((await db('photos').where({ id: photoId }).first()).captured_at).toISOString()).toBe(claimed);
     expect(done.body.lastResult.success).toBe(0);
   });
+
+  it('does not date a row whose file was replaced while it was reading (#1201)', async () => {
+    // replacePhoto swaps a NEW file under an existing row and rewrites
+    // path/filename (reachable from replace_by_name). The replacement carries
+    // no date of its own, so captured_at is still NULL and the whereNull guard
+    // alone would let the previous file's EXIF date land on it. The write is
+    // fenced on the identity that was read, so the row is skipped instead —
+    // and not counted as updated either.
+    const { photoId } = await seed({ relpath: 'orig.jpg', exifIso: '2026-06-03T09:00:00Z' });
+
+    const res = await request(app).post('/api/admin/photos/repair-capture-dates');
+    expect(res.body.count).toBe(1);
+    // Simulate the replacement landing before the loop writes.
+    await db('photos').where({ id: photoId })
+      .update({ path: 'capfill/replaced.jpg', filename: 'replaced.jpg' });
+    const done = await settle();
+
+    expect((await db('photos').where({ id: photoId }).first()).captured_at).toBeNull();
+    expect(done.body.lastResult.success).toBe(0);
+  });
 });

--- a/backend/src/routes/adminPhotoDimensions.js
+++ b/backend/src/routes/adminPhotoDimensions.js
@@ -424,8 +424,17 @@ router.post('/repair-capture-dates', adminAuth, requirePermission('settings.edit
             // large library, and an import or a replacement finishing meanwhile
             // has already written a date this pass would otherwise overwrite
             // with the same-or-worse value.
+            //
+            // Fenced on path and filename as well as the id (#1201):
+            // replacePhoto — reachable from the replace_by_name upload path
+            // (adminPhotos.js) — swaps a NEW file under an existing row and
+            // rewrites path/filename. That replacement carries no date of its
+            // own, so captured_at is still NULL and whereNull alone would let
+            // the previous file's EXIF date land on it. Matching the identity
+            // that was actually read means the update affects no rows and the
+            // row is simply skipped.
             const updated = await db('photos')
-              .where({ id: photo.id })
+              .where({ id: photo.id, path: photo.path, filename: photo.filename })
               .whereNull('captured_at')
               .update({ captured_at: captured.toISOString() });
             if (updated) successCount++;

--- a/backend/src/routes/adminPhotoDimensions.js
+++ b/backend/src/routes/adminPhotoDimensions.js
@@ -350,6 +350,7 @@ router.post('/repair-capture-dates', adminAuth, requirePermission('settings.edit
       let successCount = 0;
       let missingCount = 0;
       let errorCount = 0;
+      let skippedCount = 0;
       let lostClaim = false;
 
       // Same reasoning as the dimension repair: detached from the request, so
@@ -437,7 +438,16 @@ router.post('/repair-capture-dates', adminAuth, requirePermission('settings.edit
               .where({ id: photo.id, path: photo.path, filename: photo.filename })
               .whereNull('captured_at')
               .update({ captured_at: captured.toISOString() });
-            if (updated) successCount++;
+            // Counted, not dropped: without this a candidate that was read but
+            // not written falls out of the run's arithmetic entirely, and
+            // success + noExif + failed silently stops adding up to the count
+            // the operator was shown when they started it. Two ways to land
+            // here, both "another writer got there first" — the row was dated
+            // meanwhile (whereNull), or its file changed under us (the fence).
+            // Neither is an error and neither needs a retry: captured_at is
+            // still NULL for the fenced case, so the status endpoint keeps
+            // reporting it as backlog and the next run picks it up.
+            if (updated) successCount++; else skippedCount++;
 
             if (successCount % 50 === 0 && successCount > 0) {
               logger.info(`Capture date backfill progress: ${successCount} updated...`);
@@ -452,12 +462,15 @@ router.post('/repair-capture-dates', adminAuth, requirePermission('settings.edit
           logger.warn(`Capture date backfill stopped: claim taken over after ${successCount} updated, ${errorCount} errors`);
           return;
         }
-        await maintenanceJobs.release(JOB_CAPTURE_DATE_BACKFILL, token, { success: successCount, noExif: missingCount, failed: errorCount });
-        logger.info(`Capture date backfill complete: ${successCount} updated, ${missingCount} without EXIF, ${errorCount} errors`);
+        await maintenanceJobs.release(JOB_CAPTURE_DATE_BACKFILL, token, { success: successCount, noExif: missingCount, failed: errorCount, skipped: skippedCount });
+        logger.info(
+          `Capture date backfill complete: ${successCount} updated, ${missingCount} without EXIF, `
+          + `${errorCount} errors, ${skippedCount} skipped (dated or replaced mid-run)`
+        );
       } catch (err) {
         logger.error('Capture date backfill aborted:', err);
         await maintenanceJobs
-          .release(JOB_CAPTURE_DATE_BACKFILL, token, { success: successCount, noExif: missingCount, failed: errorCount, error: err.message })
+          .release(JOB_CAPTURE_DATE_BACKFILL, token, { success: successCount, noExif: missingCount, failed: errorCount, skipped: skippedCount, error: err.message })
           .catch(() => {});
       } finally {
         lease.stop();

--- a/frontend/src/features/settings/tabs/StatusTab.tsx
+++ b/frontend/src/features/settings/tabs/StatusTab.tsx
@@ -689,6 +689,23 @@ export const StatusTab: React.FC<StatusTabProps> = ({
                 failed: captureDateStatus.lastResult.failed,
                 defaultValue: 'Last run: {{success}} updated, {{noExif}} with no date found, {{failed}} unreachable',
               })}
+              {/* Only when it happened. Without it the three numbers above
+                  silently stop adding up to the count the run started with: a
+                  photo that was replaced, renamed or dated by someone else
+                  mid-run is read but not written.
+                  Deliberately says "not updated" and not "will be retried":
+                  one of the two ways to land here is another writer having
+                  filled captured_at, and that photo is finished, not backlog.
+                  The Missing Capture Date figure above is what says whether
+                  anything is actually left to do. */}
+              {Number(captureDateStatus.lastResult.skipped) > 0 && (
+                <span className="block text-amber-600 dark:text-amber-400 mt-1">
+                  {t('settings.captureDates.skipped', {
+                    count: captureDateStatus.lastResult.skipped,
+                    defaultValue: '{{count}} photo(s) were changed by something else while the run was reading them and were not updated.',
+                  })}
+                </span>
+              )}
             </p>
           )}
 

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -2077,6 +2077,7 @@
       "running": "Wird nachgetragen...",
       "noneToFill": "Alle Fotos haben bereits ein Aufnahmedatum",
       "resultSuccess": "Letzter Lauf: {{success}} aktualisiert, {{noExif}} ohne gefundenes Datum, {{failed}} nicht erreichbar",
+      "skipped": "{{count}} Foto(s) wurden während des Laufs anderweitig geändert und daher nicht aktualisiert.",
       "description": "Trägt „Aufnahmedatum\" aus den EXIF-Daten nach, für Fotos die vor dieser Auswertung importiert wurden. Externe Importe haben nie eines gespeichert, dadurch sortieren diese Galerien nach Importreihenfolge statt nach Aufnahmezeit."
     }
   },

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1618,6 +1618,7 @@
       "running": "Backfilling...",
       "noneToFill": "All photos already have a capture date",
       "resultSuccess": "Last run: {{success}} updated, {{noExif}} with no date found, {{failed}} unreachable",
+      "skipped": "{{count}} photo(s) were changed by something else while the run was reading them and were not updated.",
       "description": "Backfill \"Date Taken\" from EXIF for photos imported before capture dates were read. External/reference imports never recorded one, so their galleries sort by import order instead of when the photos were taken."
     }
   },

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -1181,6 +1181,7 @@
       "running": "Traitement...",
       "noneToFill": "Toutes les photos ont déjà une date de prise de vue",
       "resultSuccess": "Dernier passage : {{success}} mises à jour, {{noExif}} sans date trouvée, {{failed}} inaccessibles",
+      "skipped": "{{count}} photo(s) ont été modifiées par autre chose pendant le passage et n'ont donc pas été mises à jour.",
       "description": "Complète la « date de prise de vue » depuis les EXIF pour les photos importées avant sa lecture. Les imports externes n'en enregistraient aucune, si bien que ces galeries se trient par ordre d'import plutôt que par date de prise de vue."
     }
   },

--- a/frontend/src/i18n/locales/sl.json
+++ b/frontend/src/i18n/locales/sl.json
@@ -1181,6 +1181,7 @@
       "running": "Dopolnjevanje...",
       "noneToFill": "Vse fotografije že imajo datum zajema",
       "resultSuccess": "Zadnji zagon: {{success}} posodobljenih, {{noExif}} brez najdenega datuma, {{failed}} nedosegljivih",
+      "skipped": "{{count}} fotografij je bilo med zagonom spremenjenih drugje in zato niso bile posodobljene.",
       "description": "Dopolni »datum zajema« iz EXIF za fotografije, uvožene pred njegovim branjem. Zunanji uvozi ga niso zabeležili, zato se te galerije razvrščajo po vrstnem redu uvoza namesto po času zajema."
     }
   },


### PR DESCRIPTION
Stable twin of #1204. Same change, same test — #1201 says "same change on both branches".

## The bug

`adminPhotoDimensions.js:425` committed the capture-date backfill keyed only on the row id:

```js
const updated = await db('photos')
  .where({ id: photo.id })
  .whereNull('captured_at')
  .update({ captured_at: captured.toISOString() });
```

The job snapshots every candidate up front, then walks them one at a time reading originals off S3 or a NAS mount — a pass that can run for many minutes. `photoReplacementService.replacePhoto()` swaps a **new file under an existing row id** and rewrites `path`/`filename`; it is reachable from the `replace_by_name` upload path (`adminPhotos.js`).

A replacement landing inside that window carries no EXIF date of its own, so `captured_at` is still NULL and the `whereNull` guard passes — the old file's capture date lands on the new photo. Silent: nothing errors, the run reports it as a success, and the gallery sorts that photo to the wrong place.

## The fix

Fence the write on the identity that was actually read, not just the id:

```js
.where({ id: photo.id, path: photo.path, filename: photo.filename })
.whereNull('captured_at')
```

A replaced row now matches zero rows and is skipped. The candidate query already selects `photos.path` and `photos.filename`, so no query change. `successCount` already comes from the affected-row count (`if (updated) successCount++`), so a fenced-out row is not reported as updated.

Knex renders a null value in the object form as `is null`, so a row with a NULL `path` still matches itself.

Note: the orientation backfill this fence pattern comes from (#1199) is main-only, so this diff is the capture-date write alone — no other surface on stable carries the shape.

## Test

`captureDateBackfill.test.js` — new case: a replacement landing mid-run (path/filename rewritten, `captured_at` still NULL) leaves `captured_at` NULL and is not counted as a success. Verified on this branch that it fails on the unfenced code and passes with the fence; the other 8 cases are unchanged and green.

No UI surface touched, so no screenshot.

---

## Follow-ups from external review

Mirrors the follow-up commits on #1204, verified independently on this branch (backend suite 9/9, tsc, eslint, and the card re-rendered from this branch's code).

**Accounting.** `replacePhoto` is not the only writer of `photos.path`/`filename` — `eventRenameService.js` rewrites both on an event rename, which is not a content change. Either of those, or another writer filling `captured_at` first, makes the update affect zero rows, and those candidates fell out of the run's arithmetic: `success + noExif + failed` no longer added up to the count the operator was shown when they started the job. Now counted (`skipped`) and surfaced on the card, shown only when non-zero.

The wording states what is known — changed by something else, not updated — rather than promising a retry: for the already-dated case there is nothing to retry, and the Missing Capture Date figure above is the one that says whether work is left.

**Checked and dismissed:** whether a NULL `path` breaks the fence. Knex renders a null value in the object form as `is null` on both the pg and sqlite3 clients, so such a row still matches itself.

Screenshot in a comment below.
