### PR TITLE
fix(feedback): name the camera original in the exports, not just the stored file (#1224)

### DIFF
--- a/backend/__tests__/utils/feedbackExportCameraName.test.js
+++ b/backend/__tests__/utils/feedbackExportCameraName.test.js
@@ -1,0 +1,156 @@
+/**
+ * Feedback exports carry the camera-original filename (#1224).
+ *
+ * Both exports used to select only `photos.filename` — the sanitized stored
+ * name — so a photographer acting on client picks had nothing to match the
+ * masters on disk with.
+ *
+ * The load-bearing case is the third one: `original_filename` is overwritten
+ * the first time an edited render is uploaded over a proof (#745), so an
+ * export that read it alone would name the render rather than the master and
+ * silently stop matching. `source_filename` survives a replace by design
+ * (migration 193) and must win.
+ */
+
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+process.env.NODE_ENV = 'test';
+process.env.TEST_DATABASE_PATH = path.join(
+  fs.mkdtempSync(path.join(os.tmpdir(), 'picpeak-feedback-export-camera-')), 'db.sqlite',
+);
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'feedback-export-camera-test-secret';
+
+const { bootCrmDb, seedMinimal } = require('../integration/helpers/crmDb');
+
+const feedbackService = require('../../src/services/feedbackService');
+
+const EVENT_SLUG = 'feedback-export-camera-event';
+const GUEST = 'guest-camera-identifier';
+
+let db;
+let cleanup;
+let eventId;
+
+// filename is always the sanitized stored name; the other two vary per case.
+async function addPhoto({ filename, originalFilename, sourceFilename }) {
+  const inserted = await db('photos').insert({
+    event_id: eventId,
+    filename,
+    original_filename: originalFilename,
+    source_filename: sourceFilename,
+    path: `events/camera-name/${filename}`,
+    type: 'individual',
+    uploaded_at: new Date().toISOString(),
+  }).returning('id');
+  return inserted[0]?.id ?? inserted[0];
+}
+
+async function like(photoId) {
+  return feedbackService.submitFeedback(photoId, eventId, {
+    feedback_type: 'like',
+    guest_id: null,
+    ip_address: '127.0.0.1',
+    user_agent: 'jest',
+  }, GUEST);
+}
+
+beforeAll(async () => {
+  ({ db, cleanup } = await bootCrmDb());
+  await seedMinimal(db);
+  const inserted = await db('events').insert({
+    slug: EVENT_SLUG,
+    event_type: 'wedding',
+    event_name: 'Feedback Export Camera Name',
+    event_date: '2026-08-28',
+    host_email: 'host@example.com',
+    admin_email: 'admin@example.com',
+    password_hash: 'x',
+    share_link: `/gallery/${EVENT_SLUG}/share`,
+    share_token: 'feedback-export-camera-share',
+    expires_at: new Date(Date.now() + 7 * 24 * 3600 * 1000).toISOString(),
+    is_active: 1,
+    is_archived: 0,
+    is_draft: 0,
+    created_at: new Date().toISOString(),
+  }).returning('id');
+  eventId = inserted[0]?.id ?? inserted[0];
+}, 120000);
+
+afterAll(async () => {
+  if (cleanup) await cleanup();
+});
+
+describe('feedback exports carry the camera-original filename (#1224)', () => {
+  it('reports the camera name alongside the stored name, in both shapes', async () => {
+    const photoId = await addPhoto({
+      filename: 'wedding-smith_individual_1755892345.jpg',
+      originalFilename: 'IMG_1234.JPG',
+      sourceFilename: 'IMG_1234.JPG',
+    });
+    await like(photoId);
+
+    const [longRow] = (await feedbackService.exportEventFeedback(eventId))
+      .filter((r) => r.filename === 'wedding-smith_individual_1755892345.jpg');
+    expect(longRow.original_filename).toBe('IMG_1234.JPG');
+    // The stored name is still there — this adds a column, it does not swap one.
+    expect(longRow.filename).toBe('wedding-smith_individual_1755892345.jpg');
+
+    const [pivotRow] = (await feedbackService.exportEventFeedbackPivoted(eventId))
+      .filter((r) => r.filename === 'wedding-smith_individual_1755892345.jpg');
+    expect(pivotRow.original_filename).toBe('IMG_1234.JPG');
+  });
+
+  it('keeps naming the master after a replace overwrote original_filename', async () => {
+    // Exactly the post-round-trip row: the edited render's name landed in
+    // original_filename, source_filename still holds what the camera wrote.
+    const photoId = await addPhoto({
+      filename: 'wedding-smith_individual_1755892999.jpg',
+      originalFilename: 'Smith_Wedding_1234.jpg',
+      sourceFilename: 'IMG_1234.JPG',
+    });
+    await like(photoId);
+
+    const [longRow] = (await feedbackService.exportEventFeedback(eventId))
+      .filter((r) => r.filename === 'wedding-smith_individual_1755892999.jpg');
+    expect(longRow.original_filename).toBe('IMG_1234.JPG');
+
+    const [pivotRow] = (await feedbackService.exportEventFeedbackPivoted(eventId))
+      .filter((r) => r.filename === 'wedding-smith_individual_1755892999.jpg');
+    expect(pivotRow.original_filename).toBe('IMG_1234.JPG');
+  });
+
+  it('falls back to original_filename when nothing was captured at ingest', async () => {
+    const photoId = await addPhoto({
+      filename: 'wedding-smith_individual_1755893111.jpg',
+      originalFilename: 'DSC_9001.NEF',
+      sourceFilename: null,
+    });
+    await like(photoId);
+
+    const [longRow] = (await feedbackService.exportEventFeedback(eventId))
+      .filter((r) => r.filename === 'wedding-smith_individual_1755893111.jpg');
+    expect(longRow.original_filename).toBe('DSC_9001.NEF');
+  });
+
+  it('leaves the column empty rather than repeating the sanitized name', async () => {
+    // Blank reads as "no match possible". Echoing the stored name would invite
+    // a match attempt against a file that does not exist under that name.
+    const photoId = await addPhoto({
+      filename: 'wedding-smith_individual_1755893222.jpg',
+      originalFilename: null,
+      sourceFilename: null,
+    });
+    await like(photoId);
+
+    const [longRow] = (await feedbackService.exportEventFeedback(eventId))
+      .filter((r) => r.filename === 'wedding-smith_individual_1755893222.jpg');
+    expect(longRow.original_filename).toBeNull();
+
+    const [pivotRow] = (await feedbackService.exportEventFeedbackPivoted(eventId))
+      .filter((r) => r.filename === 'wedding-smith_individual_1755893222.jpg');
+    // The pivot builds plain objects, so its empty is '' rather than null.
+    expect(pivotRow.original_filename).toBe('');
+  });
+});

--- a/backend/src/services/feedbackService.js
+++ b/backend/src/services/feedbackService.js
@@ -5,6 +5,30 @@ const { REACTION_EMOJIS } = require('../constants/reactions');
 const { isValidColorLabel, SHARED_COLOR_LABEL_IDENTITY } = require('../constants/colorLabels');
 const { resolveEventFeedbackDefaults, DEFAULT_KEYBIND_MODE, KEYBIND_MODES } = require('./feedbackDefaults');
 
+// The camera-original name, for the feedback exports (#1224). Both exports
+// used to carry only `photos.filename` — the sanitized stored name
+// (`wedding-smith_individual_1755892345.jpg`), which matches nothing in a
+// Lightroom catalog. Acting on client picks means finding the master file, so
+// the export has to name it.
+//
+// `source_filename` first, NOT `original_filename` alone: the latter is
+// overwritten the first time an edited render is uploaded over a proof, so an
+// export taken after a Lightroom round-trip (#745) would name the render
+// rather than the master and silently stop matching. `source_filename` is
+// written once at ingest and survives a replace by design (migration 193),
+// and its backfill already covers rows that predate it.
+//
+// Aliased to `original_filename` because that is what the sibling photo export
+// calls this column, and it is the question the reader is asking ("what did
+// the camera call it"). Left empty rather than falling back to the stored
+// name: blank reads as "no match possible", where repeating the sanitized
+// name invites a match attempt that cannot succeed.
+//
+// A SQL string rather than a prebuilt db.raw(): the raw is constructed per
+// query, so this does not depend on `db` being connected at module load.
+const CAMERA_NAME_SQL =
+  'COALESCE(photos.source_filename, photos.original_filename) as original_filename';
+
 // Every writable column on event_feedback_settings (#1030). The admin form
 // posts its whole client-side state back, including UI-only keys that were
 // never columns — `enable_rate_limiting`, `rate_limit_window_minutes`,
@@ -1065,6 +1089,7 @@ class FeedbackService {
         .where('photo_feedback.event_id', eventId)
         .select(
           'photos.filename',
+          db.raw(CAMERA_NAME_SQL),
           'photo_feedback.feedback_type',
           'photo_feedback.rating',
           'photo_feedback.comment_text',
@@ -1104,6 +1129,7 @@ class FeedbackService {
         .where('photo_feedback.is_hidden', false)
         .select(
           'photos.filename',
+          db.raw(CAMERA_NAME_SQL),
           'photo_feedback.feedback_type',
           'photo_feedback.rating',
           'photo_feedback.comment_text',
@@ -1128,6 +1154,7 @@ class FeedbackService {
         if (!entry) {
           entry = {
             filename: row.filename,
+            original_filename: row.original_filename || '',
             guest_name: row.guest_name || '',
             guest_email: row.guest_email || '',
             is_favorited: false,


### PR DESCRIPTION
Closes #1224.

## The bug

Both feedback exports selected only `photos.filename` — the sanitized stored name (`wedding-smith_individual_1755892345.jpg`). The export exists so a photographer can act on client picks outside the app, and acting on them means finding the master on disk. That name matches nothing in a Lightroom catalog, so the CSV could not be joined to anything.

`feedbackService.js:1061` (`exportEventFeedback`) and `:1099` (`exportEventFeedbackPivoted`), plus the pivot row it builds.

## The fix

One column, added to both shapes:

```sql
COALESCE(photos.source_filename, photos.original_filename) as original_filename
```

**`source_filename` first, and this is the whole point.** `original_filename` is overwritten the first time an edited render is uploaded over a proof (#745), so an export taken after a round-trip would name the render rather than the master and silently stop matching. `source_filename` is written once at ingest and survives a replace by design (migration 193), and its backfill already covers rows that predate it.

That is what makes this different from the version the `8digit/picpeak` fork has been carrying (`bb7c8514`), which selects `original_filename` alone. Theirs was correct when written — `source_filename` did not exist until #1165 merged this morning.

## Three decisions

**Aliased to `original_filename`.** It is what the sibling photo export (`photoExportService.js:171`) already calls this column, and it is the question the reader is asking — "what did the camera call it". The value is the same concept either way; `source_filename` is just the durable copy of it.

**Empty when neither is known**, rather than echoing the stored name. Blank reads as "no match possible". Repeating the sanitized name invites a match attempt against a file that does not exist under it — a worse failure than an obvious gap.

**Added, not swapped.** `filename` is untouched, so anything already parsing these exports keeps working. Column order puts the new one second, right after `filename`.

The archive's `feedback_data.csv` / `.json` get it for free — `archiveService.js:66` reuses `exportEventFeedback`.

## Tests

`feedbackExportCameraName.test.js`, four cases, **all four fail without the change** (verified by stashing the service and re-running):

1. Both shapes report the camera name alongside the stored name.
2. **The load-bearing one** — a row where `original_filename` already holds the edited render's name (`Smith_Wedding_1234.jpg`) and `source_filename` still holds `IMG_1234.JPG`. The export must name the master. This is the case that would rot silently.
3. Falls back to `original_filename` when nothing was captured at ingest.
4. Empty rather than the sanitized name when neither exists.

Neighbouring suites green: `feedbackColorLabels` + `feedbackReactions`, 25 passed.

eslint adds no new errors on the changed file — 26 before, 26 after, none on the added lines. (`npm run lint` reports 928 across `src/` on `main`; untouched here.)

## Noticed while doing this — not fixed here

`photoExportService.js` selects `photos.source_filename` at `:38`, added by #1165, and **never uses it**. Every output path still reads `original_filename` (`:138` text list, `:188`/`:189` CSV, `:243`, `:282` JSON). So the photo export — the plugin-free path the round-trip guide points people at — still names the edited render after a replace, which is the exact failure the column was introduced to prevent. Filed separately rather than widened into this PR.
